### PR TITLE
feat(FON-476): add virtualized NewTable shared component

### DIFF
--- a/apps/client/src/shared/ui/new-table/Checkbox.tsx
+++ b/apps/client/src/shared/ui/new-table/Checkbox.tsx
@@ -1,0 +1,48 @@
+import { type ChangeEventHandler, useEffect, useRef } from 'react';
+
+export function Checkbox(props: {
+  checked: boolean;
+  disabled?: boolean;
+  indeterminate?: boolean;
+  label: string;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = !props.checked && !!props.indeterminate;
+  }, [props.checked, props.indeterminate]);
+
+  return (
+    <label className="relative inline-flex size-4 cursor-pointer">
+      <input
+        aria-label={props.label}
+        checked={props.checked}
+        className="peer size-4 cursor-pointer appearance-none rounded-sm border border-(--border-action-high-blue-france) bg-(--background-default-grey) checked:bg-(--background-action-high-blue-france) indeterminate:bg-(--background-action-high-blue-france) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--border-action-high-blue-france) disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={props.disabled}
+        onChange={props.onChange}
+        ref={ref}
+        type="checkbox"
+      />
+      <svg
+        aria-hidden
+        className="pointer-events-none absolute inset-0 hidden size-4 text-white peer-checked:block peer-indeterminate:hidden"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        viewBox="0 0 16 16"
+      >
+        <path d="M3.5 8.5l3 3 6-7" />
+      </svg>
+      <svg
+        aria-hidden
+        className="pointer-events-none absolute inset-0 hidden size-4 text-white peer-indeterminate:block"
+        viewBox="0 0 16 16"
+      >
+        <rect fill="currentColor" height="2" rx="1" width="9" x="3.5" y="7" />
+      </svg>
+    </label>
+  );
+}

