### PR TITLE
fix(FON-485): use a throwaway shadow database for prisma migrate dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,81 +78,25 @@ flowchart LR
   end
 ```
 
-## Bonnes pratiques
-
-PNPM est configuré par défaut avec les options suivantes dans le fichier [pnpm-workspace.yaml](./pnpm-workspace.yaml):
-
-```yaml
-preferFrozenLockfile: true # n'installe que les dépendances du lockfile
-minimumReleaseAge: 10080 # attend au moins 7 jours avant de proposer une dépendance
-allowBuilds: # liste blanche des paquets autorisés à exécuter un script d'install
-  '@nestjs/core': true
-  bcrypt: true # compilation native nécessaire
-  prisma: false # généré manuellement (voir installation) car requiert une base lancée
-  '@prisma/client': false
-  puppeteer: false
-```
-
-Tout paquet absent de `allowBuilds` est empêché d'exécuter ses scripts d'installation
-(`postinstall`, etc.), pour se protéger des attaques par supply chain
-(cf. [SHAI-HULUD 2](https://www.cert.ssi.gouv.fr/actualite/CERTFR-2025-ACT-051/)). On n'autorise
-que le strict nécessaire : `bcrypt`, `@nestjs/core` et `@swc/core` pour leur compilation native.
-
-> [!WARNING]
-> Ces mesures n'empêchent pas la plus grande vigilance avant d'installer une dépendance.
-> Chaque installation de dépendance doit être justifiée.
-
-> [!NOTE]
-> `prisma` est volontairement à `false` : le client est généré manuellement avec
-> `prisma generate --sql`, qui doit se connecter à une base déjà lancée (voir l'étape
-> d'installation).
-
-## Contribution
-
-> [!NOTE]
-> Le fichier [CLAUDE.md](./CLAUDE.md) contient de nombreuses informations relatives au style
-> utilisé dans le projet. Il est valable pour les LLMs, mais aussi très utile pour les humains.
->
-> Autrement, ne pas hésiter à se référer à ce document:
-> [https://github.com/zakirullin/cognitive-load/blob/main/README.md](https://github.com/zakirullin/cognitive-load/blob/main/README.md)
-
-Les projets front et back utilisent des conventions légèrement différentes. Pour les expliciter
-eslint et prettier ont chacun une configuration définie dans chaque projet.
-
-Pour chaque pull request, on vérifie que le code proposé respecte ces conventions. Pour éviter des cycles de CI
-inutiles, on peut utiliser le hook [husky](https://typicode.github.io/husky) `prepush` dans l'application en
-utilisant `npx husky` pour l'installer.
-
-Autrement à la racine du projet:
-
-```ts
-$ pnpm run prepush
-$ pnpm run types:check; pnpm run lint:check; pnpm run format:check;
-```
-
-Globalement, configurer son IDE pour utiliser ces configuration est le mieux, mais le workspace PNPM
-peut provoquer des conflits parfois.
-
-## Procédure d'installation de l'application Back
+## Installation
 
 Sauf indication contraire, les commandes se lancent depuis le dossier `apps/api`.
 
-1. Installation des dépendances (depuis la racine)
+1. Installer les dépendances (depuis la racine)
 
 ```bash
 pnpm install
 ```
 
-2. Copier le fichier `.env.example` vers `.env`
+2. Copier `.env.example` vers `.env`
 
 ```bash
 cp .env.example .env
 ```
 
-Le fichier `.env` (gitignoré) contient toutes les variables nécessaires pour démarrer
-l'application localement. `DATABASE_URL` pointe vers un Postgres local lancé dans Docker
-(étape 3), sur le port non-standard `5435` pour ne pas entrer en conflit avec un Postgres
-déjà présent sur la machine.
+Le fichier `.env` (gitignoré) contient toutes les variables nécessaires pour démarrer l'application
+localement. `DATABASE_URL` pointe vers un Postgres local lancé dans Docker (étape 3), sur le port
+non-standard `5435` pour ne pas entrer en conflit avec un Postgres déjà présent sur la machine.
 
 3. Démarrer les services et la base de données
 
@@ -161,15 +105,15 @@ docker compose --file ./test/docker-compose-test.yaml up -d   # Postgres :5435 +
 pnpm run prisma migrate deploy
 ```
 
