### PR TITLE
chore(FON-000): enforce oxfmt as per-language formatter in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,9 @@
   "oxc.enable.oxlint": true,
   "oxc.enable.oxfmt": true,
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "oxc.oxc-vscode"
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "[javascript]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[javascriptreact]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[typescript]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "oxc.oxc-vscode" }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,7 @@
   "oxc.enable.oxfmt": true,
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "oxc.oxc-vscode",
-  "[javascript]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
-  "[javascriptreact]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
-  "[typescript]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
-  "[typescriptreact]": { "editor.defaultFormatter": "oxc.oxc-vscode" }
+  "[javascript][javascriptreact][typescript][typescriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  }
 }


### PR DESCRIPTION
### Context

The shared `.vscode/settings.json` only set `editor.defaultFormatter` at the global level. VSCode resolves the formatter in this priority order:
> workspace per-language > user per-language > workspace global > user global

So any developer with a personal per-language override (e.g. Prettier on `[typescriptreact]` which is very common) silently beats our shared global setting and oxfmt never runs on format-on-save for them

### Change

Add `editor.defaultFormatter: "oxc.oxc-vscode"` at the per-language level for `[javascript]`, `[javascriptreact]`, `[typescript]` and `[typescriptreact]`. Since this is workspace per-language (the highest-priority level), it overrides
any personal per-language formatter without anyone having to edit their own settings