--- a/apps/client/src/shared/ui/new-table/Checkbox.tsx
+++ b/apps/client/src/shared/ui/new-table/Checkbox.tsx
@@ -26,7 +26,7 @@ export function Checkbox(props: {
       />
       <svg
         aria-hidden
-        className="pointer-events-none absolute inset-0 hidden size-4 text-white peer-checked:block peer-indeterminate:hidden"
+        className="pointer-events-none absolute inset-0 hidden size-4 text-(--text-inverted-blue-france) peer-checked:block peer-indeterminate:hidden"
         fill="none"
         stroke="currentColor"
         strokeLinecap="round"
@@ -38,7 +38,7 @@ export function Checkbox(props: {
       </svg>
       <svg
         aria-hidden
-        className="pointer-events-none absolute inset-0 hidden size-4 text-white peer-indeterminate:block"
+        className="pointer-events-none absolute inset-0 hidden size-4 text-(--text-inverted-blue-france) peer-indeterminate:block"
         viewBox="0 0 16 16"
       >
         <rect fill="currentColor" height="2" rx="1" width="9" x="3.5" y="7" />

--- a/apps/client/src/shared/ui/new-table/NewTable.fixtures.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.fixtures.tsx
@@ -1,0 +1,116 @@
+import { type ColumnDef, getCoreRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table';
+import { useCallback, useMemo, useState } from 'react';
+
+import { useSelectionColumn } from './hooks/useSelectionColumn';
+import { NewTable } from './NewTable';
+
+export type Person = {
+  age: number;
+  city: string;
+  email: string;
+  firstName: string;
+  id: string;
+  lastName: string;
+};
+
+const FIRST_NAMES = ['Camille', 'Lucas', 'Inès', 'Noé', 'Léa', 'Yanis', 'Jade', 'Hugo'];
+const LAST_NAMES = ['Martin', 'Bernard', 'Dubois', 'Petit', 'Robert', 'Moreau', 'Laurent', 'Simon'];
+const CITIES = ['Paris', 'Lyon', 'Marseille', 'Lille', 'Nantes', 'Bordeaux', 'Toulouse', 'Rennes'];
+
+export function makePeople(count: number): Person[] {
+  return Array.from({ length: count }, (_, index) => {
+    const firstName = FIRST_NAMES[index % FIRST_NAMES.length];
+    const lastName = LAST_NAMES[index % LAST_NAMES.length];
+    return {
+      age: 20 + (index % 45),
+      city: CITIES[index % CITIES.length],
+      email: `${firstName}.${lastName}.${index}@example.fr`.toLowerCase(),
+      firstName,
+      id: `person-${index}`,
+      lastName,
+    };
+  });
+}
+
+export const peopleColumns: ColumnDef<Person>[] = [
+  { accessorKey: 'firstName', header: 'Prénom', size: 160 },
+  { accessorKey: 'lastName', header: 'Nom', size: 160 },
+  { accessorKey: 'age', header: 'Âge', size: 100 },
+  { accessorKey: 'city', header: 'Ville', size: 160 },
+  { accessorKey: 'email', enableSorting: false, header: 'Email', size: 280 },
+];
+
+const ROW_TINTS = {
+  blue: 'hover:bg-(--background-open-blue-france)',
+  yellow: 'hover:bg-(--background-contrast-yellow-moutarde)',
+} as const;
+
+export function DemoTable(props: {
+  enableSorting?: boolean;
+  height?: number;
+  rowCount?: number;
+  rowTint?: keyof typeof ROW_TINTS;
+  withSelection?: boolean;
+}) {
+  const data = useMemo(() => makePeople(props.rowCount ?? 100), [props.rowCount]);
+  const selectionColumn = useSelectionColumn<Person>();
+
+  const columns = useMemo(
+    () => (props.withSelection ? [selectionColumn, ...peopleColumns] : peopleColumns),
+    [props.withSelection, selectionColumn],
+  );
+
+  const table = useReactTable({
+    columns,
+    data,
+    enableRowSelection: props.withSelection ?? false,
+    enableSorting: props.enableSorting ?? false,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.id,
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <div style={{ height: props.height ?? 480 }}>
+      <NewTable rowTint={props.rowTint ? () => ROW_TINTS[props.rowTint!] : undefined} table={table} />
+    </div>
+  );
+}
+
+const INFINITE_TOTAL = 1000;
+const INFINITE_PAGE_SIZE = 50;
+
+export function InfiniteDemoTable(props: { height?: number }) {
+  const all = useMemo(() => makePeople(INFINITE_TOTAL), []);
+  const [loaded, setLoaded] = useState(INFINITE_PAGE_SIZE);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+
+  const hasNextPage = loaded < INFINITE_TOTAL;
+  const data = useMemo(() => all.slice(0, loaded), [all, loaded]);
+
+  const fetchNextPage = useCallback(() => {
+    setIsFetchingNextPage(true);
+    setTimeout(() => {
+      setLoaded((current) => Math.min(current + INFINITE_PAGE_SIZE, INFINITE_TOTAL));
+      setIsFetchingNextPage(false);
+    }, 300);
+  }, []);
+
+  const table = useReactTable({
+    columns: peopleColumns,
+    data,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.id,
+  });
+
+  return (
+    <div style={{ height: props.height ?? 480 }}>
+      <NewTable
+        onEndReached={() => {
+          if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+        }}
+        table={table}
+      />
+    </div>
+  );
+}

--- a/apps/client/src/shared/ui/new-table/NewTable.stories.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { DemoTable, InfiniteDemoTable } from './NewTable.fixtures';
+
+const meta = {
+  title: 'Shared/NewTable',
+  component: DemoTable,
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    rowCount: {
+      control: { type: 'range', min: 0, max: 10000, step: 50 },
+      description: 'Nombre de lignes dans le jeu de données (toutes virtualisées).',
+    },
+    height: {
+      control: { type: 'range', min: 200, max: 800, step: 20 },
+      description: 'Hauteur du conteneur scrollable (px).',
+    },
+    withSelection: {
+      control: 'boolean',
+      description: 'Active la colonne de sélection (checkbox + select-all + shift-click).',
+    },
+    rowTint: {
+      control: 'inline-radio',
+      options: [undefined, 'blue', 'yellow'],
+      description: 'Couleur de survol des lignes via rowTint (gris par défaut si non défini).',
+    },
+    enableSorting: {
+      control: 'boolean',
+      description: 'Active le tri par colonne (la colonne Email reste non triable).',
+    },
+  },
+  args: {
+    rowCount: 100,
+    height: 480,
+    withSelection: false,
+    rowTint: undefined,
+    enableSorting: false,
+  },
+} satisfies Meta<typeof DemoTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Default: Story = {
+  args: { rowCount: 100 },
+};
+
+export const WithSelection: Story = {
+  args: { withSelection: true },
+};
+
+export const Sorting: Story = {
+  args: { enableSorting: true },
+};
+
+export const ManyRows: Story = {
+  args: { rowCount: 10000, withSelection: true },
+};
+
+export const Empty: Story = {
+  args: { rowCount: 0 },
+};
+
+export const InfiniteScroll: Story = {
+  render: () => <InfiniteDemoTable />,
+};

--- a/apps/client/src/shared/ui/new-table/NewTable.test.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+
+import { DemoTable } from './NewTable.fixtures';
+
+describe('NewTable', () => {
+  it('only renders a fraction of the rows (virtualization)', () => {
+    render(<DemoTable rowCount={1000} />);
+
+    const renderedRows = screen.getAllByRole('row').filter((row) => row.hasAttribute('aria-rowindex'));
+    expect(renderedRows.length).toBeLessThan(1000);
+  });
+
+  it('exposes the real total through aria-rowcount, not the rendered count', () => {
+    render(<DemoTable rowCount={1000} />);
+
+    expect(screen.getByRole('table')).toHaveAttribute('aria-rowcount', '1000');
+  });
+
+  it('selects the whole dataset with select-all, not just the visible rows', async () => {
+    const user = userEvent.setup();
+    render(<DemoTable rowCount={1000} withSelection />);
+
+    await user.click(screen.getByLabelText('Sélectionner toutes les lignes'));
+
+    expect(screen.getByLabelText('Désélectionner toutes les lignes')).toBeInTheDocument();
+  });
+
+  it('toggles the sort state of a column when its header is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DemoTable enableSorting rowCount={50} />);
+
+    const firstNameHeader = screen.getByRole('columnheader', { name: /Prénom/ });
+    expect(firstNameHeader).toHaveAttribute('aria-sort', 'none');
+
+    await user.click(screen.getByRole('button', { name: /Prénom/ }));
+    expect(firstNameHeader).toHaveAttribute('aria-sort', 'ascending');
+
+    await user.click(screen.getByRole('button', { name: /Prénom/ }));
+    expect(firstNameHeader).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('renders the empty label when there is no data', () => {
+    render(<DemoTable rowCount={0} />);
+
+    expect(screen.getByText('Aucune donnée')).toBeInTheDocument();
+  });
+
+  it('passes basic accessibility checks', async () => {
+    const { container } = render(<DemoTable rowCount={50} withSelection />);
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/client/src/shared/ui/new-table/NewTable.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.tsx
@@ -1,0 +1,137 @@
+import { flexRender, type Header, type Row, type RowData, type Table } from '@tanstack/react-table';
+import clsx from 'clsx';
+import { type ReactNode, useEffect, useRef } from 'react';
+
+import { useTableVirtualizer } from './hooks/useTableVirtualizer';
+
+function SortIcon(props: { direction: false | 'asc' | 'desc' }) {
+  const glyph = props.direction === 'asc' ? '▲' : props.direction === 'desc' ? '▼' : '↕';
+  return (
+    <span aria-hidden className="text-xs text-(--text-mention-grey)">
+      {glyph}
+    </span>
+  );
+}
+
+function HeaderCell<Data extends RowData>(props: { header: Header<Data, unknown> }) {
+  const { header } = props;
+  const sticky = header.column.columnDef.meta?.sticky;
+  const canSort = header.column.getCanSort();
+  const direction = header.column.getIsSorted();
+  const ariaSort = direction === 'asc' ? 'ascending' : direction === 'desc' ? 'descending' : 'none';
+
+  return (
+    <div
+      aria-sort={canSort ? ariaSort : undefined}
+      className={clsx(
+        'flex h-12 items-center overflow-hidden px-4 text-sm leading-6 font-bold text-ellipsis whitespace-nowrap text-(--text-default-grey)',
+        sticky && 'sticky left-0 z-3 border-r border-(--border-default-grey) bg-(--background-contrast-grey)',
+      )}
+      role="columnheader"
+      style={{ width: header.getSize() }}
+    >
+      {canSort ? (
+        <button
+          className="inline-flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 text-sm leading-6 font-bold text-(--text-default-grey) hover:text-(--text-action-high-blue-france)"
+          onClick={header.column.getToggleSortingHandler()}
+          type="button"
+        >
+          {flexRender(header.column.columnDef.header, header.getContext())}
+          <SortIcon direction={direction} />
+        </button>
+      ) : (
+        flexRender(header.column.columnDef.header, header.getContext())
+      )}
+    </div>
+  );
+}
+
+export function NewTable<Data extends RowData>(props: {
+  emptyLabel?: ReactNode;
+  isLoading?: boolean;
+  onEndReached?: () => void;
+  rowTint?: (row: Row<Data>) => string | undefined;
+  table: Table<Data>;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { onEndReached, table } = props;
+
+  const rows = table.getRowModel().rows;
+  const totalRows = rows.length;
+  const virtualizer = useTableVirtualizer({ rowCount: totalRows, scrollRef });
+  const virtualRows = virtualizer.getVirtualItems();
+
+  const lastRenderedIndex = virtualRows.at(-1)?.index;
+  useEffect(() => {
+    if (onEndReached && lastRenderedIndex !== undefined && lastRenderedIndex >= totalRows - 1) {
+      onEndReached();
+    }
+  }, [onEndReached, lastRenderedIndex, totalRows]);
+
+  const isEmpty = !props.isLoading && totalRows === 0;
+
+  return (
+    <div
+      className="relative size-full overflow-auto border border-(--border-contrast-grey) bg-(--background-default-grey) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--border-action-high-blue-france)"
+      ref={scrollRef}
+      tabIndex={0}
+    >
+      <div aria-rowcount={totalRows} className="grid w-full text-sm text-(--text-default-grey)" role="table">
+        <div className="sticky top-0 z-2 grid bg-(--background-contrast-grey)" role="rowgroup">
+          {table.getHeaderGroups().map((group) => (
+            <div className="flex w-full border-b border-(--border-default-grey)" key={group.id} role="row">
+              {group.headers.map((header) => (
+                <HeaderCell header={header} key={header.id} />
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div className="relative grid" role="rowgroup" style={{ height: `${virtualizer.getTotalSize()}px` }}>
+          {isEmpty ? (
+            <div className="p-8 text-center text-(--text-mention-grey)" role="row">
+              <div role="cell">{props.emptyLabel ?? 'Aucune donnée'}</div>
+            </div>
+          ) : null}
+
+          {virtualRows.map((virtualRow) => {
+            const row = rows[virtualRow.index];
+            return (
+              <div
+                aria-rowindex={virtualRow.index + 1}
+                aria-selected={row.getCanSelect() ? row.getIsSelected() : undefined}
+                className={clsx(
+                  'absolute flex h-12 w-full border-b border-(--border-default-grey)',
+                  props.rowTint?.(row) ??
+                    'hover:bg-(--background-alt-grey-hover) aria-selected:bg-(--background-open-blue-france)',
+                )}
+                data-index={virtualRow.index}
+                key={row.id}
+                ref={virtualizer.measureElement}
+                role="row"
+                style={{ transform: `translateY(${virtualRow.start}px)` }}
+              >
+                {row.getVisibleCells().map((cell) => {
+                  const sticky = cell.column.columnDef.meta?.sticky;
+                  return (
+                    <div
+                      className={clsx(
+                        'flex items-center overflow-hidden px-4 py-2 text-ellipsis whitespace-nowrap',
+                        sticky && 'sticky left-0 z-1 border-r border-(--border-default-grey) bg-inherit',
+                      )}
+                      key={cell.id}
+                      role="cell"
+                      style={{ width: cell.column.getSize() }}
+                    >
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/shared/ui/new-table/hooks/useSelectionColumn.tsx
+++ b/apps/client/src/shared/ui/new-table/hooks/useSelectionColumn.tsx
@@ -1,0 +1,58 @@
+import { type ColumnDef, type RowData } from '@tanstack/react-table';
+import { useMemo, useRef } from 'react';
+
+import { Checkbox } from '../Checkbox';
+
+const SELECTION_COLUMN_SIZE = 48;
+
+export function useSelectionColumn<Data extends RowData>(): ColumnDef<Data> {
+  const lastSelectedRef = useRef<string | null>(null);
+
+  return useMemo(
+    () => ({
+      enableSorting: false,
+      header: ({ table }) => (
+        <Checkbox
+          checked={table.getIsAllRowsSelected()}
+          indeterminate={table.getIsSomeRowsSelected()}
+          label={
+            table.getIsAllRowsSelected()
+              ? 'Désélectionner toutes les lignes'
+              : 'Sélectionner toutes les lignes'
+          }
+          onChange={table.getToggleAllRowsSelectedHandler()}
+        />
+      ),
+      cell: ({ row, table }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          disabled={!row.getCanSelect()}
+          label={`Sélectionner la ligne ${row.index + 1}`}
+          onChange={(event) => {
+            const shouldSelect = event.currentTarget.checked;
+            const hasShift = (event.nativeEvent as MouseEvent).shiftKey;
+            const last = lastSelectedRef.current;
+
+            if (hasShift && last) {
+              const rows = table.getRowModel().rows;
+              const lastIndex = table.getRow(last).index;
+              const [from, to] = [lastIndex, row.index].sort((a, b) => a - b);
+              table.setRowSelection((selection) => ({
+                ...selection,
+                ...Object.fromEntries(rows.slice(from, to + 1).map((r) => [r.id, shouldSelect])),
+              }));
+            } else {
+              row.toggleSelected(shouldSelect);
+            }
+
+            lastSelectedRef.current = row.id;
+          }}
+        />
+      ),
+      id: 'select',
+      meta: { sticky: true },
+      size: SELECTION_COLUMN_SIZE,
+    }),
+    [],
+  );
+}

--- a/apps/client/src/shared/ui/new-table/hooks/useTableVirtualizer.ts
+++ b/apps/client/src/shared/ui/new-table/hooks/useTableVirtualizer.ts
@@ -1,0 +1,20 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { type RefObject } from 'react';
+
+const ESTIMATED_ROW_HEIGHT = 48;
+
+export function useTableVirtualizer(props: {
+  rowCount: number;
+  scrollRef: RefObject<HTMLDivElement | null>;
+}) {
+  return useVirtualizer({
+    count: props.rowCount,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    getScrollElement: () => props.scrollRef.current,
+    measureElement:
+      typeof window !== 'undefined' && navigator.userAgent.indexOf('Firefox') === -1
+        ? (element) => element?.getBoundingClientRect().height
+        : undefined,
+    overscan: 10,
+  });
+}

--- a/apps/client/src/shared/ui/new-table/index.ts
+++ b/apps/client/src/shared/ui/new-table/index.ts
@@ -1,0 +1,3 @@
+export { NewTable } from './NewTable';
+export { useSelectionColumn } from './hooks/useSelectionColumn';
+export { useTableVirtualizer } from './hooks/useTableVirtualizer';

--- a/apps/client/src/shared/ui/new-table/new-table.types.d.ts
+++ b/apps/client/src/shared/ui/new-table/new-table.types.d.ts
@@ -1,0 +1,7 @@
+import '@tanstack/react-table';
+
+declare module '@tanstack/react-table' {
+  interface ColumnMeta {
+    sticky?: boolean;
+  }
+}

--- a/apps/client/tsconfig.vitest.json
+++ b/apps/client/tsconfig.vitest.json
@@ -6,8 +6,7 @@
   },
   "include": [
     "vitest.setup.ts",
-    "src/vite-env.d.ts",
-    "src/react-dsfr.d.ts",
+    "src/**/*.d.ts",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/*.stories.ts",


### PR DESCRIPTION
New shared table (`src/shared/ui/new-table/`) built on TanStack Table + virtual: virtualization, sorting, row selection, sticky columns, empty state, `onEndReached` for infinite scroll. Presentational only, no API / search / filter logic inside

> [!NOTE]
> Why "NewTable" (temporary): it will replace the current `DataTable` (page-based pagination) everywhere. The name lets both coexist during migration : once all tables are migrated, `DataTable` is deleted and `NewTable` renamed to take its place