### PR TITLE
fix(FON-477): elide de before a vowel in generated documents

### DIFF
--- a/apps/api/src/modules/docs/infrastructure/services/renderers/helpers.spec.ts
+++ b/apps/api/src/modules/docs/infrastructure/services/renderers/helpers.spec.ts
@@ -1,0 +1,19 @@
+import { requiresElision } from './helpers';
+
+describe('renderer helpers', () => {
+  describe('requiresElision', () => {
+    it.each`
+      word            | expected
+      ${'Procureur'}  | ${false}
+      ${'Substitut'}  | ${false}
+      ${'Avocat'}     | ${true}
+      ${'Inspecteur'} | ${true}
+      ${'Échevin'}    | ${true}
+      ${'Huissier'}   | ${true}
+      ${'  Avocat'}   | ${true}
+      ${''}           | ${false}
+    `(`returns $expected for "$word"`, ({ word, expected }) => {
+      expect(requiresElision(word)).toBe(expected);
+    });
+  });
+});

--- a/apps/api/src/modules/docs/infrastructure/services/renderers/helpers.ts
+++ b/apps/api/src/modules/docs/infrastructure/services/renderers/helpers.ts
@@ -6,6 +6,7 @@ import { DateOnlyJson, Gender } from 'shared-models';
 import { UserTitleEnum } from 'src/modules/administration/domain/user-enum';
 import { capitalize } from 'src/utils/capitalize';
 import { DateOnly } from 'src/utils/date-only';
+import { unaccent } from 'src/utils/unaccent';
 
 export function fullname(props: { firstName: string; lastName: string }): string {
   return `${capitalize(props.firstName)}\u00A0${props.lastName.toUpperCase()}`;
@@ -53,6 +54,12 @@ export function date(date: Date | DateOnly | DateOnlyJson, format: DateFormat = 
   if (formatted.match(/1er/)) return formatted.replace(/^1er/, `1<sup>er</sup>`);
 
   return formatted;
+}
+
+const elidingInitials = new Set(['a', 'e', 'i', 'o', 'u', 'y', 'h']);
+export function requiresElision(word: string): boolean {
+  const first = unaccent(word).trim()[0]?.toLowerCase();
+  return !!first && elidingInitials.has(first);
 }
 
 const conjunctionListFormatter = new Intl.ListFormat('fr', {

--- a/apps/api/src/modules/docs/infrastructure/services/renderers/templates/agenda.html.ts
+++ b/apps/api/src/modules/docs/infrastructure/services/renderers/templates/agenda.html.ts
@@ -2,7 +2,7 @@ import { stripIndent } from 'common-tags';
 
 import { Gender, Magistrat } from 'shared-models';
 
-import { conjunctionList, date, titled } from '../helpers';
+import { conjunctionList, date, requiresElision, titled } from '../helpers';
 import { UserTitleEnum } from 'src/modules/administration/domain/user-enum';
 import type { Pretty } from 'src/utils/types';
 
@@ -41,7 +41,7 @@ function agendaNominationParagraph(
     ? `, actuellement ${ctx.currentPosition} (${ctx.currentGrade})`
     : '';
   const targetPosition = ctx.targetedPosition
-    ? `, au poste de ${ctx.targetedPosition} (${ctx.targetedGrade})`
+    ? `, au poste ${requiresElision(ctx.targetedPosition) ? `d'` : 'de '}${ctx.targetedPosition} (${ctx.targetedGrade})`
     : '';
   const reporters = ctx.reporters.length > 0 ? `, au rapport de ${conjunctionList(ctx.reporters)}` : '';
 

--- a/apps/api/src/modules/docs/infrastructure/services/renderers/templates/official-report.html.ts
+++ b/apps/api/src/modules/docs/infrastructure/services/renderers/templates/official-report.html.ts
@@ -2,7 +2,7 @@ import { stripIndent } from 'common-tags';
 
 import { Gender, Magistrat } from 'shared-models';
 
-import { conjunctionList, date, displayTitled, fullname } from '../helpers';
+import { conjunctionList, date, displayTitled, fullname, requiresElision } from '../helpers';
 import { UserTitleEnum } from 'src/modules/administration/domain/user-enum';
 import { DocNominationFileOutcomeEnum } from 'src/modules/docs/domain/doc-nomination-file-outcome';
 import { DateOnly } from 'src/utils/date-only';
@@ -45,7 +45,7 @@ function officialReportNominationParagraph(ctx: {
     : '';
 
   const targetedPosition = ctx.file.targetedPosition
-    ? `, au poste de ${ctx.file.targetedPosition} (${ctx.file.targetedGrade})`
+    ? `, au poste ${requiresElision(ctx.file.targetedPosition) ? `d'` : 'de '}${ctx.file.targetedPosition} (${ctx.file.targetedGrade})`
     : '';
 
   const reporters =

--- a/apps/api/src/modules/docs/infrastructure/services/renderers/templates/presentation-plan.html.ts
+++ b/apps/api/src/modules/docs/infrastructure/services/renderers/templates/presentation-plan.html.ts
@@ -4,7 +4,7 @@ import { format } from 'date-fns';
 
 import { Magistrat, TypeDeSaisine } from 'shared-models';
 
-import { date, fullname } from '../helpers';
+import { date, fullname, requiresElision } from '../helpers';
 import { DocNominationFileOutcomeEnum } from 'src/modules/docs/domain/doc-nomination-file-outcome';
 import { DateOnly } from 'src/utils/date-only';
 import { assertIsDefined } from 'src/utils/is-defined';
@@ -102,9 +102,10 @@ function displayOutcome(ctx: {
 }
 
 function nominationFileParagraph(file: AgendaNominationFile): string {
+  const position = `${requiresElision(file.targetedPosition) ? `d'` : 'de '}${file.targetedPosition}`;
   return html`
     <li>
-      <strong>${file.name}</strong>, pour la proposition au poste de ${file.targetedPosition}
+      <strong>${file.name}</strong>, pour la proposition au poste ${position}
       (${file.targetedGrade})${file.outcomeComment ? `, aux motifs que&nbsp;: ${file.outcomeComment}` : ''}.
     </li>
   `;


### PR DESCRIPTION
- Fix missing elision in generated documents: "au poste de Avocat" => "au poste d'Avocat"
- Add `requiresElision` helper (handles accented vowels and mute h)
- Apply it to the 3 document templates (official report, agenda, presentation plan)