### PR TITLE
feat(): ajout de l'alerte lors d'un tableau avec valeurs vides

### DIFF
--- a/apps/client/src/components/shared/TableauDossiersDeNomination.tsx
+++ b/apps/client/src/components/shared/TableauDossiersDeNomination.tsx
@@ -1,9 +1,18 @@
 import Button from '@codegouvfr/react-dsfr/Button';
 import Table from '@codegouvfr/react-dsfr/Table';
 import type { ReactNode } from 'react';
-import { useState, useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import type { UserDescriptorSerialized } from 'shared-models';
 import { PrioriteEnum } from 'shared-models/models/priorite.enum';
+import {
+  AffectationProvider,
+  useAffectation,
+  type DossierAffectation
+} from '../../contexts/AffectationDossiersContext';
 import { useTable } from '../../hooks/useTable.hook';
+import type { SessionNominationFile } from '../../react-query/mutations/sg/nomination-session-affectations';
+import { ActionsGroupees } from '../secretariat-general/transparence/tableau-affectation-dossier-de-nomination/ActionsGroupees';
+import { FiltresDossiersDeNomination } from '../secretariat-general/transparence/tableau-affectation-dossier-de-nomination/FiltresDossiersDeNomination';
 import {
   applyFilters,
   dataRowsDn,
@@ -12,18 +21,9 @@ import {
   HEADER_COLUMNS_AFFECTATIONS_DN_EDITION,
   sortValueSpecificDnField
 } from '../secretariat-general/transparence/tableau-affectation-dossier-de-nomination/tableau-affectation-config';
-import { FiltresDossiersDeNomination } from '../secretariat-general/transparence/tableau-affectation-dossier-de-nomination/FiltresDossiersDeNomination';
-import { ActionsGroupees } from '../secretariat-general/transparence/tableau-affectation-dossier-de-nomination/ActionsGroupees';
 import type { FiltersState } from './filter-configurations';
 import { SortButton } from './SortButton';
 import { TableControl } from './TableControl';
-import type { UserDescriptorSerialized } from 'shared-models';
-import {
-  AffectationProvider,
-  useAffectation,
-  type DossierAffectation
-} from '../../contexts/AffectationDossiersContext';
-import type { SessionNominationFile } from '../../react-query/mutations/sg/nomination-session-affectations';
 
 export interface TableauDossiersDeNominationProps {
   dossiersDeNomination: SessionNominationFile[];
@@ -162,6 +162,7 @@ const TableauDossiersDeNominationContent = ({
         headers={TABLE_HEADER}
         data={dossierDataRows}
       />
+      {paginatedData.length === 0 ? <p className="mt-2 text-gray-600">Aucun résultat</p> : null}
 
       <TableControl
         onChange={setItemsPerPage}


### PR DESCRIPTION
Le tableau DSFR ne permet pas de renseigner une ligne de message pour les cellules vides. 
A voir en atelier si ce type de contournement peut convenir.


<img width="1275" height="393" alt="Capture d’écran 2025-11-26 à 13 17 00" src="https://github.com/user-attachments/assets/944b6af0-9ce9-47a0-a5ad-f3b64aea4f0e" />
