### PR TITLE
fix(FON-000): declare missing archivedAt index in session schema

### DIFF
--- a/apps/api/prisma/schemas/nominations.prisma
+++ b/apps/api/prisma/schemas/nominations.prisma
@@ -160,6 +160,7 @@ model Session {
   archiver             User?                 @relation(fields: [archivedBy], references: [id], onDelete: SetNull, onUpdate: NoAction, name: "session_archive_author")
 
   @@index([deletedAt])
+  @@index([archivedAt])
   @@map("session")
   @@schema("nominations_context")
 }


### PR DESCRIPTION
The `session_archived_at_idx` index already exists in the database, created by migration `20260527082038_session_archival`. However, the corresponding `@@index([archivedAt])` declaration was never added to the Prisma schema, leaving the schema out of sync with the database