-Pour la base de test:
+Pour la base de test :
 
 ```bash
 npx dotenvx run -f .env.e2e -f .env -- pnpm run prisma migrate deploy
 ```
 
 > [!WARNING]
-> Pour le moment, il est très facile de lancer les tests sur la base locale, le mieux
-> est d'utiliser le script dans le fichier package.json.
+> Pour le moment, il est très facile de lancer les tests sur la base locale, le mieux est
+> d'utiliser le script dans le fichier package.json.
 
 4. Générer le code
 
@@ -179,9 +123,9 @@ pnpm --filter api prisma generate --sql   # client Prisma + requêtes TypedSQL
 ```
 
 > [!IMPORTANT]
-> `prisma generate --sql` se connecte à la base pour typer les requêtes de `prisma/sql/` :
-> Postgres doit donc tourner et les migrations être appliquées (étape 3). Ce code n'est pas
-> versionné, à relancer après chaque `pnpm install`.
+> `prisma generate --sql` se connecte à la base pour typer les requêtes de `prisma/sql/` : Postgres
+> doit donc tourner et les migrations être appliquées (étape 3). Ce code n'est pas versionné, à
+> relancer après chaque `pnpm install`.
 
 5. Initialiser les buckets S3 (une seule fois)
 
@@ -189,7 +133,7 @@ pnpm --filter api prisma generate --sql   # client Prisma + requêtes TypedSQL
 node scripts/init-buckets.js
 ```
 
-6. Lancement de l'application
+6. Lancer l'application
 
 ```bash
 pnpm --filter api dev       # back sur :3000, Swagger sur /openapi
@@ -210,81 +154,70 @@ password: *****
 repeat password: *****
 ```
 
