### PR TITLE
feat(FON-493): serve nomination file outcome labels from the API

### DIFF
--- a/apps/api-e2e/src/generated/api/types.ts
+++ b/apps/api-e2e/src/generated/api/types.ts
@@ -519,6 +519,11 @@ export type DetailedNominationSessionDto = {
     id: string;
     name: string;
     formation: 'PARQUET' | 'SIEGE';
+    outcomes: Array<{
+        commentRequired: boolean;
+        label: string;
+        value: 'VALIDATED' | 'NON_VALIDATED' | 'SUSPENDED' | 'REMOVED' | 'WITHDRAWN' | 'ASSESSING' | 'WAITING_DSJ';
+    }>;
     date: {
         year: number;
         month: number;
@@ -651,6 +656,7 @@ export type DetailedSummaryDto = {
     }>;
     outcome: {
         value: 'VALIDATED' | 'NON_VALIDATED' | 'SUSPENDED' | 'REMOVED' | 'WITHDRAWN' | 'ASSESSING' | 'WAITING_DSJ';
+        label: string;
         comment: string | null;
     } | null;
     summary: {
@@ -807,6 +813,11 @@ export type DetailedMemberSessionDto = {
         id: string;
         isArchived: boolean;
         formation: string;
+        outcomes: Array<{
+            commentRequired: boolean;
+            label: string;
+            value: 'VALIDATED' | 'NON_VALIDATED' | 'SUSPENDED' | 'REMOVED' | 'WITHDRAWN' | 'ASSESSING' | 'WAITING_DSJ';
+        }>;
         transparency: string;
         dateTransparence: {
             year: number;
@@ -889,6 +900,7 @@ export type FoundDocsNominationFiles = {
         }>;
         outcome: {
             value: 'VALIDATED' | 'NON_VALIDATED' | 'SUSPENDED' | 'WITHDRAWN';
+            label: string;
             comment: string | null;
         } | null;
         magistrat: {

--- a/apps/api/src/modules/docs/domain/doc-nomination-file-outcome.spec.ts
+++ b/apps/api/src/modules/docs/domain/doc-nomination-file-outcome.spec.ts
@@ -1,0 +1,50 @@
+import { Magistrat } from 'shared-models';
+
+import { NominationFileOutcomeEnum } from 'src/modules/session/domain/nomination-file-outcome';
+
+import {
+  docNominationFileOutcomeLabel,
+  nominationFileOutcomeToDocNominationFileOutcome,
+} from './doc-nomination-file-outcome';
+
+describe('docNominationFileOutcomeLabel', () => {
+  it('labels the decision outcomes according to the formation', () => {
+    expect(
+      docNominationFileOutcomeLabel({ outcome: 'VALIDATED', formation: Magistrat.Formation.PARQUET }),
+    ).toBe('avis favorable');
+    expect(
+      docNominationFileOutcomeLabel({ outcome: 'VALIDATED', formation: Magistrat.Formation.SIEGE }),
+    ).toBe('avis conforme');
+    expect(
+      docNominationFileOutcomeLabel({ outcome: 'NON_VALIDATED', formation: Magistrat.Formation.PARQUET }),
+    ).toBe('avis défavorable');
+    expect(
+      docNominationFileOutcomeLabel({ outcome: 'NON_VALIDATED', formation: Magistrat.Formation.SIEGE }),
+    ).toBe('avis non conforme');
+  });
+
+  it('labels the grouped outcomes with the official documents vocabulary', () => {
+    expect(
+      docNominationFileOutcomeLabel({ outcome: 'SUSPENDED', formation: Magistrat.Formation.SIEGE }),
+    ).toBe('sursis à statuer');
+    expect(
+      docNominationFileOutcomeLabel({ outcome: 'WITHDRAWN', formation: Magistrat.Formation.SIEGE }),
+    ).toBe('retrait');
+  });
+
+  it.each([
+    ['ASSESSING', 'sursis à statuer'],
+    ['WAITING_DSJ', 'sursis à statuer'],
+    ['REMOVED', 'retrait'],
+    ['WITHDRAWN', 'retrait'],
+  ] satisfies [NominationFileOutcomeEnum, string][])(
+    'a nomination file outcome %s appears as "%s" in the documents',
+    (outcome, label) => {
+      const docOutcome = nominationFileOutcomeToDocNominationFileOutcome(outcome);
+
+      expect(
+        docNominationFileOutcomeLabel({ outcome: docOutcome, formation: Magistrat.Formation.SIEGE }),
+      ).toBe(label);
+    },
+  );
+});

--- a/apps/api/src/modules/docs/domain/doc-nomination-file-outcome.ts
+++ b/apps/api/src/modules/docs/domain/doc-nomination-file-outcome.ts
@@ -1,4 +1,9 @@
-import { NominationFileOutcomeEnum } from 'src/modules/session/domain/nomination-file-outcome';
+import { Magistrat } from 'shared-models';
+
+import {
+  NominationFileOutcomeEnum,
+  nominationFileOutcomeLabel,
+} from 'src/modules/session/domain/nomination-file-outcome';
 import { assertNever } from 'src/utils/assert-never';
 
 export const DOC_NOMINATION_FILE_OUTCOME_ENUM = [
@@ -30,5 +35,25 @@ export function nominationFileOutcomeToDocNominationFileOutcome(
 
     default:
       return assertNever(value);
+  }
+}
+
+export function docNominationFileOutcomeLabel(props: {
+  outcome: DocNominationFileOutcomeEnum;
+  formation: Magistrat.Formation;
+}): string {
+  switch (props.outcome) {
+    case 'VALIDATED':
+    case 'NON_VALIDATED':
+      return nominationFileOutcomeLabel(props);
+
+    case 'SUSPENDED':
+      return 'sursis à statuer';
+
+    case 'WITHDRAWN':
+      return 'retrait';
+
+    default:
+      return assertNever(props.outcome);
   }
 }

--- a/apps/api/src/modules/docs/infrastructure/finders/docs-nomination-files.finder.ts
+++ b/apps/api/src/modules/docs/infrastructure/finders/docs-nomination-files.finder.ts
@@ -6,6 +6,7 @@ import { Gender, Magistrat } from 'shared-models';
 
 import {
   DOC_NOMINATION_FILE_OUTCOME_ENUM,
+  docNominationFileOutcomeLabel,
   nominationFileOutcomeToDocNominationFileOutcome,
 } from '../../domain/doc-nomination-file-outcome';
 import { Prisma } from 'src/generated/prisma/client';
@@ -24,6 +25,7 @@ export class DocsNominationFilesFinder {
 
   async find(query: {
     sessionId: string;
+    formation?: Magistrat.Formation;
     ids?: readonly string[];
     tx?: Prisma.TransactionClient;
   }): Promise<FoundDocsNominationFiles> {
@@ -34,10 +36,15 @@ export class DocsNominationFilesFinder {
     })) as FoundDocsNominationFiles;
     if (sessionNominationFiles.length === 0) return { items: [] };
 
+    const formation =
+      query.formation ??
+      (await this.sessions.internalGetSessionFormation({ tx: query.tx, sessionId: query.sessionId }));
+
     const items = sessionNominationFiles.map((file) => {
       if (!file.outcome) return file;
 
       file.outcome.value = nominationFileOutcomeToDocNominationFileOutcome(file.outcome.value);
+      file.outcome.label = docNominationFileOutcomeLabel({ outcome: file.outcome.value, formation });
       return file;
     });
 
@@ -46,6 +53,7 @@ export class DocsNominationFilesFinder {
 
   async findNonReported(query: {
     sessionId: string;
+    formation?: Magistrat.Formation;
     ignoreOfficialReportId?: string;
     ids?: readonly string[];
     tx?: Prisma.TransactionClient;
@@ -91,6 +99,7 @@ export class FoundDocsNominationFiles extends createZodDto(
         outcome: z
           .object({
             value: z.enum(DOC_NOMINATION_FILE_OUTCOME_ENUM),
+            label: z.string(),
             comment: z.string().nullable(),
           })
           .nullable(),

--- a/apps/api/src/modules/docs/infrastructure/repositories/justice-presentation-plan.repository.ts
+++ b/apps/api/src/modules/docs/infrastructure/repositories/justice-presentation-plan.repository.ts
@@ -90,24 +90,28 @@ export class JusticePresentationPlanRepository {
         id: true,
         sessionId: true,
         sessionName: true,
+        formation: true,
         officialReportId: true,
         nominationFiles: { select: { nominationFileId: true }, where: { nominationFileId: { not: null } } },
       },
     });
 
     const nominationFiles = await Promise.all(
-      agendas.map(async ({ id: agendaId, officialReportId, sessionId, sessionName, nominationFiles }) => {
-        const { items } = await this.docsNominationFilesFinder.findNonReported({
-          tx,
-          sessionId,
-          ignoreOfficialReportId: officialReportId ?? undefined,
-          ids: nominationFiles.map(({ nominationFileId }) => nominationFileId as string),
-        });
+      agendas.map(
+        async ({ id: agendaId, officialReportId, sessionId, sessionName, formation, nominationFiles }) => {
+          const { items } = await this.docsNominationFilesFinder.findNonReported({
+            tx,
+            sessionId,
+            formation: prismaFormationEnumToFormationEnum(formation),
+            ignoreOfficialReportId: officialReportId ?? undefined,
+            ids: nominationFiles.map(({ nominationFileId }) => nominationFileId as string),
+          });
 
-        return items
-          .filter((file) => JusticePresentationPlanRepository.hasOutcome(file))
-          .map((f) => ({ ...f, agendaId, sessionId, sessionName }));
-      }),
+          return items
+            .filter((file) => JusticePresentationPlanRepository.hasOutcome(file))
+            .map((f) => ({ ...f, agendaId, sessionId, sessionName }));
+        },
+      ),
     ).then((result) => result.flat());
 
     const nominationFilesCreateMany = nominationFiles.map((f) => ({

--- a/apps/api/src/modules/docs/infrastructure/repositories/official-report.repository.ts
+++ b/apps/api/src/modules/docs/infrastructure/repositories/official-report.repository.ts
@@ -82,6 +82,7 @@ export class OfficialReportRepository {
       where: { id: { in: message.agendaIds as string[] } },
       select: {
         sessionId: true,
+        formation: true,
         nominationFiles: {
           select: { nominationFileId: true },
           where: { nominationFileId: { not: null } },
@@ -94,6 +95,7 @@ export class OfficialReportRepository {
         this.nominationFilesFinder.findNonReported({
           tx,
           sessionId: agenda.sessionId,
+          formation: prismaFormationEnumToFormationEnum(agenda.formation),
           ignoreOfficialReportId: message.id,
           ids: agenda.nominationFiles.flatMap((nf) => (nf.nominationFileId ? [nf.nominationFileId] : [])),
         }),

--- a/apps/api/src/modules/docs/infrastructure/services/renderers/templates/presentation-plan.html.ts
+++ b/apps/api/src/modules/docs/infrastructure/services/renderers/templates/presentation-plan.html.ts
@@ -5,7 +5,10 @@ import { format } from 'date-fns';
 import { Magistrat, TypeDeSaisine } from 'shared-models';
 
 import { date, fullname, requiresElision } from '../helpers';
-import { DocNominationFileOutcomeEnum } from 'src/modules/docs/domain/doc-nomination-file-outcome';
+import {
+  DocNominationFileOutcomeEnum,
+  docNominationFileOutcomeLabel,
+} from 'src/modules/docs/domain/doc-nomination-file-outcome';
 import { DateOnly } from 'src/utils/date-only';
 import { assertIsDefined } from 'src/utils/is-defined';
 import { TimeOnly, timeOnlyToDate } from 'src/utils/time-only';
@@ -82,23 +85,7 @@ function displayOutcome(ctx: {
   formation: Magistrat.Formation;
   outcome: Extract<DocNominationFileOutcomeEnum, 'VALIDATED' | 'NON_VALIDATED'>;
 }): string {
-  switch (ctx.outcome) {
-    case 'NON_VALIDATED':
-      switch (ctx.formation) {
-        case Magistrat.Formation.PARQUET:
-          return 'avis défavorable';
-        default:
-          return 'avis non conforme';
-      }
-
-    case 'VALIDATED':
-      switch (ctx.formation) {
-        case Magistrat.Formation.PARQUET:
-          return 'avis favorable';
-        default:
-          return 'avis conforme';
-      }
-  }
+  return docNominationFileOutcomeLabel(ctx);
 }
 
 function nominationFileParagraph(file: AgendaNominationFile): string {

--- a/apps/api/src/modules/session/domain/nomination-file-outcome.spec.ts
+++ b/apps/api/src/modules/session/domain/nomination-file-outcome.spec.ts
@@ -1,3 +1,5 @@
+import { Magistrat } from 'shared-models';
+
 import {
   NominationFileOutcome,
   NominationFileOutcomeRequiresComment,
@@ -47,6 +49,50 @@ describe('NominationFileOutcome', () => {
     });
 
     expect(outcome.comment).toBeNull();
+  });
+
+  describe('commentRequired', () => {
+    it('requires a comment for an unfavorable outcome', () => {
+      expect(NominationFileOutcome.commentRequired('NON_VALIDATED')).toBe(true);
+    });
+
+    it.each([
+      'VALIDATED',
+      'SUSPENDED',
+      'REMOVED',
+      'WITHDRAWN',
+      'ASSESSING',
+      'WAITING_DSJ',
+    ] satisfies NominationFileOutcomeEnum[])('leaves the comment optional for %s', (outcome) => {
+      expect(NominationFileOutcome.commentRequired(outcome)).toBe(false);
+    });
+  });
+
+  describe('selectableOutcomes', () => {
+    it('exposes every outcome in selection order with its label and comment requirement', () => {
+      const outcomes = NominationFileOutcome.selectableOutcomes(Magistrat.Formation.PARQUET);
+
+      expect(outcomes).toEqual([
+        { value: 'VALIDATED', label: 'avis favorable', commentRequired: false },
+        { value: 'NON_VALIDATED', label: 'avis défavorable', commentRequired: true },
+        { value: 'SUSPENDED', label: 'sursis à statuer', commentRequired: false },
+        { value: 'WAITING_DSJ', label: 'en attente complément DSJ', commentRequired: false },
+        { value: 'ASSESSING', label: 'en attente évaluation', commentRequired: false },
+        { value: 'WITHDRAWN', label: 'retrait (désistement)', commentRequired: false },
+        { value: 'REMOVED', label: 'retrait', commentRequired: false },
+      ]);
+    });
+
+    it('labels the decision outcomes according to the formation', () => {
+      const outcomes = NominationFileOutcome.selectableOutcomes(Magistrat.Formation.SIEGE);
+
+      expect(outcomes[0]).toEqual({ value: 'VALIDATED', label: 'avis conforme', commentRequired: false });
+      expect(outcomes[1]).toEqual({
+        value: 'NON_VALIDATED',
+        label: 'avis non conforme',
+        commentRequired: true,
+      });
+    });
   });
 
   describe('allowsAudition', () => {

--- a/apps/api/src/modules/session/domain/nomination-file-outcome.ts
+++ b/apps/api/src/modules/session/domain/nomination-file-outcome.ts
@@ -39,6 +39,24 @@ const FINAL_OUTCOMES = Object.freeze(
   ),
 );
 
+const OUTCOMES_IN_SELECTION_ORDER = Object.freeze(
+  Object.values({
+    VALIDATED: 'VALIDATED',
+    NON_VALIDATED: 'NON_VALIDATED',
+    SUSPENDED: 'SUSPENDED',
+    WAITING_DSJ: 'WAITING_DSJ',
+    ASSESSING: 'ASSESSING',
+    WITHDRAWN: 'WITHDRAWN',
+    REMOVED: 'REMOVED',
+  } satisfies { [K in NominationFileOutcomeEnum]: K }),
+);
+
+export type SelectableNominationFileOutcome = {
+  value: NominationFileOutcomeEnum;
+  label: string;
+  commentRequired: boolean;
+};
+
 export class NominationFileOutcome {
   /** @internal exposed for DTOs definitions  */
   static readonly enum = NOMINATION_FILE_OUTCOMES;
@@ -53,6 +71,18 @@ export class NominationFileOutcome {
 
   static allowsAudition(outcome: NominationFileOutcomeEnum | null): boolean {
     return outcome === null || (NON_FINAL_OUTCOMES as readonly NominationFileOutcomeEnum[]).includes(outcome);
+  }
+
+  static commentRequired(outcome: NominationFileOutcomeEnum): boolean {
+    return outcome === 'NON_VALIDATED';
+  }
+
+  static selectableOutcomes(formation: Magistrat.Formation): SelectableNominationFileOutcome[] {
+    return OUTCOMES_IN_SELECTION_ORDER.map((value) => ({
+      value,
+      label: nominationFileOutcomeLabel({ outcome: value, formation }),
+      commentRequired: NominationFileOutcome.commentRequired(value),
+    }));
   }
 
   static assertAllowsAudition(outcome: NominationFileOutcomeEnum | null): void {
@@ -87,7 +117,7 @@ export class NominationFileOutcome {
     comment: string | null;
   }): string | null {
     const comment = props.comment?.trim() || null;
-    if (props.outcome === 'NON_VALIDATED' && !isDefined(comment)) {
+    if (NominationFileOutcome.commentRequired(props.outcome) && !isDefined(comment)) {
       throw new NominationFileOutcomeRequiresComment(props.outcome);
     }
 

--- a/apps/api/src/modules/session/infrastructure/finders/nomination-session.finder.ts
+++ b/apps/api/src/modules/session/infrastructure/finders/nomination-session.finder.ts
@@ -1,11 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { Magistrat } from 'shared-models';
 
 import { Prisma } from 'src/generated/prisma/client';
 import { PrismaService } from 'src/modules/framework/database';
+import { prismaFormationEnumToFormationEnum } from 'src/modules/shared/mappers/formation.mapper';
 
 @Injectable()
 export class NominationSessionFinder {
   constructor(private readonly prisma: PrismaService) {}
+
+  async formation(query: { sessionId: string; tx?: Prisma.TransactionClient }): Promise<Magistrat.Formation> {
+    const session = await (query.tx ?? this.prisma).session.findUnique({
+      where: { id: query.sessionId },
+      select: { formation: true },
+    });
+    if (!session) throw new NotFoundException();
+
+    return prismaFormationEnumToFormationEnum(session.formation);
+  }
 
   async attachmentsCount(query: { sessionId: string; tx?: Prisma.TransactionClient }): Promise<number> {
     if (!query.tx) {

--- a/apps/api/src/modules/session/infrastructure/queries/detail-nomination-session.query.ts
+++ b/apps/api/src/modules/session/infrastructure/queries/detail-nomination-session.query.ts
@@ -4,6 +4,7 @@ import z from 'zod';
 
 import { dateOnlyJsonSchema, Magistrat, TypeDeSaisine } from 'shared-models';
 
+import { NominationFileOutcome } from '../../domain/nomination-file-outcome';
 import { AffectationVersionFinder } from '../finders/affectation-version.finder';
 import { UnreportedSessionFilesCountFinder } from '../finders/count-unreported-files.finder';
 import { Prisma } from 'src/generated/prisma/client';
@@ -72,10 +73,13 @@ export class DetailNominationSessionQuery {
     });
     const isArchivable = !!session.validatedAt && !session.archivedAt && unreportedCount === 0;
 
+    const formation = prismaFormationEnumToFormationEnum(session.formation);
+
     return {
       id: session.id,
       name: session.name,
-      formation: prismaFormationEnumToFormationEnum(session.formation),
+      formation,
+      outcomes: NominationFileOutcome.selectableOutcomes(formation),
       observationsClosingDate: DateOnly.fromDate(
         assertIsDefined(
           session.transparenceGds?.observationsClosingDate,
@@ -100,6 +104,13 @@ export class DetailedNominationSessionDto extends createZodDto(
     id: z.string(),
     name: z.string(),
     formation: z.enum(Magistrat.Formation),
+    outcomes: z.array(
+      z.object({
+        commentRequired: z.boolean(),
+        label: z.string(),
+        value: z.enum(NominationFileOutcome.enum),
+      }),
+    ),
     date: dateOnlyJsonSchema,
     observationsClosingDate: dateOnlyJsonSchema,
     dueDate: dateOnlyJsonSchema.nullable(),

--- a/apps/api/src/modules/session/infrastructure/queries/detail-summary.query.ts
+++ b/apps/api/src/modules/session/infrastructure/queries/detail-summary.query.ts
@@ -4,7 +4,7 @@ import z from 'zod';
 
 import { dateOnlyJsonSchema, Magistrat, PrioriteEnum } from 'shared-models';
 
-import { NominationFileOutcome } from '../../domain/nomination-file-outcome';
+import { NominationFileOutcome, nominationFileOutcomeLabel } from '../../domain/nomination-file-outcome';
 import { PrismaService } from 'src/modules/framework/database';
 import { Files } from 'src/modules/framework/files';
 import { FILE_MIME_TYPES, filenameToMimeType } from 'src/modules/framework/files/mime-type';
@@ -166,6 +166,10 @@ export class DetailSummaryQuery {
       outcome: nominationFile.outcome
         ? {
             value: nominationFile.outcome,
+            label: nominationFileOutcomeLabel({
+              outcome: nominationFile.outcome,
+              formation: prismaFormationEnumToFormationEnum(session.formation),
+            }),
             comment: nominationFile.outcomeComment,
           }
         : null,
@@ -253,6 +257,7 @@ export class DetailedSummaryDto extends createZodDto(
     outcome: z
       .object({
         value: z.enum(NominationFileOutcome.enum),
+        label: z.string(),
         comment: z.string().nullable(),
       })
       .nullable(),

--- a/apps/api/src/modules/session/infrastructure/queries/internal-detail-member-session.query.ts
+++ b/apps/api/src/modules/session/infrastructure/queries/internal-detail-member-session.query.ts
@@ -11,6 +11,7 @@ import {
   TypeDeSaisine,
 } from 'shared-models';
 
+import { NominationFileOutcome } from '../../domain/nomination-file-outcome';
 import { PrismaReportStateEnum } from 'src/generated/prisma/enums';
 import {
   internalCountTotalDetailsMemberSessionRawQuery,
@@ -21,6 +22,7 @@ import { createPaginatedZodDto, paginate, Pagination } from 'src/modules/framewo
 import { Sortable } from 'src/modules/framework/sorting';
 import { DetailsMemberSessionQueryDto } from 'src/modules/members/infrastructure/dtos/members.dto';
 import { roleToFormation } from 'src/modules/members/infrastructure/member.utils';
+import { prismaFormationEnumToFormationEnum } from 'src/modules/shared/mappers/formation.mapper';
 import { prismaPrioriteEnumToPrioriteEnum } from 'src/modules/shared/mappers/priorite.mapper';
 import { DateOnly } from 'src/utils/date-only';
 import { assertIsDefined, isDefined } from 'src/utils/is-defined';
@@ -179,6 +181,9 @@ export class InternalDetailMemberSessionQuery {
         id: session.id,
         isArchived: !!session.archivedAt,
         formation: session.formation,
+        outcomes: NominationFileOutcome.selectableOutcomes(
+          prismaFormationEnumToFormationEnum(session.formation),
+        ),
         transparency: session.name,
         dateTransparence: DateOnly.fromDate(session.date).toJson(),
         dateSeance: DateOnly.fromOptionalDate(session.transparenceGds?.dueDate)?.toJson() ?? null,
@@ -232,6 +237,13 @@ export class DetailedMemberSessionDto extends createPaginatedZodDto(
       id: z.string(),
       isArchived: z.boolean(),
       formation: z.string(),
+      outcomes: z.array(
+        z.object({
+          commentRequired: z.boolean(),
+          label: z.string(),
+          value: z.enum(NominationFileOutcome.enum),
+        }),
+      ),
       transparency: z.string(),
       dateTransparence: dateOnlyJsonSchema,
       dateSeance: dateOnlyJsonSchema.nullable(),

--- a/apps/api/src/modules/session/infrastructure/sessions.service.ts
+++ b/apps/api/src/modules/session/infrastructure/sessions.service.ts
@@ -543,6 +543,13 @@ export class SessionService {
     );
   }
 
+  internalGetSessionFormation(query: {
+    sessionId: string;
+    tx?: Prisma.TransactionClient;
+  }): Promise<Magistrat.Formation> {
+    return this.sessionsFinder.formation(query);
+  }
+
   async archiveSession(command: { sessionId: string; userId: string }): Promise<void> {
     await this.prisma.$transaction(async (tx) => {
       const session = await this.nominationSessionRepository.find(command.sessionId, { tx });

--- a/apps/client/docs/adr/2026-07-13-libelles-metier-servis-par-l-api.md
+++ b/apps/client/docs/adr/2026-07-13-libelles-metier-servis-par-l-api.md
@@ -1,0 +1,48 @@
+---
+title: Les libellés métier sont servis par l'API, react-intl gère les textes d'interface
+author:
+  - github.com/jessicakossibale
+  - github.com/jquagliatini
+date: 2026-07-13
+---
+
+## Contexte
+
+Les libellés des issues d'un dossier ("avis conforme", "sursis à statuer"…) étaient dupliqués
+en dur côté client, alors qu'ils relèvent d'une règle métier : le libellé varie selon la
+formation siège / parquet, et s'accompagne d'autres règles (commentaire obligatoire, ordre
+de sélection). Le serveur en a besoin pour lui-même, sans client dans la boucle (export Excel,
+documents générés) : une copie côté client peut diverger, avec un écran qui n'emploie plus
+les mêmes mots que le document officiel.
+
+En parallèle, les textes d'interface migrent vers react-intl. Deux mécanismes de texte
+français cohabitent donc dans le code, mais ce n'est pas une incohérence à corriger :
+chacun a son rôle.
+
+## Décision
+
+- **Le vocabulaire métier est une donnée servie par l'API**, définie une seule fois dans le
+  domaine back (`nomination-file-outcome.ts`) et exposée dans les contrats
+  (`session.outcomes[].label`, `outcome.label`). Personne ne le re-déclare : ni le client
+  (en dehors des factories de test), ni les consommateurs internes au serveur (export Excel,
+  templates de documents).
+- Les documents officiels ne connaissent que quatre issues (`DocNominationFileOutcomeEnum`) :
+  les issues non finales y deviennent "sursis à statuer" et les deux formes de retrait "retrait".
+  Ce vocabulaire réduit appartient au domaine docs (`docNominationFileOutcomeLabel`).
+- **react-intl ne gère que les textes d'interface** (boutons, titres, messages, pluriels).
+  Un message peut interpoler un libellé servi (`L'issue "{label}" nécessite un commentaire`),
+  jamais le re-déclarer en dur.
+- La présentation compacte des badges (acronymes, icônes, sévérités) reste côté client :
+  c'est de l'affichage, pas du vocabulaire.
+
+## Conséquences
+
+- Un composant **partagé entre plusieurs features** (`NominationFileOutcomeBadge`, rendu dans
+  la table et dans l'agenda) reçoit le libellé **en prop** : chaque appelant a sa source
+  légitime (contexte de la table, DTO de l'agenda…) et le composant n'est couplé à aucune
+  d'entre elles.
+- Un composant **interne à une feature** (`NominationFileOutcomeCommentModal`, monté sous
+  `NominationFilesTable`) lit le contexte de sa feature, qui porte déjà `outcomes` : le faire
+  descendre en prop ne serait que du props-drilling.
+- Si un autre enum acquiert une règle du même genre (libellé dépendant d'un contexte métier,
+  contrainte associée), il suit ce même chemin sinon ses libellés relèvent de react-intl.

--- a/apps/client/src/features/agenda/components/AgendaNominationFile.test.tsx
+++ b/apps/client/src/features/agenda/components/AgendaNominationFile.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FormationEnum } from '@/types/enums.types';
+import type { FoundDocsNominationFiles } from '@api/types';
+
+import { AgendaNominationFile } from './AgendaNominationFile';
+
+function makeDocsNominationFile(
+  overrides?: Partial<FoundDocsNominationFiles['items'][number]>,
+): FoundDocsNominationFiles['items'][number] {
+  return {
+    id: 'file-1',
+    number: 1,
+    reporters: [],
+    outcome: null,
+    magistrat: {
+      id: 'magistrat-1',
+      externalId: 1,
+      name: 'Jean Moulin',
+      position: { grade: 'I', label: 'Premier grade', functionId: null, jurisdictionId: null },
+    },
+    targetPosition: { grade: 'HH', label: 'Hors hiérarchie', functionId: null, jurisdictionId: null },
+    ...overrides,
+  };
+}
+
+function renderFile(file: FoundDocsNominationFiles['items'][number]) {
+  return render(
+    <IntlProvider defaultLocale="fr" locale="fr">
+      <AgendaNominationFile
+        checked={false}
+        file={file}
+        formation={FormationEnum.SIEGE}
+        onChange={vi.fn()}
+        search=""
+      />
+    </IntlProvider>,
+  );
+}
+
+describe('AgendaNominationFile', () => {
+  it('renders the outcome badge with its label as tooltip', () => {
+    renderFile(
+      makeDocsNominationFile({
+        outcome: { value: 'SUSPENDED', label: 'sursis à statuer', comment: null },
+      }),
+    );
+
+    expect(screen.getByTitle('sursis à statuer')).toHaveTextContent('SAS');
+  });
+
+  it('renders no outcome badge when the file has no outcome', () => {
+    renderFile(makeDocsNominationFile());
+
+    expect(screen.queryByTitle('sursis à statuer')).not.toBeInTheDocument();
+    expect(screen.getByText('Jean Moulin')).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/features/agenda/components/AgendaNominationFile.tsx
+++ b/apps/client/src/features/agenda/components/AgendaNominationFile.tsx
@@ -11,35 +11,29 @@ import type { FormationEnum } from '@/types/enums.types';
 import type { FoundDocsNominationFiles } from '@api/types';
 
 export function AgendaNominationFile(props: {
+  checked: boolean;
   file: FoundDocsNominationFiles['items'][number];
   formation: FormationEnum;
-  search: string;
-  checked: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  search: string;
 }) {
   return (
     <Checkbox
-      small
       className="anf fr-m-0"
       options={[
         {
-          nativeInputProps: {
-            onChange: props.onChange,
-            value: props.file.id,
-            checked: props.checked,
-          },
           label: (
             <div className="fr-py-4v flex w-full items-start gap-1">
               <div className="w-[3ch] shrink-0">{props.file.number}</div>
               <div className="hidden w-[10%] md:block">
-                <UserAvatarList users={props.file.reporters} max={2} size="sm" />
+                <UserAvatarList max={2} size="sm" users={props.file.reporters} />
               </div>
               <div
                 className="fr-pl-2v w-1/3 shrink-0 cursor-help"
                 title={[props.file.magistrat.position.grade, props.file.magistrat.position.label].join(' - ')}
               >
                 <div className="truncate">
-                  <Marked value={props.file.magistrat.name} search={props.search} />
+                  <Marked search={props.search} value={props.file.magistrat.name} />
                 </div>
                 <div className="cursor-help truncate text-xs">
                   {[
@@ -73,16 +67,23 @@ export function AgendaNominationFile(props: {
               <div className="hidden md:block">
                 {props.file.outcome && (
                   <NominationFileOutcomeBadge
-                    short
+                    acronym
                     formation={props.formation}
+                    label={props.file.outcome.label}
                     outcome={props.file.outcome.value}
                   />
                 )}
               </div>
             </div>
           ),
+          nativeInputProps: {
+            checked: props.checked,
+            onChange: props.onChange,
+            value: props.file.id,
+          },
         },
       ]}
+      small
     />
   );
 }

--- a/apps/client/src/features/nomination-files-table/components/NominationFilesTable.tsx
+++ b/apps/client/src/features/nomination-files-table/components/NominationFilesTable.tsx
@@ -1,11 +1,11 @@
 import type { Row } from '@tanstack/react-table';
-import React from 'react';
+import { useCallback, useEffect, useMemo, type PropsWithChildren } from 'react';
 
 import './NominationFilesTable.css';
 
 import { defineMessage } from 'react-intl';
 
-import { useNominationFilesTable } from '../context/files-table.context';
+import { useNominationFilesTable, type SessionOutcome } from '../context/files-table.context';
 import { FilesAffectationsProvider } from '../context/FilesAffectationsProvider';
 import { FilesSelectionProvider } from '../context/FilesSelectionProvider';
 import { NominationFilesTableProvider } from '../context/NominationFilesTableProvider';
@@ -30,10 +30,10 @@ import { NominationFilesTableActionsBar } from './NominationFilesActionsBar';
 import { NominationFilesAffectationsStatus } from './NominationFilesAffectationsStatus';
 import { NominationFilesStatusBadges } from './NominationFilesStatusBadges';
 
-function NominationFilesTableInner(props: React.PropsWithChildren) {
+function NominationFilesTableInner(props: PropsWithChildren) {
   const isSg = useIsSgNavigation();
 
-  const { sessionId, formation, edition } = useNominationFilesTable();
+  const { sessionId, edition } = useNominationFilesTable();
   const columns = useNominationFilesTableColumns();
   const [tableState, setTableState] = useQueryDataTableState({
     globalFilter: '',
@@ -43,7 +43,7 @@ function NominationFilesTableInner(props: React.PropsWithChildren) {
     rowSelection: {},
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!edition?.isEditing && Object.keys(tableState.rowSelection).length > 0) {
       setTableState((state) => ({ ...state, rowSelection: {} }));
     }
@@ -61,13 +61,13 @@ function NominationFilesTableInner(props: React.PropsWithChildren) {
         ?.value as (NominationFileOutcomeEnum | null)[],
     },
   });
-  const nominationFiles = React.useMemo(() => data?.items ?? [], [data]);
-  const onPageChange = React.useCallback(
+  const nominationFiles = useMemo(() => data?.items ?? [], [data]);
+  const onPageChange = useCallback(
     (pageIndex: number) =>
       setTableState((state) => ({ ...state, pagination: { ...state.pagination, pageIndex } })),
     [setTableState],
   );
-  const enableRowSelection = React.useMemo(
+  const enableRowSelection = useMemo(
     () => !!edition?.isEditing && ((row: Row<SessionNominationFile>) => row.original.content.isUpdatable),
     [edition],
   );
@@ -100,7 +100,7 @@ function NominationFilesTableInner(props: React.PropsWithChildren) {
         pagination={tableState.pagination}
         totalCount={data?.totalCount ?? 0}
       >
-        <NominationFileOutcomeCommentModalProvider formation={formation}>
+        <NominationFileOutcomeCommentModalProvider>
           <NominationFileTargetPositionProvider sessionId={sessionId}>
             <ObservationFollowUpCommentProvider>
               <ObservationFollowUpReminderProvider>
@@ -110,7 +110,7 @@ function NominationFilesTableInner(props: React.PropsWithChildren) {
                     <AlertsProvider>
                       <div className="fr-container fr-mb-4v flex flex-col gap-y-4">
                         <div className="self-center">
-                          <AlertsProvider.Alerts small className="shrink-0" />
+                          <AlertsProvider.Alerts className="shrink-0" small />
                         </div>
 
                         {isSg ? (
@@ -128,10 +128,10 @@ function NominationFilesTableInner(props: React.PropsWithChildren) {
                           content:
                             'max-w-screen-full xl:max-w-(--breakpoint-xl) 2xl:max-w-(--breakpoint-2xl) mx-auto',
                         }}
-                        table={table}
                         placeholder={
                           isLoading ? 'Chargement...' : 'Aucun résultat ne correspond aux valeurs filtrées'
                         }
+                        table={table}
                       >
                         {props.children}
 
@@ -150,10 +150,11 @@ function NominationFilesTableInner(props: React.PropsWithChildren) {
 }
 
 export function NominationFilesTable(
-  props: React.PropsWithChildren<{
-    isEditable?: boolean;
-    sessionId: string;
+  props: PropsWithChildren<{
     formation: FormationEnum;
+    isEditable?: boolean;
+    outcomes: readonly SessionOutcome[];
+    sessionId: string;
   }>,
 ) {
   return (

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-audition-date/MagistratAuditionDate.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-audition-date/MagistratAuditionDate.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { NominationFilesTableContext } from '@/features/nomination-files-table/context/files-table.context';
 import { StoryQueryClient } from '@/shared/storybook/StoryQueryClient';
 import { makeSessionNominationFile } from '@/test-utils/factories/session-nomination-file.factory';
+import { makeSessionOutcomes } from '@/test-utils/factories/session-outcomes.factory';
 
 import { MagistratAuditionDate } from './MagistratAuditionDate';
 
@@ -24,7 +25,13 @@ function MagistratAuditionDateStory(props: { editable: boolean; auditionDateTime
   return (
     <StoryQueryClient>
       <NominationFilesTableContext
-        value={{ sessionId: SESSION_ID, formation: 'SIEGE', isEditable: true, edition: undefined }}
+        value={{
+          edition: undefined,
+          formation: 'SIEGE',
+          isEditable: true,
+          outcomes: makeSessionOutcomes('SIEGE'),
+          sessionId: SESSION_ID,
+        }}
       >
         <MagistratAuditionDate
           editable={props.editable}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-header/MagistratHeader.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-header/MagistratHeader.stories.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router';
 import { NominationFilesTableProvider } from '@/features/nomination-files-table/context/NominationFilesTableProvider';
 import { StoryQueryClient } from '@/shared/storybook/StoryQueryClient';
 import { makeSessionNominationFile } from '@/test-utils/factories/session-nomination-file.factory';
+import { makeSessionOutcomes } from '@/test-utils/factories/session-outcomes.factory';
 import { FormationEnum, PrioriteEnum } from '@/types/enums.types';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import { authKeys } from '@queries/auth.queries';
@@ -87,6 +88,7 @@ function MagistratHeaderStory(props: {
       <NominationFilesTableProvider
         formation={FormationEnum.SIEGE}
         isEditable={isEditable}
+        outcomes={makeSessionOutcomes(FormationEnum.SIEGE)}
         sessionId={SESSION_ID}
       >
         <MagistratHeader nominationFile={nominationFile} sessionId={SESSION_ID} />
@@ -107,8 +109,8 @@ const meta = {
     view: { control: 'inline-radio', options: VIEWS },
   },
   args: {
-    nomMagistrat: 'Camille DURAND',
     auditionScheduled: true,
+    nomMagistrat: 'Camille DURAND',
     priorities: [PrioriteEnum.ETOILE],
     reporters: 'you',
     view: 'sg',

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-header/MagistratHeader.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-header/MagistratHeader.test.tsx
@@ -9,6 +9,7 @@ import { axe } from 'vitest-axe';
 import { NominationFilesTableProvider } from '@/features/nomination-files-table/context/NominationFilesTableProvider';
 import { frFormat } from '@/i18n/formats';
 import { makeSessionNominationFile } from '@/test-utils/factories/session-nomination-file.factory';
+import { makeSessionOutcomes } from '@/test-utils/factories/session-outcomes.factory';
 import { FormationEnum, PrioriteEnum } from '@/types/enums.types';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import * as $api from '@api/sdk';
@@ -52,6 +53,7 @@ function renderHeader(options: {
           <NominationFilesTableProvider
             formation={FormationEnum.SIEGE}
             isEditable={options.isEditable ?? true}
+            outcomes={makeSessionOutcomes(FormationEnum.SIEGE)}
             sessionId={SESSION_ID}
           >
             <MagistratHeader nominationFile={options.nominationFile} sessionId={SESSION_ID} />

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-outcome/MagistratOutcome.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-outcome/MagistratOutcome.stories.tsx
@@ -5,6 +5,7 @@ import { ObservationFollowUpReminderProvider } from '../../../observation-follow
 import { NominationFilesTableProvider } from '@/features/nomination-files-table/context/NominationFilesTableProvider';
 import { StoryQueryClient } from '@/shared/storybook/StoryQueryClient';
 import { makeSessionNominationFile } from '@/test-utils/factories/session-nomination-file.factory';
+import { makeSessionOutcomes } from '@/test-utils/factories/session-outcomes.factory';
 import { FormationEnum, NominationFileOutcomeEnum } from '@/types/enums.types';
 
 import { MagistratOutcome } from './MagistratOutcome';
@@ -14,18 +15,23 @@ const SESSION_ID = 'session-1';
 const outcomes = Object.values(NominationFileOutcomeEnum);
 
 function MagistratOutcomeStory(props: {
+  comment: string | null;
   formation: FormationEnum;
   outcome: NominationFileOutcomeEnum | null;
-  comment: string | null;
 }) {
+  const sessionOutcomes = makeSessionOutcomes(props.formation);
   const nominationFile = makeSessionNominationFile({
     content: { outcome: props.outcome ? { comment: props.comment, value: props.outcome } : null },
   });
 
   return (
     <StoryQueryClient>
-      <NominationFilesTableProvider formation={props.formation} sessionId={SESSION_ID}>
-        <NominationFileOutcomeCommentModalProvider formation={props.formation}>
+      <NominationFilesTableProvider
+        formation={props.formation}
+        outcomes={sessionOutcomes}
+        sessionId={SESSION_ID}
+      >
+        <NominationFileOutcomeCommentModalProvider>
           <ObservationFollowUpReminderProvider>
             <MagistratOutcome nominationFile={nominationFile} />
           </ObservationFollowUpReminderProvider>
@@ -38,17 +44,20 @@ function MagistratOutcomeStory(props: {
 const meta = {
   title: 'Features/Magistrat/MagistratOutcome',
   component: MagistratOutcomeStory,
-  parameters: { layout: 'padded' },
+  parameters: {
+    layout: 'padded',
+    router: { initialEntries: [`/secretariat-general/session/${SESSION_ID}`] },
+  },
   tags: ['autodocs'],
   argTypes: {
+    comment: { control: 'text' },
     formation: { control: 'inline-radio', options: Object.values(FormationEnum) },
     outcome: { control: 'select', options: [null, ...outcomes] },
-    comment: { control: 'text' },
   },
   args: {
+    comment: 'Profil conforme aux attentes de la formation.',
     formation: FormationEnum.SIEGE,
     outcome: NominationFileOutcomeEnum.VALIDATED,
-    comment: 'Profil conforme aux attentes de la formation.',
   },
 } satisfies Meta<typeof MagistratOutcomeStory>;
 
@@ -59,7 +68,7 @@ type Story = StoryObj<typeof meta>;
 export const Conforme: Story = {};
 
 export const WithoutComment: Story = {
-  args: { outcome: NominationFileOutcomeEnum.NON_VALIDATED, comment: null },
+  args: { comment: null, outcome: NominationFileOutcomeEnum.NON_VALIDATED },
 };
 
-export const NotDefined: Story = { args: { outcome: null, comment: null } };
+export const NotDefined: Story = { args: { comment: null, outcome: null } };

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-outcome/MagistratOutcomeSelect.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-outcome/MagistratOutcomeSelect.test.tsx
@@ -14,14 +14,17 @@ const mocks = vi.hoisted(() => ({
   remind: vi.fn(),
 }));
 
-vi.mock('@/features/nomination-files-table/context/files-table.context', () => ({
-  useNominationFilesTable: () => ({ formation: 'SIEGE', sessionId: 'session-1' }),
-}));
+vi.mock('@/features/nomination-files-table/context/files-table.context', async () => {
+  const { makeSessionOutcomes } = await import('@/test-utils/factories/session-outcomes.factory');
 
-vi.mock('../../../nomination-file-outcome/nomination-file-outcome-badge.utils', async (orig) => ({
-  ...(await orig<object>()),
-  useSortedNominationFileOutcomes: () => ['VALIDATED', 'NON_VALIDATED'],
-}));
+  return {
+    useNominationFilesTable: () => ({
+      formation: 'SIEGE',
+      sessionId: 'session-1',
+      outcomes: makeSessionOutcomes('SIEGE'),
+    }),
+  };
+});
 
 vi.mock('../../../nomination-file-outcome/OutcomeCommentModalContext', () => ({
   useOutcomeCommentDialog: () => ({ waitForOutcomeComment: mocks.waitForOutcomeComment }),
@@ -66,8 +69,7 @@ describe('MagistratOutcomeSelect', () => {
     expect(mocks.mutate).toHaveBeenCalledWith({ comment: null, outcome: null });
   });
 
-  it('saves the outcome and reminds about follow-up when a comment is confirmed', async () => {
-    mocks.waitForOutcomeComment.mockResolvedValue({ type: 'comment', value: 'Bien' });
+  it('saves an outcome that needs no comment without opening the comment dialog', async () => {
     const user = userEvent.setup();
     renderSelect();
 
@@ -75,7 +77,26 @@ describe('MagistratOutcomeSelect', () => {
     await user.click(await screen.findByRole('option', { name: 'CONFORME' }));
 
     await waitFor(() => expect(mocks.mutate).toHaveBeenCalledTimes(1));
-    expect(mocks.mutate).toHaveBeenCalledWith({ comment: 'Bien', outcome: 'VALIDATED' }, expect.anything());
+    expect(mocks.waitForOutcomeComment).not.toHaveBeenCalled();
+    expect(mocks.mutate).toHaveBeenCalledWith({ comment: null, outcome: 'VALIDATED' }, expect.anything());
+    expect(mocks.remind).toHaveBeenCalledTimes(1);
+    expect(mocks.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves the outcome and reminds about follow-up when a required comment is confirmed', async () => {
+    mocks.waitForOutcomeComment.mockResolvedValue({ type: 'comment', value: 'Bien' });
+    const user = userEvent.setup();
+    renderSelect();
+
+    await user.click(screen.getByRole('button', { name: 'Sélectionner' }));
+    await user.click(await screen.findByRole('option', { name: 'NON CONFORME' }));
+
+    await waitFor(() => expect(mocks.mutate).toHaveBeenCalledTimes(1));
+    expect(mocks.waitForOutcomeComment).toHaveBeenCalledWith('NON_VALIDATED');
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      { comment: 'Bien', outcome: 'NON_VALIDATED' },
+      expect.anything(),
+    );
     expect(mocks.remind).toHaveBeenCalledTimes(1);
     expect(mocks.reset).toHaveBeenCalledTimes(1);
   });
@@ -86,7 +107,7 @@ describe('MagistratOutcomeSelect', () => {
     renderSelect();
 
     await user.click(screen.getByRole('button', { name: 'Sélectionner' }));
-    await user.click(await screen.findByRole('option', { name: 'CONFORME' }));
+    await user.click(await screen.findByRole('option', { name: 'NON CONFORME' }));
 
     await waitFor(() => expect(mocks.reset).toHaveBeenCalledTimes(1));
     expect(mocks.mutate).not.toHaveBeenCalled();

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-outcome/MagistratOutcomeSelect.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-outcome/MagistratOutcomeSelect.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useSortedNominationFileOutcomes } from '../../../nomination-file-outcome/nomination-file-outcome-badge.utils';
+import { outcomeRequiresComment } from '../../../nomination-file-outcome/nomination-file-outcome.utils';
 import { NominationFileOutcomeBadge } from '../../../nomination-file-outcome/NominationFileOutcomeBadge';
 import { useOutcomeCommentDialog } from '../../../nomination-file-outcome/OutcomeCommentModalContext';
 import { useObservationFollowUpReminderModal } from '../../../observation-follow-up/useObservationFollowUpReminderModal.hook';
@@ -13,8 +13,7 @@ import {
 } from '@queries/nomination-sessions.queries';
 
 export function MagistratOutcomeSelect(props: { nominationFile: SessionNominationFile }) {
-  const { formation, sessionId } = useNominationFilesTable();
-  const outcomes = useSortedNominationFileOutcomes();
+  const { formation, sessionId, outcomes } = useNominationFilesTable();
   const { waitForOutcomeComment } = useOutcomeCommentDialog();
   const observationFollowUps = useObservationFollowUpReminderModal();
   const { mutate, reset } = useDefineNominationFileOutcomeMutation({
@@ -24,9 +23,24 @@ export function MagistratOutcomeSelect(props: { nominationFile: SessionNominatio
 
   const current = props.nominationFile.content.outcome?.value ?? null;
 
+  const save = (outcome: NominationFileOutcomeEnum, comment: string | null) => {
+    mutate(
+      { comment, outcome },
+      {
+        onSettled: () => reset(),
+        onSuccess: () => observationFollowUps.remindOfObservationFollowUpIfNecessary(props.nominationFile),
+      },
+    );
+  };
+
   const select = async (next: NominationFileOutcomeEnum | null) => {
     if (next === null) {
       mutate({ comment: null, outcome: null });
+      return;
+    }
+
+    if (!outcomeRequiresComment(outcomes, next)) {
+      save(next, null);
       return;
     }
 
@@ -36,16 +50,10 @@ export function MagistratOutcomeSelect(props: { nominationFile: SessionNominatio
       return;
     }
 
-    mutate(
-      { comment: event.value, outcome: next },
-      {
-        onSettled: () => reset(),
-        onSuccess: () => observationFollowUps.remindOfObservationFollowUpIfNecessary(props.nominationFile),
-      },
-    );
+    save(next, event.value);
   };
 
-  const options = outcomes.map((value) => ({
+  const options = outcomes.map(({ value }) => ({
     value,
     label: <NominationFileOutcomeBadge formation={formation} outcome={value} small={false} />,
   }));

--- a/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcome.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcome.tsx
@@ -1,28 +1,31 @@
 import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
-import React from 'react';
+import { useMemo, type CSSProperties } from 'react';
 
 import { useNominationFilesTable } from '@/features/nomination-files-table/context/files-table.context';
 import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
 
+import { sessionOutcomeLabel } from './nomination-file-outcome.utils';
 import { NominationFileOutcomeBadge } from './NominationFileOutcomeBadge';
 
 export function NominationFileOutcome(props: { nominationFile: SessionNominationFile }) {
-  const { formation } = useNominationFilesTable();
-  const outcome = React.useMemo(() => props.nominationFile.content.outcome, [props]);
+  const { formation, outcomes } = useNominationFilesTable();
+  const outcome = useMemo(() => props.nominationFile.content.outcome, [props]);
 
   if (!outcome) return '-';
 
+  const label = sessionOutcomeLabel(outcomes, outcome.value);
+
   if (!outcome.comment) {
-    return <NominationFileOutcomeBadge short formation={formation} outcome={outcome.value} />;
+    return <NominationFileOutcomeBadge acronym formation={formation} label={label} outcome={outcome.value} />;
   }
 
   return (
     <Tooltip kind="hover" title={outcome.comment}>
       <div
         className="flex cursor-pointer flex-row items-center gap-1"
-        style={{ '--icon-size': '10px' } as React.CSSProperties}
+        style={{ '--icon-size': '10px' } as CSSProperties}
       >
-        <NominationFileOutcomeBadge short formation={formation} outcome={outcome.value} />
+        <NominationFileOutcomeBadge acronym formation={formation} label={label} outcome={outcome.value} />
         <i className="ri-message-3-line text-(--text-action-high-blue-france) before:size-5! before:content-['']" />
       </div>
     </Tooltip>

--- a/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcomeBadge.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcomeBadge.tsx
@@ -6,27 +6,28 @@ import { FormationEnum, type NominationFileOutcomeEnum } from '@/types/enums.typ
 import { useNominationFileOutcome } from './nomination-file-outcome-badge.utils';
 
 function InnerNominationFileOutcomeBadge(props: {
+  acronym?: boolean;
   formation: FormationEnum;
+  label?: string;
   outcome: NominationFileOutcomeEnum | null;
-  short?: boolean;
   small?: boolean;
 }) {
-  const { badge, acronym, icon, severity, label } = useNominationFileOutcome(props);
+  const { badge, acronym, icon, severity } = useNominationFileOutcome(props);
 
-  const badgeLabel = props.short === true ? acronym : badge.toUpperCase();
+  const badgeLabel = props.acronym === true ? acronym : badge.toUpperCase();
 
   if (props.outcome === null) return '-';
 
   // ts hack to add the title
-  const badgeProps = { title: props.short ? label : undefined };
+  const badgeProps = { title: props.acronym ? props.label : undefined };
   return (
     <Badge
       {...badgeProps}
-      small={props.small ?? true}
-      severity={severity}
-      noIcon
       as="span"
       className="text-nowrap"
+      noIcon
+      severity={severity}
+      small={props.small ?? true}
     >
       {icon && (
         <i className={`fr-mr-1v leading-3 before:size-3! before:align-middle before:content-[""] ${icon}`} />
@@ -37,8 +38,8 @@ function InnerNominationFileOutcomeBadge(props: {
 }
 
 export const NominationFileOutcomeBadge = React.memo(InnerNominationFileOutcomeBadge, (prev, props) =>
-  (['formation', 'outcome', 'short', 'small'] as const).every((prop) =>
-    prop === 'short' || prop === 'small'
+  (['acronym', 'formation', 'label', 'outcome', 'small'] as const).every((prop) =>
+    prop === 'acronym' || prop === 'small'
       ? !!prev[prop] === !!props[prop]
       : Object.is(prev[prop], props[prop]),
   ),

--- a/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcomeCommentModal.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcomeCommentModal.tsx
@@ -4,8 +4,9 @@ import { useIsModalOpen } from '@codegouvfr/react-dsfr/Modal/useIsModalOpen';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import type { FormationEnum } from '@/types/enums.types';
+import { useNominationFilesTable } from '@/features/nomination-files-table/context/files-table.context';
 
+import { outcomeRequiresComment, sessionOutcomeLabel } from './nomination-file-outcome.utils';
 import { OutcomeCommentModalContext } from './OutcomeCommentModalContext';
 
 export const nominationFileOutcomeCommentModal = createModal({
@@ -14,25 +15,25 @@ export const nominationFileOutcomeCommentModal = createModal({
 });
 
 export function NominationFileOutcomeCommentModal(props: {
-  formation: FormationEnum;
   onChange: (comment: string | null) => unknown;
   onDrop: () => unknown;
 }) {
   const { formatMessage } = useIntl();
   const { outcome, initialComment } = useContext(OutcomeCommentModalContext);
+  const { outcomes } = useNominationFilesTable();
 
   const [hasError, setError] = useState(false);
   const [comment, setComment] = useState<string | null>(null);
   const [closedByUser, setClosedByUser] = useState(true);
 
-  const isCommentRequired = useMemo(() => outcome === 'NON_VALIDATED', [outcome]);
+  const isCommentRequired = useMemo(() => outcomeRequiresComment(outcomes, outcome), [outcomes, outcome]);
 
   const isCommentValid = (comment?.trim().length ?? 0) > 0;
   const isUnchanged = (comment?.trim() || null) === initialComment;
-  const hint =
-    props.formation === 'PARQUET'
-      ? formatMessage({ defaultMessage: 'Les avis défavorables nécessitent un commentaire' })
-      : formatMessage({ defaultMessage: 'Les avis non conformes nécessitent un commentaire' });
+  const hint = formatMessage(
+    { defaultMessage: `L'issue "{label}" nécessite un commentaire` },
+    { label: (outcome && sessionOutcomeLabel(outcomes, outcome)) ?? '' },
+  );
 
   const isOpen = useIsModalOpen(nominationFileOutcomeCommentModal, {
     onConceal() {

--- a/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcomeCommentModalProvider.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcomeCommentModalProvider.tsx
@@ -1,14 +1,11 @@
 import { useCallback, useState, type ReactNode } from 'react';
 
-import type { FormationEnum, NominationFileOutcomeEnum } from '@/types/enums.types';
+import type { NominationFileOutcomeEnum } from '@/types/enums.types';
 
 import { NominationFileOutcomeCommentModal } from './NominationFileOutcomeCommentModal';
 import { OutcomeCommentModalContext, type OutcomeCommentCallback } from './OutcomeCommentModalContext';
 
-export function NominationFileOutcomeCommentModalProvider(props: {
-  children: ReactNode;
-  formation: FormationEnum;
-}) {
+export function NominationFileOutcomeCommentModalProvider(props: { children: ReactNode }) {
   const [outcome, setOutcome] = useState<NominationFileOutcomeEnum | null>(null);
   const [initialComment, setInitialComment] = useState<string | null>(null);
   const [commentCallback, setCommentCallback] = useState<OutcomeCommentCallback | null>(null);
@@ -43,11 +40,7 @@ export function NominationFileOutcomeCommentModalProvider(props: {
         setOutcome,
       }}
     >
-      <NominationFileOutcomeCommentModal
-        formation={props.formation}
-        onChange={onCommentChange}
-        onDrop={onDrop}
-      />
+      <NominationFileOutcomeCommentModal onChange={onCommentChange} onDrop={onDrop} />
 
       {props.children}
     </OutcomeCommentModalContext>

--- a/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcomeSelector.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcomeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useObservationFollowUpReminderModal } from '../observation-follow-up/useObservationFollowUpReminderModal.hook';
 import { useNominationFilesTable } from '@/features/nomination-files-table/context/files-table.context';
@@ -9,19 +9,19 @@ import {
   type SessionNominationFile,
 } from '@queries/nomination-sessions.queries';
 
-import { useSortedNominationFileOutcomes } from './nomination-file-outcome-badge.utils';
+import { outcomeRequiresComment, sessionOutcomeLabel } from './nomination-file-outcome.utils';
 import { NominationFileOutcomeBadge } from './NominationFileOutcomeBadge';
 import { useOutcomeCommentDialog } from './OutcomeCommentModalContext';
 
 export function NominationFileOutcomeSelector(props: { nominationFile: SessionNominationFile }) {
-  const nominationFileId = React.useMemo(() => props.nominationFile.id, [props]);
-  const initialOutcome = React.useMemo(() => props.nominationFile.content.outcome?.value, [props]);
+  const nominationFileId = useMemo(() => props.nominationFile.id, [props]);
+  const initialOutcome = useMemo(() => props.nominationFile.content.outcome?.value, [props]);
 
-  const [outcome, setOutcome] = React.useState<NominationFileOutcomeEnum | '@@EMPTY'>(
+  const [outcome, setOutcome] = useState<NominationFileOutcomeEnum | '@@EMPTY'>(
     initialOutcome ?? ('@@EMPTY' as const),
   );
 
-  const { sessionId, formation } = useNominationFilesTable();
+  const { sessionId, formation, outcomes } = useNominationFilesTable();
   const outcomeCommentDialog = useOutcomeCommentDialog();
   const observationFollowUps = useObservationFollowUpReminderModal();
   const { mutate, reset, isPending } = useDefineNominationFileOutcomeMutation({
@@ -29,7 +29,7 @@ export function NominationFileOutcomeSelector(props: { nominationFile: SessionNo
     nominationFileId,
   });
 
-  const onChange = React.useCallback(
+  const onChange = useCallback(
     (changedOutcome: { value: NominationFileOutcomeEnum | null; comment: string | null }) => {
       mutate(
         changedOutcome.value
@@ -53,11 +53,17 @@ export function NominationFileOutcomeSelector(props: { nominationFile: SessionNo
     [mutate, reset, observationFollowUps, props.nominationFile],
   );
 
-  const onOutcomeChange = React.useCallback(
+  const onOutcomeChange = useCallback(
     async (outcome: NominationFileOutcomeEnum | '@@EMPTY') => {
       if (outcome === '@@EMPTY') {
         setOutcome('@@EMPTY');
         onChange({ value: null, comment: null });
+        return;
+      }
+
+      if (!outcomeRequiresComment(outcomes, outcome)) {
+        setOutcome(outcome);
+        onChange({ value: outcome, comment: null });
         return;
       }
 
@@ -70,10 +76,10 @@ export function NominationFileOutcomeSelector(props: { nominationFile: SessionNo
       setOutcome(outcome);
       onChange({ value: outcome, comment: event.value });
     },
-    [setOutcome, onChange, reset, outcomeCommentDialog],
+    [setOutcome, onChange, reset, outcomeCommentDialog, outcomes],
   );
 
-  const baseOptions = useSortedNominationFileOutcomes();
+  const baseOptions = useMemo(() => outcomes.map(({ value }) => value), [outcomes]);
   const options = useMemo(
     () =>
       (['@@EMPTY', ...baseOptions] as const).map((value) =>
@@ -84,22 +90,23 @@ export function NominationFileOutcomeSelector(props: { nominationFile: SessionNo
               label: (
                 <NominationFileOutcomeBadge
                   formation={formation}
-                  outcome={value}
                   key={`outcome_option_${value}`}
+                  outcome={value}
                 />
               ),
               selected: (
                 <NominationFileOutcomeBadge
-                  short
+                  acronym
                   formation={formation}
+                  key={`acronym_outcome_option_${value}`}
+                  label={sessionOutcomeLabel(outcomes, value)}
                   outcome={value}
-                  key={`short_outcome_option_${value}`}
                 />
               ),
             },
       ),
-    [baseOptions, formation],
+    [baseOptions, formation, outcomes],
   );
 
-  return <DropdownSelect options={options} disabled={isPending} value={outcome} onChange={onOutcomeChange} />;
+  return <DropdownSelect disabled={isPending} onChange={onOutcomeChange} options={options} value={outcome} />;
 }

--- a/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/nomination-file-outcome-badge.utils.ts
+++ b/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/nomination-file-outcome-badge.utils.ts
@@ -1,7 +1,7 @@
 import type { AlertProps } from '@codegouvfr/react-dsfr/Alert';
-import React from 'react';
+import { useMemo } from 'react';
 
-import { type FormationEnum, NominationFileOutcomeEnum, outcomeLabel } from '@/types/enums.types';
+import { type FormationEnum, NominationFileOutcomeEnum } from '@/types/enums.types';
 import type { IconClassName } from '@/types/icons.types';
 
 const NOMINATION_FILE_OUTCOME_BADGE_LABELS = {
@@ -70,13 +70,12 @@ export const useNominationFileOutcome = (outcome: {
   formation: FormationEnum;
   outcome: NominationFileOutcomeEnum | null;
 }) =>
-  React.useMemo(
+  useMemo(
     () =>
       outcome.outcome === null
         ? {
             badge: '',
             acronym: '',
-            label: '',
             icon: undefined,
             severity: undefined,
           }
@@ -85,22 +84,6 @@ export const useNominationFileOutcome = (outcome: {
             acronym: NOMINATION_FILE_OUTCOME_ACRONYM[outcome.formation][outcome.outcome],
             icon: NOMINATION_FILE_OUTCOME_ICON[outcome.outcome],
             severity: NOMINATION_FILE_OUTCOME_SEVERITY[outcome.outcome],
-            label: outcomeLabel({ value: outcome.outcome, formation: outcome.formation }),
           },
     [outcome],
-  );
-
-export const useSortedNominationFileOutcomes = (): readonly NominationFileOutcomeEnum[] =>
-  React.useMemo(
-    () =>
-      [
-        'VALIDATED',
-        'NON_VALIDATED',
-        'SUSPENDED',
-        'WAITING_DSJ',
-        'ASSESSING',
-        'WITHDRAWN',
-        'REMOVED',
-      ] as const satisfies NominationFileOutcomeEnum[],
-    [],
   );

--- a/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/nomination-file-outcome.utils.ts
+++ b/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/nomination-file-outcome.utils.ts
@@ -1,0 +1,16 @@
+import type { SessionOutcome } from '@/features/nomination-files-table/context/files-table.context';
+import type { NominationFileOutcomeEnum } from '@/types/enums.types';
+
+export function outcomeRequiresComment(
+  outcomes: readonly SessionOutcome[],
+  outcome: NominationFileOutcomeEnum | null,
+): boolean {
+  return outcomes.some(({ value, commentRequired }) => value === outcome && commentRequired);
+}
+
+export function sessionOutcomeLabel(
+  outcomes: readonly SessionOutcome[],
+  outcome: NominationFileOutcomeEnum,
+): string | undefined {
+  return outcomes.find(({ value }) => value === outcome)?.label;
+}

--- a/apps/client/src/features/nomination-files-table/context/NominationFilesTableProvider.tsx
+++ b/apps/client/src/features/nomination-files-table/context/NominationFilesTableProvider.tsx
@@ -1,36 +1,29 @@
-import React from 'react';
+import { useMemo, useState, type PropsWithChildren } from 'react';
 
 import type { FormationEnum } from '@/types/enums.types';
 
-import { NominationFilesTableContext, type NominationFilesTableContextType } from './files-table.context';
+import { NominationFilesTableContext, type SessionOutcome } from './files-table.context';
 
 export function NominationFilesTableProvider(
-  props: React.PropsWithChildren<{
-    sessionId: string;
+  props: PropsWithChildren<{
     formation: FormationEnum;
     isEditable?: boolean;
+    outcomes: readonly SessionOutcome[];
+    sessionId: string;
   }>,
 ) {
-  const [isEditing, setEditing] = React.useState<boolean>(false);
-  const [totalRowsCount, setTotalRowsCount] = React.useState<number>(0);
+  const [isEditing, setEditing] = useState<boolean>(false);
 
-  const ctx = React.useMemo(() => {
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    const ctxValue: any = {
-      sessionId: props.sessionId,
+  const ctx = useMemo(
+    () => ({
+      edition: props.isEditable !== false ? { isEditing, setEditing } : undefined,
       formation: props.formation,
       isEditable: props.isEditable !== false,
-      totalRowsCount,
-      setTotalRowsCount,
-      edition: undefined,
-    };
-
-    if (props.isEditable !== false) {
-      ctxValue.edition = { isEditing, setEditing };
-    }
-
-    return ctxValue as NominationFilesTableContextType;
-  }, [props, isEditing, setEditing, totalRowsCount, setTotalRowsCount]);
+      outcomes: props.outcomes,
+      sessionId: props.sessionId,
+    }),
+    [props.formation, props.isEditable, props.outcomes, props.sessionId, isEditing],
+  );
 
   return <NominationFilesTableContext value={ctx}>{props.children}</NominationFilesTableContext>;
 }

--- a/apps/client/src/features/nomination-files-table/context/files-table.context.ts
+++ b/apps/client/src/features/nomination-files-table/context/files-table.context.ts
@@ -1,22 +1,26 @@
-import React from 'react';
+import { createContext, useContext } from 'react';
 
 import type { FormationEnum } from '@/types/enums.types';
+import type { DetailedNominationSessionDto } from '@api/types';
+
+export type SessionOutcome = DetailedNominationSessionDto['outcomes'][number];
 
 export type NominationFilesTableContextType = {
-  sessionId: string;
-  formation: FormationEnum;
-  isEditable: boolean;
   edition:
     | { isEditing: boolean; setEditing: (value: boolean | ((v: boolean) => boolean)) => void }
     | undefined;
+  formation: FormationEnum;
+  isEditable: boolean;
+  outcomes: readonly SessionOutcome[];
+  sessionId: string;
 };
 
-export const NominationFilesTableContext = React.createContext<NominationFilesTableContextType>(
+export const NominationFilesTableContext = createContext<NominationFilesTableContextType>(
   null as unknown as NominationFilesTableContextType,
 );
 
 export function useNominationFilesTable(): NominationFilesTableContextType {
-  const ctx = React.useContext(NominationFilesTableContext);
+  const ctx = useContext(NominationFilesTableContext);
   if (!ctx) throw new Error(`Unknown NominationFilesTableContext`);
 
   return ctx;

--- a/apps/client/src/features/nomination-files-table/hooks/useNominationFilesTableColumns.hook.tsx
+++ b/apps/client/src/features/nomination-files-table/hooks/useNominationFilesTableColumns.hook.tsx
@@ -1,15 +1,14 @@
 import { createColumnHelper } from '@tanstack/react-table';
-import React from 'react';
+import { useMemo } from 'react';
 
 import { MagistratPanelTrigger } from '../components/cells/magistrat-side-panel/components/MagistratPanelTrigger';
-import { useSortedNominationFileOutcomes } from '../components/cells/nomination-file-outcome/nomination-file-outcome-badge.utils';
 import { NominationFilesOutcomeCell } from '../components/cells/nomination-file-outcome/NominationFilesOutcomeCell';
 import { NominationFilesPriorityCell } from '../components/cells/NominationFilesPriorityCell';
 import { ObservantsCell } from '../components/cells/observations/ObservantsCell';
 import { ReportersCell } from '../components/cells/reporters/ReportersCell';
 import { NominationFileTargetPositionCell } from '../components/cells/targeted-position/NominationFileTargetPositionCell';
 import { useNominationFilesTable } from '../context/files-table.context';
-import { outcomeLabel, PrioriteEnum, PrioriteEnumLabels } from '@/types/enums.types';
+import { PrioriteEnum, PrioriteEnumLabels } from '@/types/enums.types';
 import { toFullName } from '@/utils/user.utils';
 import type { ListedCurrentlyAffectedReportersDto } from '@api/types';
 import {
@@ -19,10 +18,9 @@ import {
 
 const h = createColumnHelper<SessionNominationFile>();
 export const useNominationFilesTableColumns = () => {
-  const { sessionId, formation } = useNominationFilesTable();
-  const outcomes = useSortedNominationFileOutcomes();
+  const { sessionId, outcomes } = useNominationFilesTable();
 
-  return React.useMemo(
+  return useMemo(
     () => [
       h.accessor('content.numeroDeDossier', {
         id: 'fileNumber',
@@ -112,18 +110,16 @@ export const useNominationFilesTableColumns = () => {
             label: 'Issue(s)',
             type: 'enum',
             values: [{ id: 'null', label: 'Aucune' }].concat(
-              outcomes.map((value) => {
-                let label = outcomeLabel({ formation, value });
-                label = label[0].toUpperCase() + label.slice(1);
-
-                return { id: value, label };
-              }),
+              outcomes.map(({ value, label }) => ({
+                id: value,
+                label: label[0].toUpperCase() + label.slice(1),
+              })),
             ),
           },
         },
       }),
     ],
-    [formation, outcomes, sessionId],
+    [outcomes, sessionId],
   );
 };
 

--- a/apps/client/src/features/reports/components/ReportsDnVueGenerale.tsx
+++ b/apps/client/src/features/reports/components/ReportsDnVueGenerale.tsx
@@ -1,16 +1,26 @@
-import type React from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { NominationFilesTable } from '@/features/nomination-files-table/components/NominationFilesTable';
+import type { SessionOutcome } from '@/features/nomination-files-table/context/files-table.context';
 import type { FormationEnum } from '@/types/enums.types';
 
 import { TransparencyAttachmentsSection } from './TransparencyAttachmentsSection';
 
 export const ReportsDnVueGenerale = (
-  props: React.PropsWithChildren<{ sessionId: string; formation: FormationEnum }>,
+  props: PropsWithChildren<{
+    formation: FormationEnum;
+    outcomes: readonly SessionOutcome[];
+    sessionId: string;
+  }>,
 ) => {
   return (
     <div className="fr-my-4v flex flex-col gap-4">
-      <NominationFilesTable formation={props.formation} sessionId={props.sessionId!} isEditable={false}>
+      <NominationFilesTable
+        formation={props.formation}
+        isEditable={false}
+        outcomes={props.outcomes}
+        sessionId={props.sessionId!}
+      >
         {props.children}
       </NominationFilesTable>
       <TransparencyAttachmentsSection sessionId={props.sessionId} />

--- a/apps/client/src/features/summary/components/SummaryOutcomeNotice.tsx
+++ b/apps/client/src/features/summary/components/SummaryOutcomeNotice.tsx
@@ -1,31 +1,32 @@
 import Notice from '@codegouvfr/react-dsfr/Notice';
+import { FormattedMessage } from 'react-intl';
 
 import { useIsSg } from '@/features/auth/hooks/roles.hook';
 import { useSummary } from '@/features/summary/context/SummaryContext';
-import { outcomeLabel } from '@/types/enums.types';
 
 export function SummaryOutcomeNotice() {
   const isSg = useIsSg();
   const { summary } = useSummary();
-  const outcome = summary.outcome?.value;
+  const label = summary.outcome?.label;
 
-  if (!outcome) return null;
-
-  const label = outcomeLabel({ formation: summary.formation, value: outcome });
+  if (!label) return null;
 
   return (
     <Notice
       className="fr-mb-12v rounded-lg"
+      description={
+        isSg ? (
+          <FormattedMessage defaultMessage="une synthèse n'est probablement plus nécessaire" />
+        ) : (
+          <FormattedMessage defaultMessage="cette synthèse n'est peut-être plus d'actualité" />
+        )
+      }
       severity="warning"
       title={
-        <>
-          L'issue "<span className="underline">{label}</span>" a déjà été renseignée pour ce dossier
-        </>
-      }
-      description={
-        isSg
-          ? `une synthèse n'est probablement plus nécessaire`
-          : `cette synthèse n'est peut-être plus d'actualité`
+        <FormattedMessage
+          defaultMessage={`L'issue "{label}" a déjà été renseignée pour ce dossier`}
+          values={{ label: <span className="underline">{label}</span> }}
+        />
       }
     />
   );

--- a/apps/client/src/features/transparence/components/Transparence.tsx
+++ b/apps/client/src/features/transparence/components/Transparence.tsx
@@ -69,9 +69,10 @@ export function Transparence() {
           </div>
           <div className="fr-mb-8v">
             <NominationFilesTable
-              sessionId={sessionId!}
               formation={transparence.formation}
               isEditable={!transparence.isArchived}
+              outcomes={transparence.outcomes}
+              sessionId={sessionId!}
             />
           </div>
         </div>

--- a/apps/client/src/generated/api/types.ts
+++ b/apps/client/src/generated/api/types.ts
@@ -522,6 +522,11 @@ export type DetailedNominationSessionDto = {
     id: string;
     name: string;
     formation: 'PARQUET' | 'SIEGE';
+    outcomes: Array<{
+        commentRequired: boolean;
+        label: string;
+        value: 'VALIDATED' | 'NON_VALIDATED' | 'SUSPENDED' | 'REMOVED' | 'WITHDRAWN' | 'ASSESSING' | 'WAITING_DSJ';
+    }>;
     date: {
         year: number;
         month: number;
@@ -654,6 +659,7 @@ export type DetailedSummaryDto = {
     }>;
     outcome: {
         value: 'VALIDATED' | 'NON_VALIDATED' | 'SUSPENDED' | 'REMOVED' | 'WITHDRAWN' | 'ASSESSING' | 'WAITING_DSJ';
+        label: string;
         comment: string | null;
     } | null;
     summary: {
@@ -810,6 +816,11 @@ export type DetailedMemberSessionDto = {
         id: string;
         isArchived: boolean;
         formation: string;
+        outcomes: Array<{
+            commentRequired: boolean;
+            label: string;
+            value: 'VALIDATED' | 'NON_VALIDATED' | 'SUSPENDED' | 'REMOVED' | 'WITHDRAWN' | 'ASSESSING' | 'WAITING_DSJ';
+        }>;
         transparency: string;
         dateTransparence: {
             year: number;
@@ -892,6 +903,7 @@ export type FoundDocsNominationFiles = {
         }>;
         outcome: {
             value: 'VALIDATED' | 'NON_VALIDATED' | 'SUSPENDED' | 'WITHDRAWN';
+            label: string;
             comment: string | null;
         } | null;
         magistrat: {

--- a/apps/client/src/pages/reports/ReportListPage.tsx
+++ b/apps/client/src/pages/reports/ReportListPage.tsx
@@ -1,7 +1,7 @@
 import { colors } from '@codegouvfr/react-dsfr';
 import Button from '@codegouvfr/react-dsfr/Button';
 import { createColumnHelper } from '@tanstack/react-table';
-import React, { type FC } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { defineMessage } from 'react-intl';
 import { generatePath, useParams } from 'react-router';
 
@@ -28,7 +28,7 @@ import { useUser } from '@queries/auth.queries';
 import { useDetailedMemberGdsSession } from '@queries/members.queries';
 
 function useReportListColumns(sessionId: string) {
-  return React.useMemo(() => {
+  return useMemo(() => {
     const h = createColumnHelper<DetailedMemberSessionDto['items'][number]>();
     return [
       h.accessor('folderNumber', {
@@ -184,7 +184,7 @@ export const ReportListPage: FC = () => {
     },
   });
 
-  const onChange = React.useCallback(() => {
+  const onChange = useCallback(() => {
     setTableState((state) => ({
       ...state,
       sorting: [],
@@ -207,8 +207,9 @@ export const ReportListPage: FC = () => {
 
         {focus === 'general' ? (
           <ReportsDnVueGenerale
-            sessionId={detailedGdsSession.session.id}
             formation={detailedGdsSession.session.formation as FormationEnum}
+            outcomes={detailedGdsSession.session.outcomes}
+            sessionId={detailedGdsSession.session.id}
           >
             <ReportListViewToggle />
           </ReportsDnVueGenerale>

--- a/apps/client/src/test-utils/factories/session-outcomes.factory.ts
+++ b/apps/client/src/test-utils/factories/session-outcomes.factory.ts
@@ -1,0 +1,19 @@
+import type { SessionOutcome } from '@/features/nomination-files-table/context/files-table.context';
+import type { FormationEnum } from '@/types/enums.types';
+
+export function makeSessionOutcomes(formation: FormationEnum): SessionOutcome[] {
+  const decisionLabels =
+    formation === 'PARQUET'
+      ? { VALIDATED: 'avis favorable', NON_VALIDATED: 'avis défavorable' }
+      : { VALIDATED: 'avis conforme', NON_VALIDATED: 'avis non conforme' };
+
+  return [
+    { value: 'VALIDATED', label: decisionLabels.VALIDATED, commentRequired: false },
+    { value: 'NON_VALIDATED', label: decisionLabels.NON_VALIDATED, commentRequired: true },
+    { value: 'SUSPENDED', label: 'sursis à statuer', commentRequired: false },
+    { value: 'WAITING_DSJ', label: 'en attente complément DSJ', commentRequired: false },
+    { value: 'ASSESSING', label: 'en attente évaluation', commentRequired: false },
+    { value: 'WITHDRAWN', label: 'retrait (désistement)', commentRequired: false },
+    { value: 'REMOVED', label: 'retrait', commentRequired: false },
+  ];
+}

--- a/apps/client/src/types/enums.types.ts
+++ b/apps/client/src/types/enums.types.ts
@@ -97,34 +97,6 @@ export const NominationFileOutcomeEnum = {
   WAITING_DSJ: 'WAITING_DSJ',
 } as const satisfies Record<NominationFileOutcomeEnum, NominationFileOutcomeEnum>;
 
-const NOMINATION_FILE_OUTCOME_LABELS = {
-  PARQUET: {
-    VALIDATED: 'avis favorable',
-    NON_VALIDATED: 'avis défavorable',
-    SUSPENDED: 'sursis à statuer',
-    REMOVED: 'retrait',
-    WITHDRAWN: 'retrait (désistement)',
-    ASSESSING: 'en attente évaluation',
-    WAITING_DSJ: 'en attente complément DSJ',
-  },
-  SIEGE: {
-    VALIDATED: 'avis conforme',
-    NON_VALIDATED: 'avis non conforme',
-    SUSPENDED: 'sursis à statuer',
-    REMOVED: 'retrait',
-    WITHDRAWN: 'retrait (désistement)',
-    ASSESSING: 'en attente évaluation',
-    WAITING_DSJ: 'en attente complément DSJ',
-  },
-} as const satisfies Record<FormationEnum, Record<NominationFileOutcomeEnum, string>>;
-
-export function outcomeLabel(outcome: {
-  formation: FormationEnum;
-  value: NominationFileOutcomeEnum;
-}): string {
-  return NOMINATION_FILE_OUTCOME_LABELS[outcome.formation][outcome.value];
-}
-
 export type ObservationFollowupEnum = NonNullable<FollowUpOnObservationDto['followUp']>;
 export const ObservationFollowUpEnum = {
   ALERT: 'ALERT',


### PR DESCRIPTION
Outcome labels ("avis conforme", "sursis à statuer"…) were duplicated in the client, even though they follow a business rule (the label depends on the formation and comes with a comment requirement and a selection order) that the server also needs on its own for the Excel export and the generated documents. The domain is now the single source of truth and the API serves it.

See ADR `apps/client/docs/adr/2026-07-13-libelles-metier-servis-par-l-api.md`

### Changes

- API serves `session.outcomes[]` (`value`, `label`, `commentRequired`) and `outcome.label`
- `NominationFileOutcome.commentRequired()` is the only place the "NON_VALIDATED needs a comment" rule lives, the persistence invariant uses it too
- Documents only know 4 outcomes, so they keep their own `docNominationFileOutcomeLabel`
- Client drops the hardcoded `outcomeLabel` map and `useSortedNominationFileOutcomes`

### Behaviour changes

- The comment modal no longer opens for outcomes that don't require a comment
- In the agenda, an outcome aggregated as `WITHDRAWN` now reads "retrait" instead of "retrait (désistement)"
