### PR TITLE
fix(FON-000): retours atelier 28/01/26

### DIFF
--- a/apps/api/src/modules/report/infrastructure/queries/detail-report.query.ts
+++ b/apps/api/src/modules/report/infrastructure/queries/detail-report.query.ts
@@ -187,7 +187,7 @@ export class DetailReportQuery {
 
     return {
       id: report.id,
-      sessionId: report.id,
+      sessionId: report.sessionId,
       nominationFileId: report.nominationFile.id,
       comment: report.comment,
       state: prismaReportStateEnumToReportState(report.state),

--- a/apps/client/src/components/reports/components/ReportOverview/Observers.tsx
+++ b/apps/client/src/components/reports/components/ReportOverview/Observers.tsx
@@ -1,12 +1,9 @@
-import Card from '@codegouvfr/react-dsfr/Card';
 import { cx } from '@codegouvfr/react-dsfr/fr/cx';
 
-import { capitalize } from '@/utils/string.utils';
+import { ObservationCard } from '@/components/shared/observations';
 import type { DetailedReportDto } from '@api/types';
 import clsx from 'clsx';
 import { ReportVM } from '../../../../VM/ReportVM';
-import { DateOnly } from '../../../../models/date-only.model';
-import { getObservationDetailsPath } from '../../../../utils/route-path.utils';
 import { reportHtmlIds } from '../../dom/html-ids';
 
 export const Observers = ({
@@ -53,39 +50,17 @@ export const Observers = ({
       {hasObservations && (
         <>
           <h3 className={cx('fr-h6', 'fr-mt-3w', 'fr-mb-2w')}>Observations reçues</h3>
-          <div className={clsx('grid grid-cols-1 gap-4 md:grid-cols-2')}>
-            {observations.map((observation: NonNullable<DetailedReportDto['observations']>[number]) => {
-              const magistratName = `${observation.magistrat.lastName.toUpperCase()} ${capitalize(observation.magistrat.firstName)}`;
-
-              const observationPath = getObservationDetailsPath(
-                {
-                  sessionId,
-                  nominationFileId,
-                  observationId: observation.id
-                },
-                'membre'
-              );
-              const linkWithReport = reportId ? `${observationPath}?reportId=${reportId}` : observationPath;
-
-              return (
-                <Card
-                  key={observation.id}
-                  title={magistratName}
-                  desc={
-                    <div className={cx('fr-text--sm')}>
-                      <p className={cx('fr-mb-0', 'fr-text--light')}>
-                        Observation du {DateOnly.fromDateOnly(observation.dateReception)}
-                      </p>
-                    </div>
-                  }
-                  linkProps={{
-                    to: linkWithReport
-                  }}
-                  enlargeLink
-                  size="small"
-                />
-              );
-            })}
+          <div className={clsx('grid grid-cols-2 gap-4')}>
+            {observations.map((observation: NonNullable<DetailedReportDto['observations']>[number]) => (
+              <ObservationCard
+                key={observation.id}
+                observation={observation}
+                sessionId={sessionId!}
+                nominationFileId={nominationFileId!}
+                context="membre"
+                reportId={reportId}
+              />
+            ))}
           </div>
         </>
       )}

--- a/apps/client/src/components/shared/ObservationDetailsContent.tsx
+++ b/apps/client/src/components/shared/ObservationDetailsContent.tsx
@@ -1,12 +1,13 @@
-import { Link } from 'react-router-dom';
 import Button from '@codegouvfr/react-dsfr/Button';
 import Card from '@codegouvfr/react-dsfr/Card';
+import { Link } from 'react-router-dom';
 
-import { DateOnly } from '@/models/date-only.model';
-import type { ObservationDetails } from '@queries/observations.queries';
 import { TipTapEditor } from '@/components/reports/components/ReportOverview/TipTapEditor';
 import type { FilesUploader } from '@/components/reports/components/ReportOverview/TipTapEditor/extensions/editor-file-uploader';
+import { DateOnly } from '@/models/date-only.model';
+import type { ObservationDetails } from '@queries/observations.queries';
 import { getObservationDetailsPath } from '../../utils/route-path.utils';
+import { LolfiMagistratLink } from './LolfiMagistratLink';
 import { ObservationFollowUpSelector } from './observations/follow-up-selector/ObservationFollowUpSelector';
 
 type ObservationDetailsContentProps = {
@@ -68,7 +69,15 @@ export function ObservationDetailsContent({
               </div>
               <div className="fr-grid-row fr-mb-2w">
                 <dt className="fr-col-4 fr-text--bold">Magistrat observé :</dt>
-                <dd className="fr-col-8 fr-m-0">{observation.observedMagistrat?.name}</dd>
+                <dd className="fr-col-8 fr-m-0 flex items-center gap-2">
+                  {observation.observedMagistrat?.name}
+                  <LolfiMagistratLink
+                    sessionId={sessionId}
+                    nominationFileId={nominationFileId}
+                    name={observation.observedMagistrat?.name}
+                    small
+                  />
+                </dd>
               </div>
               <div className="fr-grid-row fr-mb-2w">
                 <dt className="fr-col-4 fr-text--bold">Poste observé :</dt>
@@ -82,8 +91,19 @@ export function ObservationDetailsContent({
             <dl className="fr-mb-0">
               <div className="fr-grid-row fr-mb-2w">
                 <dt className="fr-col-4 fr-text--bold">NOM Prénom :</dt>
-                <dd className="fr-col-8 fr-m-0">
-                  {observant.lastName.toUpperCase()} {observant.firstName}
+                <dd className="fr-col-8 fr-m-0 flex items-center gap-2">
+                  <span>
+                    {observant.lastName.toUpperCase()} {observant.firstName}
+                  </span>
+                  {/* TODO revoir cette partie, conditionné au fait que l'observant soit un candidat.  */}
+                  {candidacy && (
+                    <LolfiMagistratLink
+                      sessionId={sessionId}
+                      nominationFileId={candidacy.nominationFileId}
+                      name={`${observant.lastName.toUpperCase()} ${observant.firstName}`}
+                      small
+                    />
+                  )}
                 </dd>
               </div>
               {candidacy && (

--- a/apps/client/src/components/shared/nomination-files-table/components/cells/magistrat-details/MagistratDetails.tsx
+++ b/apps/client/src/components/shared/nomination-files-table/components/cells/magistrat-details/MagistratDetails.tsx
@@ -14,7 +14,10 @@ import {
 
 import { LolfiMagistratLink } from '@/components/shared/LolfiMagistratLink';
 import { TextValue } from '@/components/shared/TextValue';
+import { ObservationCard } from '@/components/shared/observations';
 import { UserAvatarList } from '@/components/shared/user-avatar';
+
+import clsx from 'clsx';
 
 import { MagistratSummaryButton } from './MagistratSummaryButton';
 import { MemberMemo } from './member-memo/MemberMemo';
@@ -103,6 +106,23 @@ export const MagistratDetails: FC<MagistratDetailsProps> = ({ sessionId, nominat
           {formattedBiography}
         </div>
       </div>
+
+      {nominationFile.observations && nominationFile.observations.length > 0 && (
+        <div>
+          <label className="text-xl font-semibold">Observations ({nominationFile.observations.length})</label>
+          <div className={clsx('grid grid-cols-1 gap-4 md:grid-cols-2', 'mt-2')}>
+            {nominationFile.observations.map((observation) => (
+              <ObservationCard
+                key={observation.id}
+                observation={observation}
+                sessionId={sessionId}
+                nominationFileId={nominationFile.id}
+                context="sg"
+              />
+            ))}
+          </div>
+        </div>
+      )}
 
       <MemberMemo sessionId={sessionId} nominationFileId={nominationFile.id} memo={nominationFile.memo} />
     </div>

--- a/apps/client/src/components/shared/nomination-files-table/components/cells/observations/ObservationsList.tsx
+++ b/apps/client/src/components/shared/nomination-files-table/components/cells/observations/ObservationsList.tsx
@@ -1,9 +1,10 @@
 import Button from '@codegouvfr/react-dsfr/Button';
 import { type FC } from 'react';
 
+import { getObservationDetailsPath } from '@/utils/route-path.utils';
 import {
-  useObservationsQuery,
   useGetObservationFileUrlMutation,
+  useObservationsQuery,
   type Observation
 } from '@queries/observations.queries';
 
@@ -44,6 +45,24 @@ const ObservationCard: FC<{
           )}
         </div>
         <div className="flex gap-1">
+          <Button
+            iconId="ri-external-link-line"
+            priority="tertiary no outline"
+            size="small"
+            title="Voir les détails"
+            linkProps={{
+              to: getObservationDetailsPath(
+                {
+                  sessionId,
+                  nominationFileId,
+                  observationId: observation.id
+                },
+                'sg'
+              ),
+              target: '_blank',
+              rel: 'noopener noreferrer'
+            }}
+          />
           <Button
             iconId="ri-edit-line"
             priority="tertiary no outline"

--- a/apps/client/src/components/shared/observations/ObservationCard.tsx
+++ b/apps/client/src/components/shared/observations/ObservationCard.tsx
@@ -1,0 +1,56 @@
+import Card from '@codegouvfr/react-dsfr/Card';
+import { cx } from '@codegouvfr/react-dsfr/fr/cx';
+
+import type { DetailedReportDto } from '@/generated/api/types';
+import { DateOnly } from '@/models/date-only.model';
+import type { SessionNominationFile } from '@/queries/nomination-sessions.queries';
+import { getObservationDetailsPath } from '@/utils/route-path.utils';
+import { capitalize } from '@/utils/string.utils';
+
+type ObservationCardProps = {
+  observation: DetailedReportDto['observations'][number] | SessionNominationFile['observations'][number];
+  sessionId: string;
+  nominationFileId: string;
+  context: 'sg' | 'membre';
+  reportId?: string;
+};
+
+export function ObservationCard({
+  observation,
+  sessionId,
+  nominationFileId,
+  context,
+  reportId
+}: ObservationCardProps) {
+  const magistratName = observation.magistrat
+    ? `${observation.magistrat.lastName.toUpperCase()} ${capitalize(observation.magistrat.firstName)}`
+    : 'Magistrat inconnu';
+
+  const dateObj = 'dateReception' in observation ? observation.dateReception : observation.date;
+
+  const observationPath = getObservationDetailsPath(
+    {
+      sessionId,
+      nominationFileId,
+      observationId: observation.id
+    },
+    context
+  );
+  const linkWithReport = reportId ? `${observationPath}?reportId=${reportId}` : observationPath;
+
+  return (
+    <Card
+      title={magistratName}
+      desc={
+        <div className={cx('fr-text--sm')}>
+          <p className={cx('fr-mb-0', 'fr-text--light')}>Observation du {DateOnly.fromDateOnly(dateObj)}</p>
+        </div>
+      }
+      linkProps={{
+        to: linkWithReport
+      }}
+      enlargeLink
+      size="small"
+    />
+  );
+}

--- a/apps/client/src/components/shared/observations/index.ts
+++ b/apps/client/src/components/shared/observations/index.ts
@@ -1,0 +1,1 @@
+export { ObservationCard } from './ObservationCard';


### PR DESCRIPTION
PR traitant des différents retours liés à l'atelier du 28/01/2026 : 

- Correction d'un bug sur le fil d'ariane depuis la page de rapport 

- Affichage des liens LOLFI sur les magistrats observants et observés de la fiche détail d'une observation 

- Accès à la fiche détail des observations depuis le menu d'édition du tableau de supervision SG

- Ajout des observations dans la modale des magistrats. 