### PR TITLE
ci(FON-491): fail when generated OpenAPI clients drift from the contract

### DIFF
--- a/.github/workflows/integration-checks.yml
+++ b/.github/workflows/integration-checks.yml
@@ -96,6 +96,26 @@ jobs:
       - name: Create buckets if necessary
         run: node apps/api/scripts/init-buckets.js
 
+      - name: Check generated OpenAPI clients are up-to-date
+        shell: bash
+        run: |
+          setsid pnpm --filter api start:e2e &
+          SERVER_PID=$!
+          trap 'kill -- -$SERVER_PID 2>/dev/null || true' EXIT
+
+          timeout 90 bash -c 'until curl -sf http://localhost:3000/openapi/root.json > /dev/null; do sleep 1; done'
+
+          pnpm run openapi:generate
+
+          if [ -n "$(git status --porcelain -- apps/client/src/generated apps/api-e2e/src/generated)" ]; then
+            git status --porcelain -- apps/client/src/generated apps/api-e2e/src/generated
+            git diff -- apps/client/src/generated apps/api-e2e/src/generated
+            echo "::error::Generated OpenAPI clients are out of date. Start the API then run 'pnpm run openapi:generate' and commit the result."
+            exit 1
+          fi
+        env:
+          PORT: '3000'
+
       - name: Test Api
         run: pnpm --filter api test
 

--- a/apps/client/src/generated/api/types.ts
+++ b/apps/client/src/generated/api/types.ts
@@ -783,6 +783,10 @@ export type DetailedMemberSessionDto = {
         currentPosition: string | null;
         targettedPosition: string;
         targetedGrade: 'I' | 'II' | 'III' | 'HH' | 'G1' | 'G2' | 'G3' | 'G3sup';
+        /**
+         * LODAM observers, we need to keep them until we recover data from LODAM
+         */
+        observers: Array<string>;
         observations: Array<{
             id: string;
             hasDescription: boolean;


### PR DESCRIPTION
- Adds a CI step that starts the API, regenerates the OpenAPI clients (`client` + `api-e2e`) and fails if the committed files differ

### Why

- The generated clients are committed but never verified: a back-end DTO change without regeneration goes unnoticed and the front type-checks against a stale contract
- Proof: #463 and #464 each regenerated correctly on their own branch, yet the merge silently produced a client matching neither. This check makes that impossible
