### PR TITLE
refactor: deprecates write to affectation table

### DIFF
--- a/apps/api/cli/import-nominations-from-local-file/import-nominations-from-local-file.cli.e2e-spec.ts
+++ b/apps/api/cli/import-nominations-from-local-file/import-nominations-from-local-file.cli.e2e-spec.ts
@@ -361,6 +361,7 @@ const expectedDossierDeNominationV1FromContent = (
     sessionId: expect.any(String),
     dossierDeNominationImportéId: expect.any(String),
     content: expectedContent,
+    priority: null,
   };
 };
 
@@ -397,6 +398,7 @@ const expectedDossierDeNominationV2FromContent = (
     sessionId: expect.any(String),
     dossierDeNominationImportéId: expect.any(String),
     content: expectedContent,
+    priority: null,
   };
 };
 

--- a/apps/api/drizzle/0061_adds_dossier_rapporteur.sql
+++ b/apps/api/drizzle/0061_adds_dossier_rapporteur.sql
@@ -1,0 +1,29 @@
+CREATE TYPE "nominations_context"."priorite_enum" AS ENUM('ETOILE', 'OUTRE_MER', 'PROFILE');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "nominations_context"."dossier_rapporteur" (
+	"user_id" uuid NOT NULL,
+	"dossier_id" uuid NOT NULL,
+	"version_id" uuid NOT NULL,
+	CONSTRAINT "dossier_rapporteur_dossier_id_user_id_version_id_pk" PRIMARY KEY("dossier_id","user_id","version_id")
+);
+--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_affectation_session_version";--> statement-breakpoint
+ALTER TABLE "nominations_context"."dossier_de_nomination" ADD COLUMN "priority" "nominations_context"."priorite_enum";--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nominations_context"."dossier_rapporteur" ADD CONSTRAINT "dossier_rapporteur_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "identity_and_access_context"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nominations_context"."dossier_rapporteur" ADD CONSTRAINT "dossier_rapporteur_dossier_id_dossier_de_nomination_id_fk" FOREIGN KEY ("dossier_id") REFERENCES "nominations_context"."dossier_de_nomination"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nominations_context"."dossier_rapporteur" ADD CONSTRAINT "dossier_rapporteur_version_id_affectation_id_fk" FOREIGN KEY ("version_id") REFERENCES "nominations_context"."affectation"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "dossier_rapporteur_user_id_index" ON "nominations_context"."dossier_rapporteur" USING btree ("user_id");