-Le CLI est interactif et demandera les informations manquantes si nécessaires.
-Rôles disponibles : `MEMBRE_DU_SIEGE`, `MEMBRE_DU_PARQUET`, `MEMBRE_COMMUN`,
-`ADJOINT_SECRETAIRE_GENERAL`, `ADMIN` ([voir les rôles](./apps/api/prisma/schemas/identity.prisma#L80)).
-Il est recommandé de créer un membre commun et un agent du secrétariat général.
+Le CLI est interactif et demandera les informations manquantes si nécessaire. Rôles disponibles :
+`MEMBRE_DU_SIEGE`, `MEMBRE_DU_PARQUET`, `MEMBRE_COMMUN`, `ADJOINT_SECRETAIRE_GENERAL`, `ADMIN`
+([voir les rôles](./apps/api/prisma/schemas/identity.prisma#L80)). Il est recommandé de créer un
+membre commun et un agent du secrétariat général.
 
-8. Accès à l'application : [http://localhost:5173](http://localhost:5173)
+8. Accéder à l'application : [http://localhost:5173](http://localhost:5173)
 
-## Tests E2E playwright
+## Migrations (Prisma)
 
-Les tests playwright exécutent l'application dans un mode particulier pour faciliter les tests, sans trop s'éloigner du comportement de production.
+`prisma migrate deploy` applique les migrations existantes. C'est ce qui tourne à l'installation et
+au déploiement (prod).
 
-Il faut déjà démarrer l'application back des tests. Playwright est capable de l'exécuter, mais s'il y a un bug les logs seront plus lisibles dans un processus séparé
+Pour créer une nouvelle migration, on modifie un schéma dans `prisma/schemas/`, puis :
 
-```
-$ pnpm --filter api start:e2e
-```
-
-Démarrer l'appli front
-
-```
-$ pnpm --filter client dev
+```bash
+pnpm run prisma migrate dev --name <nom_de_la_migration>
 ```
 
-Ensuite démarrer playwright
-
-```
-$ pnpm --filter client playwright test --ui
-```
+Cette commande crée une base "shadow" temporaire à chaque exécution pour valider les migrations.
+L'utilisateur PostgreSQL doit donc pouvoir créer des bases (droit `CREATEDB`). Pas de config à faire :
+le Docker de dev l'autorise déjà.
 
 ## Génération du SDK front
 
-Pour générer le code du contrat d'interface entre le front et le back, on utilise
-[openapi](https://swagger.io/specification/) dans un mode _code-first_.
-
-La spécification est générée directement depuis nos contrôleurs nest, grâce à
+Le contrat d'interface entre le front et le back est généré en mode _code-first_ : la spécification
+[OpenAPI](https://swagger.io/specification/) est produite directement depuis les contrôleurs Nest,
+grâce à
 
 - [@nestjs/swagger](https://docs.nestjs.com/openapi/introduction)
 - [nestjs-zod](https://www.npmjs.com/package/nestjs-zod/v/5.0.1)
 
 Swagger UI est exposé par défaut sur [/openapi](http://localhost:3000/openapi).
 
-Le SDK front est généré avec [@hey-api/openapi-ts](https://heyapi.dev/openapi-ts), et ces plugins:
+Le SDK front est généré avec [@hey-api/openapi-ts](https://heyapi.dev/openapi-ts) et ses plugins
+[typescript](https://heyapi.dev/openapi-ts/plugins/typescript),
+[sdk](https://heyapi.dev/openapi-ts/plugins/sdk) et
+[client-fetch](https://heyapi.dev/openapi-ts/clients/fetch). On ne génère _volontairement pas_ le
+client @tanstack/react-query, qui n'offre pas le _namespacing_ disponible dans le sdk. La
+configuration est dans [apps/client/openapi-ts.config.ts](./apps/client/openapi-ts.config.ts).
 
-- [typescript](https://heyapi.dev/openapi-ts/plugins/typescript)
-- [sdk](https://heyapi.dev/openapi-ts/plugins/sdk)
-- [client-fetch](https://heyapi.dev/openapi-ts/clients/fetch)
+### Régénérer le client
 
-On ne génère _volontairement pas_ le client @tanstack/react-query puisque ce dernier n'offre
-pas la fonctionnalité de _namespacing_ disponible dans le sdk directement.
+Le back doit tourner (il expose la spécification) :
 
-La configuration de l'outil est disponible dans [apps/client/openapi-ts.config.ts](./apps/client/openapi-ts.config.ts).
-
-### Générer le client
-
-Pour mettre à jour le client, il faut démarrer le back
-
-```
+```bash
 cd apps/api
 pnpm run dev
 ```
 
-Une fois disponible, on peut lancer le script de génération:
+Puis :
 
-```
+```bash
 cd apps/client
 pnpm run openapi:generate
 ```
 
-openapi-ts utilise directement la spécification exposée par nest.
-
 > [!NOTE]
-> Le code généré est directement embarqué dans le dépôt de code pour faciliter les choses.
+> Le code généré est embarqué dans le dépôt pour faciliter les choses.
 
-L'api est exploité dans des hooks custom qui retournent la `Query` ou la `Mutation`
-de @tanstack/react-query dans le dossier [apps/client/src/queries](./apps/client/src/queries).
+### Consommer l'API
+
+Le sdk est utilisé dans des hooks custom qui retournent la `Query` ou la `Mutation`
+@tanstack/react-query, dans [apps/client/src/queries](./apps/client/src/queries). Les types générés
+s'importent depuis `@api/types`.
 
 ```ts
 // apps/client/src/queries/auth.queries.ts
@@ -309,10 +242,74 @@ export function useLogout() {
 }
 ```
 
-Enfin, les types générés peuvent être utilisés au niveau des composants depuis `@api/types`.
+## Tests E2E (Playwright)
 
-```tsx
-// apps/client/src/components/secretariat-general/membres/details/DetailsMember.tsx
-import type { DetailedMemberDto } from '@api/types';
-// ...
+Les tests Playwright exécutent l'application dans un mode particulier pour faciliter les tests, sans
+trop s'éloigner du comportement de production.
+
+Démarrer d'abord le back des tests. Playwright sait le lancer lui-même, mais dans un processus séparé
+les logs sont plus lisibles en cas de bug :
+
+```bash
+pnpm --filter api start:e2e
 ```
+
+Démarrer le front :
+
+```bash
+pnpm --filter client dev
+```
+
+Puis Playwright :
+
+```bash
+pnpm --filter client playwright test --ui
+```
+
+## Contribution
+
+> [!NOTE]
+> Le fichier [CLAUDE.md](./CLAUDE.md) contient de nombreuses informations relatives au style
+> utilisé dans le projet.
+>
+> Autrement, ne pas hésiter à se référer à ce document:
+> [https://github.com/zakirullin/cognitive-load/blob/main/README.md](https://github.com/zakirullin/cognitive-load/blob/main/README.md)
+
+### Conventions et CI
+
+Les projets front et back utilisent des conventions légèrement différentes : oxlint (lint) et oxfmt
+(formatage) ont chacun une configuration par projet. Configurer son IDE pour les utiliser est le
+mieux même si le workspace pnpm peut parfois créer des conflits.
+
+Chaque pull request vérifie le respect de ces conventions. Pour éviter des cycles de CI inutiles, on
+peut installer le hook [husky](https://typicode.github.io/husky) `prepush` avec `npx husky`. Sinon, à
+la racine :
+
+```bash
+pnpm run prepush
+# ou
+pnpm run types:check; pnpm run lint:check; pnpm run format:check
+```
+
+### Dépendances
+
+pnpm est configuré dans [pnpm-workspace.yaml](./pnpm-workspace.yaml) :
+
+```yaml
+preferFrozenLockfile: true # n'installe que les dépendances du lockfile
+minimumReleaseAge: 10080 # attend au moins 7 jours avant de proposer une dépendance
+allowBuilds: # liste blanche des paquets autorisés à exécuter un script d'install
+  '@nestjs/core': true
+  bcrypt: true # compilation native nécessaire
+  prisma: false # client généré manuellement (voir Installation)
+  '@prisma/client': false
+  puppeteer: false
+```
+
+Tout paquet absent de `allowBuilds` ne peut pas exécuter ses scripts d'installation (`postinstall`,
+etc.), pour se protéger des attaques par supply chain (cf.
+[SHAI-HULUD 2](https://www.cert.ssi.gouv.fr/actualite/CERTFR-2025-ACT-051/)). On n'autorise que le
+strict nécessaire (`bcrypt`, `@nestjs/core`, `@swc/core`) pour leur compilation native.
+
+> [!WARNING]
+> Ces mesures ne remplacent pas la vigilance : chaque ajout de dépendance doit être justifié.

--- a/apps/api/prisma.config.ts
+++ b/apps/api/prisma.config.ts
@@ -11,6 +11,5 @@ export default defineConfig({
   engine: 'classic',
   datasource: {
     url: env('DATABASE_URL'),
-    shadowDatabaseUrl: 'postgresql://fondation:secret@localhost:5435/fondation_shadow',
   },
 });


### PR DESCRIPTION
- Found while working on [FON-341](https://github.com/betagouv/fondation/pull/463) : `prisma migrate dev` failed locally (`P3006` on `00_squash`), the persistent shadow database keeps the `unaccent_fr` config, causing a collision on replay
- Removed `shadowDatabaseUrl` so Prisma uses a throwaway shadow each run. Needs `CREATEDB` locally (already OK with the dev Docker)
- No production impact (`migrate deploy` uses no shadow)
- README: added a Migrations (Prisma) section and reorganized the structure
- Full diagnosis (problem, discarded solutions, decision, impact) documented on [Notion](https://app.notion.com/p/08-07-2026-Prisma-migrate-dev-collision-unaccent_fr-sur-la-shadow-database-39ca2ff25f158055b7d3e211b5db0ce8?source=copy_link)