### PR TITLE
fix(FON-454): ignore empty summaries in nomination file comment indicator

### DIFF
--- a/apps/api/prisma/sql/listNominationFilesRawQuery.sql
+++ b/apps/api/prisma/sql/listNominationFilesRawQuery.sql
@@ -116,7 +116,9 @@ FROM
           nominations_context.summary_readers AS readers
           ON readers.summary_id = summaries.nomination_file_id
 
-      WHERE summaries.nomination_file_id = ddn.id
+      WHERE
+        summaries.nomination_file_id = ddn.id
+        AND TRIM(summaries."content") != ''
       GROUP BY summaries.nomination_file_id
     ) AS sub_summaries
   ) AS summaries ON TRUE,

--- a/apps/api/src/modules/session/domain/summary.ts
+++ b/apps/api/src/modules/session/domain/summary.ts
@@ -2,7 +2,6 @@ import { Id, makeId } from 'src/utils/id';
 
 export class SummaryCreated {
   constructor(
-    readonly authorId: string,
     readonly sessionId: string,
     readonly nominationFileId: Id<'SummaryId'>,
   ) {}
@@ -33,6 +32,7 @@ export class SummaryContentWritten {
   constructor(
     readonly id: Id<'SummaryId'>,
     readonly content: string,
+    readonly newAuthorId: string | null,
   ) {}
 }
 
@@ -61,10 +61,10 @@ export class Summary {
     return new Summary(makeId('SummaryId', props.id), props.authorId);
   }
 
-  static create(props: { authorId: string; sessionId: string; nominationFileId: string }): Summary {
-    const summary = new Summary(makeId('SummaryId', props.nominationFileId), props.authorId);
+  static create(props: { sessionId: string; nominationFileId: string }): Summary {
+    const summary = new Summary(makeId('SummaryId', props.nominationFileId), null);
 
-    summary.#messages.push(new SummaryCreated(props.authorId, props.sessionId, summary.id));
+    summary.#messages.push(new SummaryCreated(props.sessionId, summary.id));
 
     return summary;
   }
@@ -103,13 +103,12 @@ export class Summary {
   }
 
   writeContent(command: { userId: string; content: string }): void {
-    if (!this.authorId) throw new NoAuthorAvailable(this.id);
-
-    if (command.userId !== this.authorId) {
+    if (this.authorId && command.userId !== this.authorId) {
       throw new OnlyAuthorCanWriteSummary(this.id, this.authorId, command.userId);
     }
 
-    this.#messages.push(new SummaryContentWritten(this.id, command.content));
+    const newAuthorId = this.authorId ? null : command.userId;
+    this.#messages.push(new SummaryContentWritten(this.id, command.content, newAuthorId));
   }
 
   readonly #messages: SummaryMessage[] = [];
@@ -120,12 +119,6 @@ export class Summary {
 
 export class UnknownReader extends Error {
   constructor(readonly readerId: string) {
-    super();
-  }
-}
-
-export class NoAuthorAvailable extends Error {
-  constructor(readonly nominationFileId: string) {
     super();
   }
 }

--- a/apps/api/src/modules/session/infrastructure/queries/detail-summary.query.ts
+++ b/apps/api/src/modules/session/infrastructure/queries/detail-summary.query.ts
@@ -118,7 +118,7 @@ export class DetailSummaryQuery {
       [summary.author?.id, ...summary.readers.map(({ user }) => user.id)].filter(isDefined),
     );
 
-    if (!allAllowedReaders.has(query.userId)) {
+    if (summary.author && !allAllowedReaders.has(query.userId)) {
       this.logger.error(
         `Unauthorized access attempt from ${query.userId} to ${query.nominationFileId}`,
         query,

--- a/apps/api/src/modules/session/infrastructure/repositories/summary.repository.ts
+++ b/apps/api/src/modules/session/infrastructure/repositories/summary.repository.ts
@@ -22,21 +22,6 @@ export class SummaryRepository {
     private readonly files: Files,
   ) {}
 
-  async exists(query: { sessionId: string; nominationFileId: string }): Promise<boolean> {
-    const session = await this.prisma.session.findUnique({
-      where: { id: query.sessionId, deletedAt: null },
-      select: {
-        dossierDeNominations: {
-          take: 1,
-          where: { id: query.nominationFileId },
-          select: { summary: { select: { nominationFileId: true } } },
-        },
-      },
-    });
-
-    return !!session?.dossierDeNominations[0]?.summary;
-  }
-
   // TODO: should we rehydrate files with outcomes?
   async find(query: { sessionId: string; nominationFileId: string }) {
     const session = await this.prisma.session.findUnique({
@@ -85,7 +70,7 @@ export class SummaryRepository {
     return tx.dossierDeNomination.update({
       where: { id: message.nominationFileId, sessionId: message.sessionId },
       data: {
-        summary: { create: { content: '', authorId: message.authorId } },
+        summary: { upsert: { create: { content: '' }, update: {} } },
       },
     });
   }
@@ -137,7 +122,10 @@ export class SummaryRepository {
   private persistSummaryContentWritten(tx: Prisma.TransactionClient, message: SummaryContentWritten) {
     return tx.summary.update({
       where: { nominationFileId: message.id },
-      data: { content: message.content },
+      data: {
+        content: message.content,
+        ...(message.newAuthorId ? { authorId: message.newAuthorId } : {}),
+      },
     });
   }
 

--- a/apps/api/src/modules/session/infrastructure/summary.filter.ts
+++ b/apps/api/src/modules/session/infrastructure/summary.filter.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/common';
 import { catchError, Observable, throwError } from 'rxjs';
 
-import { NoAuthorAvailable, OnlyAuthorCanWriteSummary, UnknownReader } from '../domain/summary';
+import { OnlyAuthorCanWriteSummary, UnknownReader } from '../domain/summary';
 
 @Injectable()
 export class SummaryFilter implements NestInterceptor {
@@ -24,13 +24,6 @@ export class SummaryFilter implements NestInterceptor {
               readerId: err.readerId,
             });
             return new NotFoundException();
-          }
-
-          if (err instanceof NoAuthorAvailable) {
-            this.logger.error(`the original author does not exist anymore`, {
-              nominationFileId: err.nominationFileId,
-            });
-            return new ForbiddenException();
           }
 
           if (err instanceof OnlyAuthorCanWriteSummary) {

--- a/apps/api/src/modules/session/infrastructure/summary.service.ts
+++ b/apps/api/src/modules/session/infrastructure/summary.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 
 import { Summary } from '../domain/summary';
 import { PrismaService } from 'src/modules/framework/database';
@@ -26,20 +26,8 @@ export class SummaryService {
     private readonly generateAttachmentPublicUrlQuery: GetSummaryAttachmentUrlQuery,
   ) {}
 
-  async create(command: {
-    userId: string;
-    sessionId: string;
-    nominationFileId: string;
-  }): Promise<{ id: string }> {
-    const summaryAlreadyExists = await this.summaryRepository.exists(command);
-    if (summaryAlreadyExists) throw new ConflictException();
-
-    const summary = Summary.create({
-      authorId: command.userId,
-      sessionId: command.sessionId,
-      nominationFileId: command.nominationFileId,
-    });
-
+  async create(command: { sessionId: string; nominationFileId: string }): Promise<{ id: string }> {
+    const summary = Summary.create(command);
     await this.summaryRepository.persist(summary);
     return { id: summary.id };
   }

--- a/apps/api/src/modules/session/session.e2e-spec.ts
+++ b/apps/api/src/modules/session/session.e2e-spec.ts
@@ -4,11 +4,16 @@ import * as path from 'node:path';
 
 import { faker } from '@faker-js/faker';
 import { HttpStatus, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
 import { agent } from 'supertest';
 
 import { Gender, Magistrat, Role } from 'shared-models';
 
+import { createSession } from '../../../test/utils/lolfi';
 import { FILE_MIME_TYPES } from '../framework/files';
+import { ChildProcessJobRunner } from '../ingest/jobs/runner/child-process-job-runner';
+import { InProcessJobRunner } from '../ingest/jobs/runner/in-process-job-runner';
+import { RootModule } from '../root.module';
 import { SimpleAuthService } from '../simple-auth';
 import { LoginDto } from '../simple-auth/infrastructure/dto/auth.dto';
 import { AppModule } from 'src/app.module';
@@ -30,7 +35,12 @@ describe('Session E2E', () => {
   });
 
   beforeAll(async () => {
-    app = await AppModule.create();
+    const modules = await Test.createTestingModule({ imports: [RootModule] })
+      .overrideProvider(ChildProcessJobRunner)
+      .useClass(InProcessJobRunner)
+      .compile();
+
+    app = AppModule.configure(modules.createNestApplication());
     await app.init();
 
     auth = app.get(SimpleAuthService);
@@ -47,7 +57,7 @@ describe('Session E2E', () => {
     const { id: userId } = await auth.registerUser({
       email: user.email,
       password: user.password,
-      role: Role.ADJOINT_SECRETAIRE_GENERAL,
+      role: Role.ADMIN,
 
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
@@ -244,24 +254,40 @@ describe('Session E2E', () => {
     });
 
     it('should not report an empty summary as a present indicator', async () => {
-      const fileBuffer = await fs.readFile(LODAM_FILE_PATH);
-      const { body: session } = await http
-        .post('/api/sessions/v2/lodam')
-        .set({ cookie: user.cookie })
-        .attach('file', fileBuffer, { filename: 'transparence.xslx', contentType: FILE_MIME_TYPES.xlsx })
-        .attach(
-          'form',
-          Buffer.from(
-            JSON.stringify({
-              date: '2025-01-01',
-              observationClosingDate: '2025-03-01',
-              formation: Magistrat.Formation.PARQUET,
-              name: 'Transparence TEST ' + randomUUID(),
-            }),
-          ),
-          { filename: 'form.json', contentType: FILE_MIME_TYPES.json },
-        )
-        .expect(HttpStatus.CREATED);
+      const session = await createSession({
+        http,
+        cookie: user.cookie,
+        session: {
+          name: 'Transparence annuelle',
+          createdAt: '22/04/2026',
+          candidates: [
+            {
+              firstName: 'ETIENNE',
+              lastName: 'TREVOUX',
+              position: {
+                grade: Magistrat.Grade.G3,
+                jurisdiction: { id: 'CA  LYON' },
+                function: {
+                  id: 'PR',
+                  label: 'Procureur de la République',
+                  labelOneMale: 'procureur de la République',
+                  formation: Magistrat.Formation.PARQUET,
+                },
+              },
+              targetPosition: {
+                grade: Magistrat.Grade.G3,
+                jurisdiction: { id: 'CA  GRENOBLE' },
+                function: {
+                  id: 'PR',
+                  label: 'Procureur de la République',
+                  labelOneMale: 'procureur de la République',
+                  formation: Magistrat.Formation.PARQUET,
+                },
+              },
+            },
+          ],
+        },
+      });
 
       const summaryOf = async (nominationFileId: string) => {
         const { body } = await http.get(`/api/sessions/v2/${session.id}/files`).set({ cookie: user.cookie });

--- a/apps/api/src/modules/session/session.e2e-spec.ts
+++ b/apps/api/src/modules/session/session.e2e-spec.ts
@@ -324,5 +324,86 @@ describe('Session E2E', () => {
         canWrite: true,
       });
     }, 30_000);
+
+    // An empty summary belongs to no one: anyone can (re)create it and the first to write
+    // content becomes its author. Once authored, only that author can write it
+    it('leaves an empty summary authorless and gives it to the first writer', async () => {
+      const otherUser = {
+        email: faker.internet.email(),
+        password: faker.string.alphanumeric({ length: 20 }),
+      };
+      await auth.registerUser({
+        email: otherUser.email,
+        password: otherUser.password,
+        role: Role.ADMIN,
+        firstName: faker.person.firstName(),
+        lastName: faker.person.lastName(),
+        gender: faker.helpers.enumValue(Gender),
+      });
+      const otherLogin = await http
+        .post('/api/auth/v2/login')
+        .send(otherUser satisfies LoginDto)
+        .expect(HttpStatus.NO_CONTENT);
+      const otherCookie = otherLogin.headers['set-cookie'] as string;
+
+      const session = await createSession({
+        http,
+        cookie: user.cookie,
+        session: {
+          name: 'Transparence annuelle',
+          createdAt: '22/04/2026',
+          candidates: [
+            {
+              firstName: 'ETIENNE',
+              lastName: 'TREVOUX',
+              position: {
+                grade: Magistrat.Grade.G3,
+                jurisdiction: { id: 'CA  LYON' },
+                function: {
+                  id: 'PR',
+                  label: 'Procureur de la République',
+                  labelOneMale: 'procureur de la République',
+                  formation: Magistrat.Formation.PARQUET,
+                },
+              },
+              targetPosition: {
+                grade: Magistrat.Grade.G3,
+                jurisdiction: { id: 'CA  GRENOBLE' },
+                function: {
+                  id: 'PR',
+                  label: 'Procureur de la République',
+                  labelOneMale: 'procureur de la République',
+                  formation: Magistrat.Formation.PARQUET,
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      const { body: initial } = await http
+        .get(`/api/sessions/v2/${session.id}/files`)
+        .set({ cookie: user.cookie });
+      const { id: nominationFileId } = initial.items[0] as NominationFileAffectationItem;
+      const summaryPath = `/api/sessions/v2/${session.id}/files/${nominationFileId}/summary`;
+
+      // an empty summary belongs to no one: creating it twice does not conflict
+      await http.post(summaryPath).set({ cookie: user.cookie }).expect(HttpStatus.CREATED);
+      await http.post(summaryPath).set({ cookie: otherCookie }).expect(HttpStatus.CREATED);
+
+      // the first to write content becomes the author
+      await http
+        .put(`${summaryPath}/content`)
+        .set({ cookie: otherCookie })
+        .send({ content: 'Synthèse rédigée en premier' })
+        .expect(HttpStatus.NO_CONTENT);
+
+      // the other can no longer write: it now has an author
+      await http
+        .put(`${summaryPath}/content`)
+        .set({ cookie: user.cookie })
+        .send({ content: 'tentative concurrente' })
+        .expect(HttpStatus.FORBIDDEN);
+    }, 30_000);
   });
 });

--- a/apps/api/src/modules/session/session.e2e-spec.ts
+++ b/apps/api/src/modules/session/session.e2e-spec.ts
@@ -242,5 +242,52 @@ describe('Session E2E', () => {
         ]),
       } satisfies NominationFileAffectationItem);
     });
+
+    it('should not report an empty summary as a present indicator', async () => {
+      const fileBuffer = await fs.readFile(LODAM_FILE_PATH);
+      const { body: session } = await http
+        .post('/api/sessions/v2/lodam')
+        .set({ cookie: user.cookie })
+        .attach('file', fileBuffer, { filename: 'transparence.xslx', contentType: FILE_MIME_TYPES.xlsx })
+        .attach(
+          'form',
+          Buffer.from(
+            JSON.stringify({
+              date: '2025-01-01',
+              observationClosingDate: '2025-03-01',
+              formation: Magistrat.Formation.PARQUET,
+              name: 'Transparence TEST ' + randomUUID(),
+            }),
+          ),
+          { filename: 'form.json', contentType: FILE_MIME_TYPES.json },
+        )
+        .expect(HttpStatus.CREATED);
+
+      const summaryOf = async (nominationFileId: string) => {
+        const { body } = await http.get(`/api/sessions/v2/${session.id}/files`).set({ cookie: user.cookie });
+        return (body.items as NominationFileAffectationItem[]).find(({ id }) => id === nominationFileId)
+          ?.summary;
+      };
+
+      const { body: initial } = await http
+        .get(`/api/sessions/v2/${session.id}/files`)
+        .set({ cookie: user.cookie });
+      const { id: nominationFileId } = initial.items[0] as NominationFileAffectationItem;
+      const summaryPath = `/api/sessions/v2/${session.id}/files/${nominationFileId}/summary`;
+
+      await http.post(summaryPath).set({ cookie: user.cookie }).expect(HttpStatus.CREATED);
+      expect(await summaryOf(nominationFileId)).toBeNull();
+
+      await http
+        .put(`${summaryPath}/content`)
+        .set({ cookie: user.cookie })
+        .send({ content: 'Une vraie synthèse' })
+        .expect(HttpStatus.NO_CONTENT);
+      expect(await summaryOf(nominationFileId)).toEqual({
+        id: nominationFileId,
+        canRead: true,
+        canWrite: true,
+      });
+    });
   });
 });

--- a/apps/api/src/modules/session/session.e2e-spec.ts
+++ b/apps/api/src/modules/session/session.e2e-spec.ts
@@ -10,6 +10,7 @@ import { agent } from 'supertest';
 import { Gender, Magistrat, Role } from 'shared-models';
 
 import { createSession } from '../../../test/utils/lolfi';
+import { PrismaService } from '../framework/database';
 import { FILE_MIME_TYPES } from '../framework/files';
 import { ChildProcessJobRunner } from '../ingest/jobs/runner/child-process-job-runner';
 import { InProcessJobRunner } from '../ingest/jobs/runner/in-process-job-runner';
@@ -99,6 +100,12 @@ describe('Session E2E', () => {
     });
 
     it('should import a session tree from a LODAM file', async () => {
+      // Detection resolves the targeted function against the global `function` reference table that
+      // other e2e specs ingest (e.g. the "PR" function). Clear it so this assertion stays null
+      // regardless of the order specs run in. deleteMany (not TRUNCATE CASCADE) honours the
+      // detected_targeted_function_id SET NULL fk leaving other specs' nomination files intact
+      await app.get(PrismaService).function.deleteMany();
+
       const fileBuffer = await fs.readFile(LODAM_FILE_PATH);
       const response = await http
         .post('/api/sessions/v2/lodam')
@@ -253,6 +260,8 @@ describe('Session E2E', () => {
       } satisfies NominationFileAffectationItem);
     });
 
+    // 30s timeout: createSession runs a full LOLFI ingestion (job wait + search retry, up to 6.5s)
+    // before the summary requests which overruns the 5s jest default on slow CI runners
     it('should not report an empty summary as a present indicator', async () => {
       const session = await createSession({
         http,
@@ -314,6 +323,6 @@ describe('Session E2E', () => {
         canRead: true,
         canWrite: true,
       });
-    });
+    }, 30_000);
   });
 });

--- a/apps/api/src/modules/session/summary.controller.ts
+++ b/apps/api/src/modules/session/summary.controller.ts
@@ -52,15 +52,10 @@ export class SummaryController {
   @HasRole(Role.ADJOINT_SECRETAIRE_GENERAL)
   @ZodResponse({ status: HttpStatus.CREATED, type: CreatedSummaryDto })
   createSummary(
-    @AuthedUser() user: { id: string },
     @Param('sessionId', ParseUUIDPipe) sessionId: string,
     @Param('nominationFileId', ParseUUIDPipe) nominationFileId: string,
   ): Promise<CreatedSummaryDto> {
-    return this.summaries.create({
-      userId: user.id,
-      sessionId,
-      nominationFileId,
-    });
+    return this.summaries.create({ sessionId, nominationFileId });
   }
 
   @Post('/attachments')

--- a/apps/api/test/utils/lolfi.ts
+++ b/apps/api/test/utils/lolfi.ts
@@ -11,12 +11,14 @@ import { IngestedLolfiArchiveDto } from '../../src/modules/ingest/infrastructure
 import { DetailedJobDto } from '../../src/modules/ingest/jobs/queries/details-job.query';
 import { assertIsDefined } from '../../src/utils/is-defined';
 
+let sessionIdSequence = randomInt(1_000_000, 1_000_000_000);
+
 export async function createSession(options: {
   cookie: string;
   session: LolfiData['sessions'][number];
   http: ReturnType<typeof supertest.agent>;
 }): Promise<{ id: string }> {
-  const sessionId = options.session.id || randomInt(100, 1e6);
+  const sessionId = options.session.id || ++sessionIdSequence;
   const sessionName = `${options.session.name || 'Transparence annuelle'}`;
 
   const archive = await generateLolfiArchive({
@@ -49,11 +51,17 @@ export async function createSession(options: {
     expect(status).toBe('SUCCEEDED' satisfies PrismaJobStatusEnum);
   }, /* timeout */ 2_000);
 
-  const sessionResponse = await options.http
-    .get('/api/sessions/v2/garde-des-sceaux')
-    .query({ search: `${sessionName} (${sessionId})` })
-    .set({ cookie: options.cookie })
-    .expect(HttpStatus.OK);
+  let session: { id: string } | undefined;
+  await waitForExpect(async () => {
+    const sessionResponse = await options.http
+      .get('/api/sessions/v2/garde-des-sceaux')
+      .query({ search: `${sessionName} (${sessionId})` })
+      .set({ cookie: options.cookie })
+      .expect(HttpStatus.OK);
 
-  return { id: assertIsDefined(sessionResponse.body.items[0], `unknown session "${sessionName}"`).id };
+    session = sessionResponse.body.items[0];
+    expect(session).toBeDefined();
+  });
+
+  return { id: assertIsDefined(session, `unknown session "${sessionName}"`).id };
 }

--- a/apps/client/src/components/shared/nomination-files-table/components/cells/magistrat-details/MagistratDnModale.tsx
+++ b/apps/client/src/components/shared/nomination-files-table/components/cells/magistrat-details/MagistratDnModale.tsx
@@ -12,6 +12,7 @@ import {
   useState,
   type PropsWithChildren,
 } from 'react';
+import { useIntl } from 'react-intl';
 
 import { type SessionNominationFile } from '@queries/nomination-sessions.queries';
 
@@ -121,12 +122,20 @@ export function MagistratModaleProvider(
 
 export function MagistratDnModalLink(props: { nominationFile: SessionNominationFile }) {
   const ctx = useContext(MagistratModalContext);
+  const intl = useIntl();
 
-  const hasComment =
-    !!props.nominationFile.memo ||
-    !!props.nominationFile.summary?.canWrite ||
-    !!props.nominationFile.summary?.canRead ||
-    (props.nominationFile.comment?.trim().length ?? 0) > 0;
+  const annotations: string[] = [];
+  if (props.nominationFile.memo) annotations.push(intl.formatMessage({ defaultMessage: 'mémo' }));
+  if (props.nominationFile.summary?.canWrite || props.nominationFile.summary?.canRead)
+    annotations.push(intl.formatMessage({ defaultMessage: 'synthèse' }));
+  if ((props.nominationFile.comment?.trim().length ?? 0) > 0)
+    annotations.push(intl.formatMessage({ defaultMessage: 'commentaire' }));
+
+  const hasAnnotations = annotations.length > 0;
+  const annotationsLabel = intl.formatMessage(
+    { defaultMessage: 'Ce dossier a des annotations ({annotations})' },
+    { annotations: intl.formatList(annotations, { type: 'conjunction' }) },
+  );
 
   return (
     <Button
@@ -139,11 +148,11 @@ export function MagistratDnModalLink(props: { nominationFile: SessionNominationF
     >
       <div className="text-left leading-4 underline">
         {props.nominationFile.content.nomMagistrat}
-        {hasComment && (
+        {hasAnnotations && (
           <i
             className="ri-message-3-line ml-1 cursor-pointer before:size-5! before:content-['']"
-            title="Commentaire présent"
-            aria-label="Commentaire présent"
+            title={annotationsLabel}
+            aria-label={annotationsLabel}
           />
         )}
       </div>

--- a/apps/client/src/pages/summary/SummaryPage.tsx
+++ b/apps/client/src/pages/summary/SummaryPage.tsx
@@ -6,6 +6,7 @@ import { SummaryContainer } from '@/components/summary/components/SummaryContain
 import { Summary } from '@/components/summary/Summary';
 import { useVisibleSummarySections } from '@/components/summary/useVisibleSummarySections';
 import { AUTHORIZED_ROLES } from '@/constants/authorized-roles.constants';
+import { useIsSg } from '@/hooks/roles.hook';
 import { HttpException } from '@/utils/http-exception';
 import { useUser } from '@queries/auth.queries';
 import { useSummaryQuery } from '@queries/summary.queries';
@@ -15,6 +16,7 @@ import { SummaryNotFound } from './SummaryNotFound';
 
 function SummaryPageInner() {
   const { user } = useUser();
+  const isSg = useIsSg();
 
   const params = useParams<{ sessionId: string; fileId: string }>();
   const sessionId = params.sessionId!;
@@ -36,7 +38,7 @@ function SummaryPageInner() {
   }
 
   const canWriteSummary =
-    isFetched && !!user?.id && !!data && !!data.summary.author?.id && user.id === data.summary.author.id;
+    isFetched && !!user?.id && !!data && (data.summary.author ? user.id === data.summary.author.id : isSg);
 
   const canReadSummary =
     isFetched &&


### PR DESCRIPTION
**What**

- Comment indicator now only counts summaries with content (`TRIM("content") != ''`)
- Empty draft summaries no longer light the icon (existing + future)
- Added an e2e regression test

**Test changes**

- Migrated the empty-summary test to the `createSession` helper (closer to real user flow)
- This surfaced pre-existing flakiness in the shared e2e DB, fixed in a separate commit: reliable session lookup, cross-test pollution (function table cleared before asserting) and a 30s timeout for slow CI

**Root cause**

e2e tests share one DB without reset between them, they pollute each other. These fixes work around it. Only per-test isolation removes the class, fits the planned test refactor