--- a/apps/api/drizzle/meta/0061_snapshot.json
+++ b/apps/api/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,1247 @@
+{
+  "id": "a7c0b77f-e59b-409a-8fd4-dbb9e8664204",
+  "prevId": "ea77c0a9-62dd-4bde-b79b-e63dccebda6e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "data_administration_context.excluded_jurisdictions": {
+      "name": "excluded_jurisdictions",
+      "schema": "data_administration_context",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_id": {
+          "name": "jurisdiction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "excluded_jurisdictions_user_id_users_id_fk": {
+          "name": "excluded_jurisdictions_user_id_users_id_fk",
+          "tableFrom": "excluded_jurisdictions",
+          "tableTo": "users",
+          "schemaTo": "identity_and_access_context",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "excluded_jurisdictions_jurisdiction_id_jurisdictions_codejur_fk": {
+          "name": "excluded_jurisdictions_jurisdiction_id_jurisdictions_codejur_fk",
+          "tableFrom": "excluded_jurisdictions",
+          "tableTo": "jurisdictions",
+          "schemaTo": "data_administration_context",
+          "columnsFrom": [
+            "jurisdiction_id"
+          ],
+          "columnsTo": [
+            "codejur"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "excluded_jurisdictions_user_id_jurisdiction_id_pk": {
+          "name": "excluded_jurisdictions_user_id_jurisdiction_id_pk",
+          "columns": [
+            "user_id",
+            "jurisdiction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "data_administration_context.jurisdictions": {
+      "name": "jurisdictions",
+      "schema": "data_administration_context",
+      "columns": {
+        "codejur": {
+          "name": "codejur",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type_jur": {
+          "name": "type_jur",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adr1": {
+          "name": "adr1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr2": {
+          "name": "adr2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrondissement": {
+          "name": "arrondissement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codepos": {
+          "name": "codepos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_suppression": {
+          "name": "date_suppression",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "libelle": {
+          "name": "libelle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ressort": {
+          "name": "ressort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ville_jur": {
+          "name": "ville_jur",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ville": {
+          "name": "ville",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "data_administration_context.nomination_files": {
+      "name": "nomination_files",
+      "schema": "data_administration_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "row_number": {
+          "name": "row_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "data_administration_context.transparence_files": {
+      "name": "transparence_files",
+      "schema": "data_administration_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transparence_id": {
+          "name": "transparence_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transparence_files_transparence_id_transparences_id_fk": {
+          "name": "transparence_files_transparence_id_transparences_id_fk",
+          "tableFrom": "transparence_files",
+          "tableTo": "transparences",
+          "schemaTo": "data_administration_context",
+          "columnsFrom": [
+            "transparence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transparence_files_file_id_files_id_fk": {
+          "name": "transparence_files_file_id_files_id_fk",
+          "tableFrom": "transparence_files",
+          "tableTo": "files",
+          "schemaTo": "files_context",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "data_administration_context.transparences": {
+      "name": "transparences",
+      "schema": "data_administration_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "formation": {
+          "name": "formation",
+          "type": "formation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_transparence": {
+          "name": "date_transparence",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_echeance": {
+          "name": "date_echeance",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_prise_de_poste": {
+          "name": "date_prise_de_poste",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_cloture_delai_observation": {
+          "name": "date_cloture_delai_observation",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nomination_files": {
+          "name": "nomination_files",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transparences_name_formation_date_transparence_unique": {
+          "name": "transparences_name_formation_date_transparence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "formation",
+            "date_transparence"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "files_context.files": {
+      "name": "files",
+      "schema": "files_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "storage_provider",
+          "typeSchema": "files_context",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "identity_and_access_context.files": {
+      "name": "files",
+      "schema": "identity_and_access_context",
+      "columns": {
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "file_type",
+          "typeSchema": "identity_and_access_context",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "identity_and_access_context.sessions": {
+      "name": "sessions",
+      "schema": "identity_and_access_context",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "schemaTo": "identity_and_access_context",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "identity_and_access_context.users": {
+      "name": "users",
+      "schema": "identity_and_access_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "identity_and_access_context",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "identity_and_access_context",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "nominations_context.affectation": {
+      "name": "affectation",
+      "schema": "nominations_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "statut": {
+          "name": "statut",
+          "type": "statut_affectation",
+          "typeSchema": "nominations_context",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BROUILLON'"
+        },
+        "date_publication": {
+          "name": "date_publication",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auteur_publication": {
+          "name": "auteur_publication",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formation": {
+          "name": "formation",
+          "type": "formation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affectations_dossiers_de_nominations": {
+          "name": "affectations_dossiers_de_nominations",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "affectation_session_id_version_index": {
+          "name": "affectation_session_id_version_index",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_one_brouillon_per_session": {
+          "name": "idx_one_brouillon_per_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"affectation\".\"statut\" = 'BROUILLON'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nominations_context.dossier_de_nomination": {
+      "name": "dossier_de_nomination",
+      "schema": "nominations_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dossier_de_nomination_import_id": {
+          "name": "dossier_de_nomination_import_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priorite_enum",
+          "typeSchema": "nominations_context",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dossier_de_nomination_dossier_de_nomination_import_id_unique": {
+          "name": "dossier_de_nomination_dossier_de_nomination_import_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dossier_de_nomination_import_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "nominations_context.dossier_rapporteur": {
+      "name": "dossier_rapporteur",
+      "schema": "nominations_context",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dossier_id": {
+          "name": "dossier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dossier_rapporteur_user_id_index": {
+          "name": "dossier_rapporteur_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dossier_rapporteur_user_id_users_id_fk": {
+          "name": "dossier_rapporteur_user_id_users_id_fk",
+          "tableFrom": "dossier_rapporteur",
+          "tableTo": "users",
+          "schemaTo": "identity_and_access_context",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dossier_rapporteur_dossier_id_dossier_de_nomination_id_fk": {
+          "name": "dossier_rapporteur_dossier_id_dossier_de_nomination_id_fk",
+          "tableFrom": "dossier_rapporteur",
+          "tableTo": "dossier_de_nomination",
+          "schemaTo": "nominations_context",
+          "columnsFrom": [
+            "dossier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dossier_rapporteur_version_id_affectation_id_fk": {
+          "name": "dossier_rapporteur_version_id_affectation_id_fk",
+          "tableFrom": "dossier_rapporteur",
+          "tableTo": "affectation",
+          "schemaTo": "nominations_context",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dossier_rapporteur_dossier_id_user_id_version_id_pk": {
+          "name": "dossier_rapporteur_dossier_id_user_id_version_id_pk",
+          "columns": [
+            "dossier_id",
+            "user_id",
+            "version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nominations_context.pre_analyse": {
+      "name": "pre_analyse",
+      "schema": "nominations_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dossier_de_nomination_id": {
+          "name": "dossier_de_nomination_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regles": {
+          "name": "regles",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pre_analyse_dossier_de_nomination_id_unique": {
+          "name": "pre_analyse_dossier_de_nomination_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dossier_de_nomination_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "nominations_context.session": {
+      "name": "session",
+      "schema": "nominations_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formation": {
+          "name": "formation",
+          "type": "formation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_de_saisine": {
+          "name": "type_de_saisine",
+          "type": "type_de_saisine",
+          "typeSchema": "nominations_context",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_import_id": {
+          "name": "session_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_session_import_id_unique": {
+          "name": "session_session_import_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_import_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "reports_context.report_rule": {
+      "name": "report_rule",
+      "schema": "reports_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "rule_group": {
+          "name": "rule_group",
+          "type": "rule_group",
+          "typeSchema": "reports_context",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "rule_name",
+          "typeSchema": "reports_context",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "report_rule_report_id_reports_id_fk": {
+          "name": "report_rule_report_id_reports_id_fk",
+          "tableFrom": "report_rule",
+          "tableTo": "reports",
+          "schemaTo": "reports_context",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reports_context.reports": {
+      "name": "reports",
+      "schema": "reports_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nomination_file_id": {
+          "name": "nomination_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "state": {
+          "name": "state",
+          "type": "report_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NEW'"
+        },
+        "formation": {
+          "name": "formation",
+          "type": "formation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_files": {
+          "name": "attached_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_kernel_context.domain_events": {
+      "name": "domain_events",
+      "schema": "shared_kernel_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "domain_event_status",
+          "typeSchema": "shared_kernel_context",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "files_context.storage_provider": {
+      "name": "storage_provider",
+      "schema": "files_context",
+      "values": [
+        "SCALEWAY"
+      ]
+    },
+    "identity_and_access_context.file_type": {
+      "name": "file_type",
+      "schema": "identity_and_access_context",
+      "values": [
+        "PIECE_JOINTE_TRANSPARENCE",
+        "PIECE_JOINTE_TRANSPARENCE_POUR_PARQUET",
+        "PIECE_JOINTE_TRANSPARENCE_POUR_SIEGE"
+      ]
+    },
+    "identity_and_access_context.gender": {
+      "name": "gender",
+      "schema": "identity_and_access_context",
+      "values": [
+        "MALE",
+        "FEMALE"
+      ]
+    },
+    "identity_and_access_context.role": {
+      "name": "role",
+      "schema": "identity_and_access_context",
+      "values": [
+        "MEMBRE_DU_SIEGE",
+        "MEMBRE_DU_PARQUET",
+        "MEMBRE_COMMUN",
+        "ADJOINT_SECRETAIRE_GENERAL"
+      ]
+    },
+    "nominations_context.priorite_enum": {
+      "name": "priorite_enum",
+      "schema": "nominations_context",
+      "values": [
+        "ETOILE",
+        "OUTRE_MER",
+        "PROFILE"
+      ]
+    },
+    "nominations_context.statut_affectation": {
+      "name": "statut_affectation",
+      "schema": "nominations_context",
+      "values": [
+        "BROUILLON",
+        "PUBLIEE"
+      ]
+    },
+    "nominations_context.type_de_saisine": {
+      "name": "type_de_saisine",
+      "schema": "nominations_context",
+      "values": [
+        "TRANSPARENCE_GDS"
+      ]
+    },
+    "public.report_state": {
+      "name": "report_state",
+      "schema": "public",
+      "values": [
+        "NEW",
+        "IN_PROGRESS",
+        "READY_TO_SUPPORT",
+        "SUPPORTED"
+      ]
+    },
+    "reports_context.rule_group": {
+      "name": "rule_group",
+      "schema": "reports_context",
+      "values": [
+        "management",
+        "statutory",
+        "qualitative"
+      ]
+    },
+    "reports_context.rule_name": {
+      "name": "rule_name",
+      "schema": "reports_context",
+      "values": [
+        "TRANSFER_TIME",
+        "GETTING_GRADE_IN_PLACE",
+        "JUDICIARY_ROLE_CHANGE_IN_SAME_RESSORT",
+        "JUDICIARY_ROLE_CHANGE_IN_SAME_JURIDICTION",
+        "GRADE_ON_SITE_AFTER_7_YEARS",
+        "MINISTRY_OF_JUSTICE_IN_LESS_THAN_3_YEARS",
+        "MINISTER_CABINET",
+        "GRADE_REGISTRATION",
+        "HH_WITHOUT_2_FIRST_GRADE_POSITIONS",
+        "LEGAL_PROFESSION_IN_JUDICIAL_COURT_LESS_THAN_5_YEARS_AGO",
+        "RETOUR_AVANT_5_ANS_DANS_FONCTION_SPECIALISEE_OCCUPEE_9_ANS",
+        "NOMINATION_CA_AVANT_4_ANS",
+        "CONFLICT_OF_INTEREST_PRE_MAGISTRATURE",
+        "CONFLICT_OF_INTEREST_WITH_RELATIVE_PROFESSION",
+        "EVALUATIONS",
+        "DISCIPLINARY_ELEMENTS"
+      ]
+    },
+    "shared_kernel_context.domain_event_status": {
+      "name": "domain_event_status",
+      "schema": "shared_kernel_context",
+      "values": [
+        "NEW",
+        "PENDING",
+        "CONSUMED"
+      ]
+    },
+    "public.formation": {
+      "name": "formation",
+      "schema": "public",
+      "values": [
+        "PARQUET",
+        "SIEGE"
+      ]
+    },
+    "public.transparency": {
+      "name": "transparency",
+      "schema": "public",
+      "values": [
+        "AUTOMNE_2024",
+        "PROCUREURS_GENERAUX_8_NOVEMBRE_2024",
+        "PROCUREURS_GENERAUX_25_NOVEMBRE_2024",
+        "TABLEAU_GENERAL_T_DU_25_NOVEMBRE_2024",
+        "CABINET_DU_MINISTRE_DU_21_JANVIER_2025",
+        "SIEGE_DU_06_FEVRIER_2025",
+        "PARQUET_DU_06_FEVRIER_2025",
+        "PARQUET_DU_20_FEVRIER_2025",
+        "DU_03_MARS_2025",
+        "GRANDE_TRANSPA_DU_21_MARS_2025",
+        "DU_30_AVRIL_2025",
+        "MARCH_2026"
+      ]
+    }
+  },
+  "schemas": {
+    "data_administration_context": "data_administration_context",
+    "files_context": "files_context",
+    "identity_and_access_context": "identity_and_access_context",
+    "nominations_context": "nominations_context",
+    "reports_context": "reports_context",
+    "shared_kernel_context": "shared_kernel_context"
+  },
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1762354966776,
       "tag": "0060_unique-index-affectation-version",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1762533811368,
+      "tag": "0061_adds_dossier_rapporteur",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/modules/framework/drizzle/schemas/identity-and-access-context.schema.ts
+++ b/apps/api/src/modules/framework/drizzle/schemas/identity-and-access-context.schema.ts
@@ -1,6 +1,7 @@
 import { relations, sql } from 'drizzle-orm';
 import { pgSchema, text, timestamp, varchar, uuid } from 'drizzle-orm/pg-core';
 import { drizzleExcludedJurisdictions } from './data-administration-context.schema';
+import { drizzleDossierRapporteur } from './nomination-context.schema';
 
 export const identityAndAccessContextSchema = pgSchema(
   'identity_and_access_context',
@@ -57,4 +58,5 @@ export const users = identityAndAccessContextSchema.table('users', {
 export const drizzleUsersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   excludedJurisdictionIds: many(drizzleExcludedJurisdictions),
+  rapporteurSur: many(drizzleDossierRapporteur),
 }));

--- a/apps/api/src/modules/framework/drizzle/schemas/nomination-context.schema.ts
+++ b/apps/api/src/modules/framework/drizzle/schemas/nomination-context.schema.ts
@@ -1,16 +1,19 @@
-import { sql } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import {
   index,
   integer,
   jsonb,
   pgSchema,
+  primaryKey,
   text,
   timestamp,
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
-import { StatutAffectation } from 'src/nominations-context/sessions/business-logic/models/affectation';
+import { users } from './identity-and-access-context.schema';
 import { formationEnum } from './shared-kernel.schema';
+
+import { StatutAffectation } from 'src/nominations-context/sessions/business-logic/models/affectation';
 
 export const nominationsContextSchema = pgSchema('nominations_context');
 
@@ -50,10 +53,6 @@ export const affectationPm = nominationsContextSchema.table(
   },
   (table) => ({
     sessionVersionUnique: uniqueIndex().on(table.sessionId, table.version),
-    sessionVersionIdx: index('idx_affectation_session_version').on(
-      table.sessionId,
-      table.version,
-    ),
     oneBrouillonPerSessionIdx: index('idx_one_brouillon_per_session')
       .on(table.sessionId)
       .where(sql`${table.statut} = 'BROUILLON'`),
@@ -82,6 +81,11 @@ export const sessionPm = nominationsContextSchema.table('session', {
   content: jsonb('content').$type<object>().notNull(),
 });
 
+export const drizzlePrioriteEnum = nominationsContextSchema.enum(
+  'priorite_enum',
+  ['ETOILE', 'OUTRE_MER', 'PROFILE'],
+);
+
 export const dossierDeNominationPm = nominationsContextSchema.table(
   'dossier_de_nomination',
   {
@@ -94,5 +98,55 @@ export const dossierDeNominationPm = nominationsContextSchema.table(
       .unique()
       .notNull(),
     content: jsonb('content').notNull(),
+    priority: drizzlePrioriteEnum(),
   },
+);
+
+export const drizzleDossierRapporteur = nominationsContextSchema.table(
+  'dossier_rapporteur',
+  {
+    userId: uuid()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    dossierId: uuid()
+      .notNull()
+      .references(() => dossierDeNominationPm.id, {
+        onDelete: 'cascade',
+      }),
+    versionId: uuid()
+      .notNull()
+      .references(() => affectationPm.id, { onDelete: 'cascade' }),
+  },
+  (t) => ({
+    userIdx: index().on(t.userId),
+    primaryKey: primaryKey({ columns: [t.dossierId, t.userId, t.versionId] }),
+  }),
+);
+
+export const drizzleDossierRapporteurRelations = relations(
+  drizzleDossierRapporteur,
+  ({ one }) => ({
+    dossierDeNomination: one(dossierDeNominationPm, {
+      fields: [drizzleDossierRapporteur.dossierId],
+      references: [dossierDeNominationPm.id],
+    }),
+    user: one(users, {
+      fields: [drizzleDossierRapporteur.userId],
+      references: [users.id],
+    }),
+    version: one(affectationPm, {
+      fields: [drizzleDossierRapporteur.versionId],
+      references: [affectationPm.id],
+    }),
+  }),
+);
+
+export const drizzleDossierDeNominationRelations = relations(
+  dossierDeNominationPm,
+  ({ many }) => ({ rapporteurs: many(drizzleDossierRapporteur) }),
+);
+
+export const drizzleAffectationRelations = relations(
+  affectationPm,
+  ({ many }) => ({ rapporteurs: many(drizzleDossierRapporteur) }),
 );

--- a/apps/api/src/nominations-context/dossier-de-nominations/adapters/primary/secondary/gateways/repositories/drizzle/sql-dossier-de-nomination.repository.it-spec.ts
+++ b/apps/api/src/nominations-context/dossier-de-nominations/adapters/primary/secondary/gateways/repositories/drizzle/sql-dossier-de-nomination.repository.it-spec.ts
@@ -57,6 +57,7 @@ describe('SQL Dossier De Nomination Repository', () => {
       dossierDeNominationImportéId: aImportId,
       content: aContent,
       createdAt: expect.any(Date),
+      priority: null,
     });
   });
 

--- a/apps/api/src/nominations-context/sessions/adapters/secondary/gateways/repositories/drizzle/sql-affectation.repository.it-spec.ts
+++ b/apps/api/src/nominations-context/sessions/adapters/secondary/gateways/repositories/drizzle/sql-affectation.repository.it-spec.ts
@@ -17,6 +17,12 @@ import { TransactionPerformer } from 'src/shared-kernel/business-logic/gateways/
 import { clearDB } from 'test/docker-postgresql-manager';
 import { affectationPm } from './schema/affectation-pm';
 import { SqlAffectationRepository } from './sql-affectation.repository';
+import {
+  dossierDeNominationPm,
+  users,
+} from 'src/modules/framework/drizzle/schemas';
+import { faker } from '@faker-js/faker';
+import { randomBytes, randomUUID } from 'crypto';
 
 describe('SQL Affectation Repository', () => {
   let sqlAffectationRepository: SqlAffectationRepository;
@@ -24,12 +30,50 @@ describe('SQL Affectation Repository', () => {
   let uuidGenerator: DeterministicUuidGenerator;
   let db: DrizzleDb;
 
+  let anAffectations: AffectationsDossiersDeNominations[];
+  let affectationSnapshot: AffectationSnapshot;
+
   beforeAll(() => {
     db = getDrizzleInstance(drizzleConfigForTest);
   });
 
   beforeEach(async () => {
     await clearDB(db);
+    const rapporteurId = randomUUID();
+    await db.insert(users).values({
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+      password: randomBytes(32).toString('hex'),
+      email: faker.internet.email(),
+      gender: 'MALE',
+      role: 'MEMBRE_COMMUN',
+      id: rapporteurId,
+    });
+
+    const dossierId = randomUUID();
+    await db.insert(dossierDeNominationPm).values({
+      content: {},
+      dossierDeNominationImportéId: randomUUID(),
+      sessionId: aSessionId,
+      id: dossierId,
+    });
+
+    anAffectations = [
+      {
+        dossierDeNominationId: dossierId,
+        rapporteurIds: [rapporteurId],
+      },
+    ];
+
+    affectationSnapshot = {
+      id: anAffectationId,
+      sessionId: aSessionId,
+      formation: aFormation,
+      affectationsDossiersDeNominations: anAffectations,
+      version: 1,
+      statut: StatutAffectation.BROUILLON,
+    };
+
     sqlAffectationRepository = new SqlAffectationRepository();
     transactionPerformer = new DrizzleTransactionPerformer(db);
     uuidGenerator = new DeterministicUuidGenerator();
@@ -101,18 +145,3 @@ describe('SQL Affectation Repository', () => {
 const anAffectationId = '490558fb-67b8-4522-9dab-7dc82961e39a';
 const aSessionId = '550da006-4f50-4c9e-b2b9-9342d3406ee9';
 const aFormation = Magistrat.Formation.PARQUET;
-const anAffectations: AffectationsDossiersDeNominations[] = [
-  {
-    dossierDeNominationId: '3024f09a-1663-4c9c-a730-b9221f1b0067',
-    rapporteurIds: ['943e9546-3735-454f-92a9-e2e9ad4f7ea6'],
-  },
-];
-
-const affectationSnapshot: AffectationSnapshot = {
-  id: anAffectationId,
-  sessionId: aSessionId,
-  version: 1,
-  statut: StatutAffectation.BROUILLON,
-  formation: aFormation,
-  affectationsDossiersDeNominations: anAffectations,
-};

--- a/apps/api/src/nominations-context/sessions/adapters/secondary/gateways/repositories/drizzle/sql-affectation.repository.ts
+++ b/apps/api/src/nominations-context/sessions/adapters/secondary/gateways/repositories/drizzle/sql-affectation.repository.ts
@@ -1,34 +1,47 @@
-import { and, desc, eq, max, sql } from 'drizzle-orm';
+import { and, desc, eq, max, sql, inArray } from 'drizzle-orm';
 import { AffectationRepository } from 'src/nominations-context/sessions/business-logic/gateways/repositories/affectation.repository';
 import {
   Affectation,
   affectationsDossiersDeNominationsSchema,
-  AffectationSnapshot,
   StatutAffectation,
 } from 'src/nominations-context/sessions/business-logic/models/affectation';
 import { DrizzleTransactionableAsync } from 'src/shared-kernel/adapters/secondary/gateways/providers/drizzle-transaction-performer';
 import { toFormation } from 'src/shared-kernel/adapters/secondary/gateways/repositories/drizzle/schema';
 import z from 'zod';
 import { affectationPm } from './schema/affectation-pm';
+import {
+  dossierDeNominationPm,
+  drizzleDossierRapporteur,
+} from 'src/modules/framework/drizzle/schemas';
+import { PrioriteEnum } from 'shared-models';
+import { isDefined } from 'src/utils/is-defined';
 
 export class SqlAffectationRepository implements AffectationRepository {
   save(affectation: Affectation): DrizzleTransactionableAsync<void> {
     return async (db) => {
       const affectationSnapshot = affectation.snapshot();
 
-      const existingAffectation = await db
-        .select({ id: affectationPm.id })
-        .from(affectationPm)
-        .where(eq(affectationPm.id, affectationSnapshot.id))
-        .limit(1);
+      await db
+        .delete(drizzleDossierRapporteur)
+        .where(
+          inArray(
+            drizzleDossierRapporteur.dossierId,
+            Array.from(
+              new Set(
+                affectationSnapshot.affectationsDossiersDeNominations.map(
+                  ({ dossierDeNominationId }) => dossierDeNominationId,
+                ),
+              ),
+            ),
+          ),
+        );
 
-      if (existingAffectation.length === 0) {
-        const affectationDb = SqlAffectationRepository.mapToDb(affectation);
-        await db.insert(affectationPm).values(affectationDb);
-      } else {
-        await db
-          .update(affectationPm)
-          .set({
+      await db
+        .insert(affectationPm)
+        .values(affectationSnapshot)
+        .onConflictDoUpdate({
+          target: affectationPm.id,
+          set: {
             formation: affectationSnapshot.formation,
             version: affectationSnapshot.version,
             statut: affectationSnapshot.statut,
@@ -36,8 +49,37 @@ export class SqlAffectationRepository implements AffectationRepository {
             auteurPublication: affectationSnapshot.auteurPublication,
             affectationsDossiersDeNominations:
               affectationSnapshot.affectationsDossiersDeNominations,
-          })
-          .where(eq(affectationPm.id, affectationSnapshot.id));
+          },
+        });
+
+      await db.insert(drizzleDossierRapporteur).values(
+        affectationSnapshot.affectationsDossiersDeNominations.flatMap((d) =>
+          d.rapporteurIds.map((userId) => ({
+            userId,
+            versionId: affectationSnapshot.id,
+            dossierId: d.dossierDeNominationId,
+          })),
+        ),
+      );
+
+      const affectationByPriority =
+        affectationSnapshot.affectationsDossiersDeNominations
+          .filter((a): a is typeof a & { priorite: PrioriteEnum } =>
+            isDefined(a.priorite),
+          )
+          .reduce((byPriority, { priorite, dossierDeNominationId }) => {
+            const list = byPriority.get(priorite) ?? [];
+            list.push(dossierDeNominationId);
+            byPriority.set(priorite, list);
+
+            return byPriority;
+          }, new Map<PrioriteEnum, string[]>());
+
+      for (const [priority, dossierIds] of affectationByPriority.entries()) {
+        await db
+          .update(dossierDeNominationPm)
+          .set({ priority })
+          .where(inArray(dossierDeNominationPm.id, dossierIds));
       }
     };
   }
@@ -123,16 +165,6 @@ export class SqlAffectationRepository implements AffectationRepository {
       const dernierNumero = result[0]?.maxVersion ?? 0;
       return dernierNumero + 1;
     };
-  }
-
-  static mapToDb(affectation: Affectation): typeof affectationPm.$inferInsert {
-    return SqlAffectationRepository.mapSnapshotToDb(affectation.snapshot());
-  }
-
-  static mapSnapshotToDb(
-    snapshot: AffectationSnapshot,
-  ): typeof affectationPm.$inferInsert {
-    return snapshot;
   }
 
   static mapToDomain(row: typeof affectationPm.$inferSelect): Affectation {


### PR DESCRIPTION
## 🟢 request for comment OPEN

L'utilisation de la table des affectations est source d'erreur, l'idée ici est de commencer à la déprécier.

Inspiration pour le processus de migration: https://kiranrao.ca/2022/05/04/zero-downtime-migrations.html 