### PR TITLE
feat(FON-258): rework the observation modal and show observations in the side panel

### DIFF
--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/MagistratDetails.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/MagistratDetails.tsx
@@ -7,7 +7,7 @@ import { MagistratAuditionNotice } from './magistrat-audition-date/MagistratAudi
 import { MagistratBiography } from './magistrat-biography/MagistratBiography';
 import { MagistratCareerInfo } from './magistrat-career-info/MagistratCareerInfo';
 import { MagistratHeader } from './magistrat-header/MagistratHeader';
-import { MagistratObservations } from './magistrat-observations/MagistratObservations';
+import { MagistratObservationsInbox } from './magistrat-observations/MagistratObservationsInbox';
 import { MagistratOutcome } from './magistrat-outcome/MagistratOutcome';
 import { MagistratSummary } from './magistrat-summary/MagistratSummary';
 import { MemberMemo } from './member-memo/MemberMemo';
@@ -29,7 +29,7 @@ export function MagistratDetails(props: { nominationFile: SessionNominationFile;
       <MagistratOutcome key={`${nominationFile.id}-outcome`} nominationFile={nominationFile} />
       <MagistratCareerInfo content={nominationFile.content} />
       <MagistratBiography historique={historique} />
-      <MagistratObservations nominationFile={nominationFile} sessionId={sessionId} />
+      <MagistratObservationsInbox nominationFile={nominationFile} sessionId={sessionId} />
       <SgComment
         key={`${nominationFile.id}-comment`}
         initialComment={nominationFile.comment}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-attachments/MagistratAttachments.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-attachments/MagistratAttachments.tsx
@@ -62,7 +62,7 @@ export function MagistratAttachments(props: {
     <div>
       <p className="fr-mb-4v text-xl font-semibold" id={labelId}>
         <FormattedMessage
-          defaultMessage="{count, plural, one {Pièce jointe} other {Pièces jointes}}"
+          defaultMessage="{count, plural, one {Pièce jointe du dossier} other {Pièces jointes du dossier}}"
           values={{ count: attachments.length }}
         />
       </p>

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-audition-date/MagistratAuditionDateForm.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-audition-date/MagistratAuditionDateForm.tsx
@@ -196,7 +196,7 @@ export function MagistratAuditionDateForm(props: {
         />
         {!isPast && (date || time) && (
           <Button
-            className="ml-auto min-h-9! px-3.5! py-1.5! text-[0.9375rem]!"
+            className="ml-auto btn-compact"
             onClick={clear}
             priority="secondary"
             size="small"

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-audition-date/MagistratAuditionNotice.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-audition-date/MagistratAuditionNotice.tsx
@@ -29,7 +29,7 @@ export function MagistratAuditionNotice(props: {
     <AuditionBanner date={auditionDate} time={auditionTime} className="-mx-8 -mt-10 px-8 py-4">
       {editable && !isPast && (
         <Button
-          className="ml-auto whitespace-nowrap underline underline-offset-2 hover:bg-transparent! hover:decoration-2"
+          className="ml-auto whitespace-nowrap text-(--text-default-info)! underline underline-offset-4 hover:bg-transparent! hover:decoration-2"
           onClick={goToDateField}
           priority="tertiary no outline"
           size="small"

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-header/MagistratHeader.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-header/MagistratHeader.tsx
@@ -70,7 +70,7 @@ export function MagistratHeader(props: { nominationFile: SessionNominationFile; 
           (isEditing ? (
             <div className="flex items-center gap-2">
               <Button
-                className="min-h-9! px-3.5! py-1.5! text-[0.9375rem]!"
+                className="btn-compact"
                 disabled={affectation.isPending}
                 onClick={stopEditing}
                 priority="secondary"
@@ -79,7 +79,7 @@ export function MagistratHeader(props: { nominationFile: SessionNominationFile; 
                 <FormattedMessage defaultMessage="Annuler" />
               </Button>
               <Button
-                className="min-h-9! px-3.5! py-1.5! text-[0.9375rem]!"
+                className="btn-compact"
                 disabled={affectation.isPending}
                 onClick={affectation.save}
                 priority="primary"
@@ -89,12 +89,7 @@ export function MagistratHeader(props: { nominationFile: SessionNominationFile; 
               </Button>
             </div>
           ) : (
-            <Button
-              className="min-h-9! px-3.5! py-1.5! text-[0.9375rem]!"
-              onClick={startEditing}
-              priority="secondary"
-              size="small"
-            >
+            <Button className="btn-compact" onClick={startEditing} priority="secondary" size="small">
               <FormattedMessage defaultMessage="Modifier" />
             </Button>
           ))}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-observations/MagistratObservations.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-observations/MagistratObservations.tsx
@@ -1,6 +1,7 @@
 import Button from '@codegouvfr/react-dsfr/Button';
 import Tag from '@codegouvfr/react-dsfr/Tag';
 import clsx from 'clsx';
+import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
@@ -57,33 +58,33 @@ function MagistratObservationCard({ observation, file }: { observation: Observat
   });
 
   return (
-    <div className="relative row-span-3 grid grid-rows-subgrid border border-(--border-default-grey) bg-(--background-default-grey) px-6 pt-6 pb-4">
-      {observation.followUp && (
-        <Tag
-          className={`absolute top-0 right-0 rounded-none! font-medium! ${FOLLOW_UP_TAG_CLASS[observation.followUp]}`}
-          small
-        >
-          {ObservationFollowUpEnumLabels[observation.followUp]}
-        </Tag>
-      )}
-      <div className="fr-mb-4v -mx-6 -mt-6 flex flex-col gap-1.5 bg-(--background-alt-grey) px-6 py-4">
+    <div className="row-span-2 grid snap-start grid-rows-subgrid gap-y-0 border border-(--border-default-grey) bg-(--background-default-grey) px-6 pt-6 pb-4">
+      <div className="fr-mb-4v -mx-6 -mt-6 flex flex-col items-start gap-1.5 bg-(--background-alt-grey) px-6 py-4">
+        {observation.followUp && (
+          <Tag
+            className={`min-h-5! rounded-sm! px-1.5! py-0.5! text-[0.625rem]! font-semibold! uppercase ${FOLLOW_UP_TAG_CLASS[observation.followUp]}`}
+            small
+          >
+            {ObservationFollowUpEnumLabels[observation.followUp]}
+          </Tag>
+        )}
         <div className="text-lg font-bold">{magistratName}</div>
         {observation.magistrat?.currentPosition && (
           <div className="text-xs text-(--text-mention-grey)">{observation.magistrat.currentPosition}</div>
         )}
       </div>
-      <div>
-        <div className="flex flex-col gap-1 text-[0.9375rem] text-(--text-default-grey)">
+      <div className="flex flex-col">
+        <div className="flex flex-col gap-1 text-sm-plus text-(--text-default-grey)">
           <div>
             <FormattedMessage
-              defaultMessage="{date, date, dateOnlyShort} : observation reçue"
+              defaultMessage="Reçue le {date, date, dateOnlyShort}"
               values={{ date: new Date(observation.dateReception) }}
             />
           </div>
           {observation.createdBy && (
-            <div>
+            <div className="text-xs text-(--text-mention-grey)">
               <FormattedMessage
-                defaultMessage="{date, date, dateOnlyShort} : saisie par {lastName} {firstName}"
+                defaultMessage="Saisie par {lastName} {firstName} le {date, date, dateOnlyShort}"
                 values={{
                   date: new Date(observation.createdAt),
                   lastName: observation.createdBy.lastName,
@@ -95,7 +96,7 @@ function MagistratObservationCard({ observation, file }: { observation: Observat
         </div>
 
         {observation.files.length > 0 && (
-          <div className="fr-mt-4v fr-pt-4v border-t">
+          <div>
             <div className="fr-mb-2v fr-text--sm fr-text--bold">
               <FormattedMessage
                 defaultMessage="{count, plural, one {Pièce jointe :} other {Pièces jointes :}}"
@@ -119,43 +120,38 @@ function MagistratObservationCard({ observation, file }: { observation: Observat
             </ul>
           </div>
         )}
-      </div>
 
-      <div
-        className={clsx(
-          '-mr-2 flex justify-end gap-1',
-          observation.files.length > 0 ? 'fr-pt-3v' : 'fr-pt-8v',
-        )}
-      >
-        <Button
-          iconId="ri-eye-line"
-          linkProps={{ to: detailPath }}
-          priority="tertiary no outline"
-          size="small"
-          title={detailTitle}
-        />
-        {isSg && (
-          <>
-            <Button
-              iconId="ri-edit-line"
-              onClick={() => edit(observation, file)}
-              priority="tertiary no outline"
-              size="small"
-              title={intl.formatMessage({
-                defaultMessage: "Éditer l'observation",
-              })}
-            />
-            <Button
-              iconId="ri-delete-bin-line"
-              onClick={() => requestDelete(observation, file)}
-              priority="tertiary no outline"
-              size="small"
-              title={intl.formatMessage({
-                defaultMessage: "Supprimer l'observation",
-              })}
-            />
-          </>
-        )}
+        <div className="fr-pt-3v mt-auto -mr-2 flex justify-end gap-1">
+          <Button
+            iconId="ri-eye-line"
+            linkProps={{ to: detailPath }}
+            priority="tertiary no outline"
+            size="small"
+            title={detailTitle}
+          />
+          {isSg && (
+            <>
+              <Button
+                iconId="ri-edit-line"
+                onClick={() => edit(observation, file)}
+                priority="tertiary no outline"
+                size="small"
+                title={intl.formatMessage({
+                  defaultMessage: "Éditer l'observation",
+                })}
+              />
+              <Button
+                iconId="ri-delete-bin-line"
+                onClick={() => requestDelete(observation, file)}
+                priority="tertiary no outline"
+                size="small"
+                title={intl.formatMessage({
+                  defaultMessage: "Supprimer l'observation",
+                })}
+              />
+            </>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -168,6 +164,7 @@ export function MagistratObservations({
   nominationFile: SessionNominationFile;
   sessionId: string;
 }) {
+  const intl = useIntl();
   const isSg = useIsSgNavigation();
   const { open } = useObservationsModal();
   const { observants } = nominationFile.content;
@@ -177,6 +174,27 @@ export function MagistratObservations({
     nominationFileId: nominationFile.id,
   });
   const observations = data?.observations ?? [];
+  const isScrollable = observations.length > 2;
+
+  const scroller = useRef<HTMLDivElement>(null);
+  const [{ atStart, atEnd }, setEdges] = useState({ atStart: true, atEnd: true });
+
+  const refreshEdges = () => {
+    const element = scroller.current;
+    if (!element) return;
+    setEdges({
+      atStart: element.scrollLeft <= 0,
+      atEnd: Math.ceil(element.scrollLeft + element.clientWidth) >= element.scrollWidth,
+    });
+  };
+
+  useEffect(refreshEdges, [observations.length]);
+
+  const scrollByCard = (direction: 1 | -1) =>
+    scroller.current?.scrollBy({
+      left: direction * scroller.current.clientWidth * 0.5,
+      behavior: 'smooth',
+    });
 
   const file: ActiveFile = {
     sessionId,
@@ -197,16 +215,39 @@ export function MagistratObservations({
             values={{ count: observersCount }}
           />
         </h3>
-        {isSg && (
-          <Button
-            className="min-h-9! px-3.5! py-1.5! text-[0.9375rem]!"
-            onClick={() => open(file, 'create')}
-            priority="secondary"
-            size="small"
-          >
-            <FormattedMessage defaultMessage="Ajouter" />
-          </Button>
-        )}
+        <div className="flex items-center gap-1">
+          {isScrollable && (
+            <>
+              <Button
+                disabled={atStart}
+                iconId="fr-icon-arrow-left-s-line"
+                onClick={() => scrollByCard(-1)}
+                priority="tertiary"
+                size="small"
+                title={intl.formatMessage({ defaultMessage: 'Observations précédentes' })}
+              />
+              <Button
+                className="fr-mr-1v"
+                disabled={atEnd}
+                iconId="fr-icon-arrow-right-s-line"
+                onClick={() => scrollByCard(1)}
+                priority="tertiary"
+                size="small"
+                title={intl.formatMessage({ defaultMessage: 'Observations suivantes' })}
+              />
+            </>
+          )}
+          {isSg && (
+            <Button
+              className="btn-compact"
+              onClick={() => open(file, 'create')}
+              priority="secondary"
+              size="small"
+            >
+              <FormattedMessage defaultMessage="Ajouter" />
+            </Button>
+          )}
+        </div>
       </div>
 
       {formattedObservers && (
@@ -220,7 +261,19 @@ export function MagistratObservations({
       )}
 
       {observations.length > 0 && (
-        <div className={clsx('grid grid-cols-1 gap-4 md:grid-cols-2', 'fr-mt-2v')}>
+        <div
+          aria-label={intl.formatMessage({ defaultMessage: 'Observations reçues' })}
+          className={clsx(
+            'fr-mt-2v grid grid-rows-[auto_1fr] gap-4',
+            isScrollable
+              ? 'snap-x scrollbar-none auto-cols-[85%] grid-flow-col overflow-x-auto md:auto-cols-[46%]'
+              : 'grid-cols-1 md:grid-cols-2',
+          )}
+          onScroll={refreshEdges}
+          ref={scroller}
+          role="group"
+          tabIndex={isScrollable ? 0 : undefined}
+        >
           {observations.map((observation) => (
             <MagistratObservationCard key={observation.id} observation={observation} file={file} />
           ))}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-observations/MagistratObservationsInbox.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-observations/MagistratObservationsInbox.stories.tsx
@@ -1,0 +1,207 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+
+import { ObservationsModalProvider } from '../../../observations/context/ObservationsModalProvider';
+import { StoryQueryClient } from '@/shared/storybook/StoryQueryClient';
+import { makeSessionNominationFile } from '@/test-utils/factories/session-nomination-file.factory';
+import { ROUTE_PATHS } from '@/utils/route-path.utils';
+import { observationKeys, type Observation } from '@queries/observations.queries';
+
+import { MagistratObservationsInbox } from './MagistratObservationsInbox';
+
+const SESSION_ID = 'session-1';
+const NOMINATION_FILE_ID = 'nomination-file';
+
+const OBSERVERS = ['Syndicat de la magistrature', 'Union syndicale des magistrats'];
+
+const LONG_DESCRIPTION = [
+  "Je souhaite appeler l'attention du Conseil sur la charge actuelle de la juridiction et sur les conséquences de cette proposition pour le service civil, dont l'effectif est contraint depuis la transparence précédente.",
+  "Deux postes de juge sont vacants depuis dix-huit mois, et le départ envisagé priverait le tribunal du seul magistrat formé au contentieux de la protection. Les délais d'audiencement, déjà supérieurs à la moyenne du ressort, s'en trouveraient mécaniquement dégradés.",
+  "Je précise enfin que la proposition ne mentionne ni les fonctions exercées par intérim depuis janvier, ni l'expérience acquise à la chambre commerciale, qui me paraissent pourtant déterminantes pour apprécier la candidature concurrente.",
+].join('\n\n');
+
+const MAGISTRAT_MARTIN = {
+  currentPosition: 'Juge au tribunal judiciaire de Nantes',
+  firstName: 'Léa',
+  id: 'magistrat-1',
+  lastName: 'Martin',
+  usedName: null,
+};
+
+const MAGISTRAT_DUPONT = {
+  currentPosition: 'Procureur de la République adjoint près le tribunal judiciaire de Rennes',
+  firstName: 'Marc',
+  id: 'magistrat-2',
+  lastName: 'Dupont',
+  usedName: null,
+};
+
+const MAGISTRAT_BERNARD = {
+  currentPosition: null,
+  firstName: 'Claire',
+  id: 'magistrat-3',
+  lastName: 'Bernard',
+  usedName: null,
+};
+
+const MAGISTRAT_LONG_NAME = {
+  currentPosition:
+    "Première vice-présidente chargée de l'instruction au tribunal judiciaire de Saint-Denis de la Réunion",
+  firstName: 'Marie-Charlotte',
+  id: 'magistrat-4',
+  lastName: 'de La Rochefoucauld-Montbrison',
+  usedName: null,
+};
+
+const ANNE_ROY = { firstName: 'Anne', id: 'user-1', lastName: 'Roy' };
+
+const LONG_TEXT_WITH_ATTACHMENTS: Observation = {
+  createdAt: '2026-07-13',
+  createdBy: ANNE_ROY,
+  dateReception: '2026-07-02',
+  description: LONG_DESCRIPTION,
+  files: [
+    { id: 'file-1', name: 'observation-martin.pdf' },
+    { id: 'file-2', name: 'note-charge-juridiction.docx' },
+  ],
+  followUp: 'REFERENCE',
+  id: 'observation-1',
+  magistrat: MAGISTRAT_MARTIN,
+};
+
+const LONG_TEXT_WITHOUT_ATTACHMENT: Observation = {
+  createdAt: '2026-07-13',
+  createdBy: ANNE_ROY,
+  dateReception: '2026-07-05',
+  description: LONG_DESCRIPTION,
+  files: [],
+  followUp: 'ALERT',
+  id: 'observation-2',
+  magistrat: MAGISTRAT_DUPONT,
+};
+
+const ATTACHMENT_WITHOUT_TEXT: Observation = {
+  createdAt: '2026-07-13',
+  createdBy: ANNE_ROY,
+  dateReception: '2026-07-09',
+  description: '',
+  files: [{ id: 'file-3', name: 'courrier-bernard.pdf' }],
+  followUp: 'INTERESTING',
+  id: 'observation-3',
+  magistrat: MAGISTRAT_BERNARD,
+};
+
+const SHORT_TEXT: Observation = {
+  createdAt: '2026-07-14',
+  createdBy: ANNE_ROY,
+  dateReception: '2026-07-12',
+  description: 'Observation transmise par un magistrat concurrent.',
+  files: [],
+  followUp: null,
+  id: 'observation-4',
+  magistrat: MAGISTRAT_MARTIN,
+};
+
+const LONG_NAME: Observation = {
+  createdAt: '2026-07-14',
+  createdBy: ANNE_ROY,
+  dateReception: '2026-07-11',
+  description: 'Observation transmise par une magistrate au nom particulièrement long.',
+  files: [],
+  followUp: 'INTERESTING',
+  id: 'observation-6',
+  magistrat: MAGISTRAT_LONG_NAME,
+};
+
+const NO_CONTENT: Observation = {
+  createdAt: '2026-07-14',
+  createdBy: null,
+  dateReception: '2026-07-14',
+  description: '',
+  files: [],
+  followUp: null,
+  id: 'observation-5',
+  magistrat: null,
+};
+
+const OBSERVATIONS = [
+  LONG_TEXT_WITH_ATTACHMENTS,
+  LONG_TEXT_WITHOUT_ATTACHMENT,
+  ATTACHMENT_WITHOUT_TEXT,
+  SHORT_TEXT,
+  LONG_NAME,
+  NO_CONTENT,
+];
+
+const VIEWS = ['sg', 'member'] as const;
+type View = (typeof VIEWS)[number];
+
+function seed(observations: Observation[]) {
+  return (client: QueryClient) =>
+    client.setQueryData(
+      observationKeys.observations({ sessionId: SESSION_ID, nominationFileId: NOMINATION_FILE_ID }),
+      { observations },
+    );
+}
+
+function MagistratObservationsInboxStory(props: {
+  observations: Observation[];
+  observers: number;
+  view: View;
+}) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate(props.view === 'sg' ? ROUTE_PATHS.SG.DASHBOARD : ROUTE_PATHS.TRANSPARENCES.DASHBOARD);
+  }, [props.view, navigate]);
+
+  const nominationFile = makeSessionNominationFile({
+    id: NOMINATION_FILE_ID,
+    content: { observants: props.observers > 0 ? OBSERVERS.slice(0, props.observers) : null },
+  });
+
+  return (
+    <StoryQueryClient key={props.observations.map(({ id }) => id).join('-')} seed={seed(props.observations)}>
+      <ObservationsModalProvider>
+        <MagistratObservationsInbox nominationFile={nominationFile} sessionId={SESSION_ID} />
+      </ObservationsModalProvider>
+    </StoryQueryClient>
+  );
+}
+
+const meta = {
+  title: 'Features/Magistrat/MagistratObservationsInbox',
+  component: MagistratObservationsInboxStory,
+  parameters: { layout: 'padded' },
+  argTypes: {
+    observations: { control: false },
+    observers: { control: { type: 'range', min: 0, max: OBSERVERS.length, step: 1 } },
+    view: { control: 'inline-radio', options: VIEWS },
+  },
+  args: { observations: OBSERVATIONS, observers: 1, view: 'sg' },
+} satisfies Meta<typeof MagistratObservationsInboxStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SgView: Story = {};
+
+export const MemberView: Story = { args: { view: 'member' } };
+
+export const LongText: Story = { args: { observations: [LONG_TEXT_WITH_ATTACHMENTS] } };
+
+export const LongTextWithoutAttachment: Story = { args: { observations: [LONG_TEXT_WITHOUT_ATTACHMENT] } };
+
+export const AttachmentWithoutText: Story = { args: { observations: [ATTACHMENT_WITHOUT_TEXT] } };
+
+export const NoContent: Story = { args: { observations: [NO_CONTENT] } };
+
+export const StableHeight: Story = {
+  args: { observations: [LONG_TEXT_WITH_ATTACHMENTS, NO_CONTENT, SHORT_TEXT] },
+};
+
+export const LongObserverName: Story = { args: { observations: [LONG_NAME, SHORT_TEXT] } };
+
+export const Empty: Story = { args: { observations: [], observers: 0 } };

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-observations/MagistratObservationsInbox.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-observations/MagistratObservationsInbox.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeSessionNominationFile } from '@/test-utils/factories/session-nomination-file.factory';
+import type { Observation } from '@queries/observations.queries';
+
+import { MagistratObservationsInbox } from './MagistratObservationsInbox';
+
+const isSg = vi.fn(() => true);
+vi.mock('@/features/auth/hooks/roles.hook', () => ({ useIsSgNavigation: () => isSg() }));
+
+const open = vi.fn();
+vi.mock('../../../observations/context/ObservationsModalContext', () => ({
+  useObservationsModal: () => ({ open, edit: vi.fn(), requestDelete: vi.fn() }),
+}));
+
+let observations: Observation[] = [];
+vi.mock('@queries/observations.queries', () => ({
+  useObservationsQuery: () => ({ data: { observations } }),
+  useGetObservationFileUrlMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+function makeObservation(overrides: Partial<Observation> & Pick<Observation, 'id'>): Observation {
+  return {
+    createdAt: '2026-07-13',
+    createdBy: { firstName: 'Anne', id: 'user-1', lastName: 'Roy' },
+    dateReception: '2026-07-02',
+    description: 'Observation',
+    files: [],
+    followUp: null,
+    magistrat: {
+      currentPosition: null,
+      firstName: 'Léa',
+      id: 'magistrat-1',
+      lastName: 'Martin',
+      usedName: null,
+    },
+    ...overrides,
+  };
+}
+
+const MARTIN = makeObservation({ id: 'observation-1' });
+const DUPONT = makeObservation({
+  description: 'Observation de Dupont',
+  id: 'observation-2',
+  magistrat: {
+    currentPosition: null,
+    firstName: 'Marc',
+    id: 'magistrat-2',
+    lastName: 'Dupont',
+    usedName: null,
+  },
+});
+
+function renderInbox(content: { observants?: string[] | null } = {}) {
+  const nominationFile = makeSessionNominationFile({ content: { observants: content.observants ?? null } });
+  return render(
+    <MemoryRouter>
+      <IntlProvider defaultLocale="fr" locale="fr">
+        <MagistratObservationsInbox nominationFile={nominationFile} sessionId="session-1" />
+      </IntlProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isSg.mockReturnValue(true);
+  observations = [];
+});
+
+describe('MagistratObservationsInbox', () => {
+  it('shows the empty state when there is neither observer nor observation', () => {
+    renderInbox();
+
+    expect(screen.getByText('Aucun observant sur cette proposition')).toBeInTheDocument();
+  });
+
+  it('uses the singular heading for a single observer', () => {
+    renderInbox({ observants: ['Tribunal de Lyon'] });
+
+    expect(screen.getByRole('heading', { name: 'Observant' })).toBeInTheDocument();
+    expect(screen.getByText('Tribunal de Lyon')).toBeInTheDocument();
+  });
+
+  it('uses the plural heading when several observers are present', () => {
+    renderInbox({ observants: ['Tribunal de Lyon', 'Cour de Paris'] });
+
+    expect(screen.getByRole('heading', { name: 'Observants' })).toBeInTheDocument();
+  });
+
+  it('lets an SG add an observation', async () => {
+    const user = userEvent.setup();
+    renderInbox();
+
+    await user.click(screen.getByRole('button', { name: 'Ajouter' }));
+
+    expect(open).toHaveBeenCalledWith(
+      { sessionId: 'session-1', id: 'nomination-file', name: 'Camille DURAND' },
+      'create',
+    );
+  });
+
+  it('hides the add button from a member', () => {
+    isSg.mockReturnValue(false);
+    renderInbox({ observants: ['Tribunal de Lyon'] });
+
+    expect(screen.queryByRole('button', { name: 'Ajouter' })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for a member when there is neither observer nor observation', () => {
+    isSg.mockReturnValue(false);
+    renderInbox();
+
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    expect(screen.queryByText('Aucun observant sur cette proposition')).not.toBeInTheDocument();
+  });
+
+  it('selects the first observation by default', () => {
+    observations = [MARTIN, DUPONT];
+    renderInbox();
+
+    const [first, second] = screen.getAllByRole('tab');
+
+    expect(first).toHaveAttribute('aria-selected', 'true');
+    expect(second).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('leaves a single tab stop in the list', () => {
+    observations = [MARTIN, DUPONT];
+    renderInbox();
+
+    const [first, second] = screen.getAllByRole('tab');
+
+    expect(first).toHaveAttribute('tabindex', '0');
+    expect(second).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('opens the panel of the clicked observation and deactivates the other one', async () => {
+    const user = userEvent.setup();
+    observations = [MARTIN, DUPONT];
+    renderInbox();
+
+    await user.click(screen.getByRole('tab', { name: /DUPONT/ }));
+
+    expect(screen.getByRole('tab', { name: /DUPONT/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tabpanel', { name: /DUPONT/ })).not.toHaveAttribute('inert');
+    expect(screen.getByRole('tabpanel', { name: /MARTIN/ })).toHaveAttribute('inert');
+  });
+
+  it('moves the selection with the arrow keys', async () => {
+    const user = userEvent.setup();
+    observations = [MARTIN, DUPONT];
+    renderInbox();
+
+    screen.getByRole('tab', { name: /MARTIN/ }).focus();
+    await user.keyboard('{ArrowDown}');
+
+    expect(screen.getByRole('tab', { name: /DUPONT/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: /DUPONT/ })).toHaveFocus();
+  });
+
+  it('wraps around at the start of the list', async () => {
+    const user = userEvent.setup();
+    observations = [MARTIN, DUPONT];
+    renderInbox();
+
+    screen.getByRole('tab', { name: /MARTIN/ }).focus();
+    await user.keyboard('{ArrowUp}');
+
+    expect(screen.getByRole('tab', { name: /DUPONT/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('announces the text and attachment hints to assistive technology', () => {
+    observations = [makeObservation({ files: [{ id: 'file-1', name: 'note.pdf' }], id: 'observation-1' })];
+    renderInbox();
+
+    const tab = screen.getByRole('tab');
+
+    expect(within(tab).getByText('Contient un texte')).toBeInTheDocument();
+    expect(within(tab).getByText('Contient une pièce jointe')).toBeInTheDocument();
+  });
+
+  it('tells the reader when an observation carries no content', () => {
+    observations = [makeObservation({ description: '', files: [], id: 'observation-1' })];
+    renderInbox();
+
+    expect(screen.getByText('Aucun contenu transmis pour cette observation')).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-observations/MagistratObservationsInbox.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-observations/MagistratObservationsInbox.tsx
@@ -1,0 +1,344 @@
+import Button from '@codegouvfr/react-dsfr/Button';
+import Tag from '@codegouvfr/react-dsfr/Tag';
+import clsx from 'clsx';
+import { useState, type KeyboardEvent } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import {
+  useObservationsModal,
+  type ActiveFile,
+} from '../../../observations/context/ObservationsModalContext';
+import { useIsSgNavigation } from '@/features/auth/hooks/roles.hook';
+import { formatObservers } from '@/features/reports/utils/formatters';
+import { ObservationFollowUpEnumLabels, type ObservationFollowupEnum } from '@/types/enums.types';
+import { getObservationDetailsPath } from '@/utils/route-path.utils';
+import { capitalize } from '@/utils/string.utils';
+import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
+import {
+  useGetObservationFileUrlMutation,
+  useObservationsQuery,
+  type Observation,
+} from '@queries/observations.queries';
+
+const FOLLOW_UP_TAG_CLASS: Record<ObservationFollowupEnum, string> = {
+  ALERT: 'bg-(--background-contrast-error)! text-(--text-default-error)!',
+  INTERESTING: 'bg-(--background-contrast-info)! text-(--text-default-info)!',
+  REFERENCE: 'bg-(--background-contrast-success)! text-(--text-default-success)!',
+};
+
+const tabId = (observationId: string) => `observation-tab-${observationId}`;
+const panelId = (observationId: string) => `observation-panel-${observationId}`;
+
+function observantName(observation: Observation, unknownLabel: string) {
+  return observation.magistrat
+    ? `${observation.magistrat.lastName.toUpperCase()} ${capitalize(observation.magistrat.firstName)}`
+    : unknownLabel;
+}
+
+function FollowUpTag({ followUp }: { followUp: ObservationFollowupEnum }) {
+  return (
+    <Tag
+      className={`min-h-5! rounded-sm! px-1.5! py-0.5! text-[0.625rem]! font-semibold! uppercase ${FOLLOW_UP_TAG_CLASS[followUp]}`}
+      small
+    >
+      {ObservationFollowUpEnumLabels[followUp]}
+    </Tag>
+  );
+}
+
+function ObservationReader({ file, observation }: { file: ActiveFile; observation: Observation }) {
+  const intl = useIntl();
+  const isSg = useIsSgNavigation();
+  const { edit, requestDelete } = useObservationsModal();
+  const { mutate: getFileUrl, isPending: isLoadingFile } = useGetObservationFileUrlMutation();
+
+  const handleFileClick = (fileId: string) =>
+    getFileUrl(
+      { sessionId: file.sessionId, nominationFileId: file.id, observationId: observation.id, fileId },
+      { onSuccess: (url) => window.open(url, '_blank') },
+    );
+
+  const detailPath = getObservationDetailsPath({
+    sessionId: file.sessionId,
+    nominationFileId: file.id,
+    observationId: observation.id,
+    context: isSg ? 'sg' : 'membre',
+  });
+
+  const isEmpty = !observation.description && observation.files.length === 0;
+
+  return (
+    <article
+      aria-label={intl.formatMessage(
+        { defaultMessage: 'Observation de {name}' },
+        {
+          name: observantName(observation, intl.formatMessage({ defaultMessage: 'Magistrat inconnu' })),
+        },
+      )}
+      className="fr-p-6v flex w-full flex-col gap-3"
+    >
+      <header className="flex items-center justify-between gap-6">
+        {observation.createdBy && !isEmpty && (
+          <div className="min-w-0 text-xs text-(--text-mention-grey)">
+            <FormattedMessage
+              defaultMessage="Fiche créée le {date, date, dateOnlyShort} par {lastName} {firstName}"
+              values={{
+                date: new Date(observation.createdAt),
+                lastName: observation.createdBy.lastName,
+                firstName: observation.createdBy.firstName,
+              }}
+            />
+          </div>
+        )}
+
+        <div className="-mr-2 ml-auto flex shrink-0 gap-0.5">
+          <Button
+            iconId="ri-eye-line"
+            linkProps={{ to: detailPath }}
+            priority="tertiary no outline"
+            size="small"
+            title={intl.formatMessage({ defaultMessage: "Voir le détail de l'observation" })}
+          />
+          {isSg && (
+            <>
+              <Button
+                iconId="ri-edit-line"
+                onClick={() => edit(observation, file)}
+                priority="tertiary no outline"
+                size="small"
+                title={intl.formatMessage({ defaultMessage: "Éditer l'observation" })}
+              />
+              <Button
+                iconId="ri-delete-bin-line"
+                onClick={() => requestDelete(observation, file)}
+                priority="tertiary no outline"
+                size="small"
+                title={intl.formatMessage({ defaultMessage: "Supprimer l'observation" })}
+              />
+            </>
+          )}
+        </div>
+      </header>
+
+      {isEmpty && (
+        <p className="fr-mb-0 flex flex-1 items-center justify-center pb-10 text-center text-sm-plus text-(--text-mention-grey) italic">
+          <FormattedMessage defaultMessage="Aucun contenu transmis pour cette observation" />
+        </p>
+      )}
+
+      {observation.description && (
+        <p className="fr-mb-0 text-sm-plus whitespace-pre-line text-(--text-default-grey)">
+          {observation.description}
+        </p>
+      )}
+
+      {observation.files.length > 0 && (
+        <div className="fr-pt-4v border-t border-(--border-default-grey)">
+          <div className="fr-mb-2v fr-text--sm fr-text--bold">
+            <FormattedMessage
+              defaultMessage="{count, plural, one {Pièce jointe :} other {Pièces jointes :}}"
+              values={{ count: observation.files.length }}
+            />
+          </div>
+          <ul className="fr-raw-list flex flex-col items-start">
+            {observation.files.map((attachment) => (
+              <li key={attachment.id}>
+                <Button
+                  className="px-0!"
+                  disabled={isLoadingFile}
+                  iconId="ri-attachment-2"
+                  onClick={() => handleFileClick(attachment.id)}
+                  priority="tertiary no outline"
+                  size="small"
+                >
+                  {attachment.name}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </article>
+  );
+}
+
+export function MagistratObservationsInbox({
+  nominationFile,
+  sessionId,
+}: {
+  nominationFile: SessionNominationFile;
+  sessionId: string;
+}) {
+  const intl = useIntl();
+  const isSg = useIsSgNavigation();
+  const { open } = useObservationsModal();
+  const { observants } = nominationFile.content;
+
+  const { data } = useObservationsQuery({ sessionId, nominationFileId: nominationFile.id });
+  const observations = data?.observations ?? [];
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = observations.find((observation) => observation.id === selectedId) ?? observations[0];
+
+  const selectWithArrows = (event: KeyboardEvent<HTMLDivElement>) => {
+    const STEPS: Record<string, number> = { ArrowDown: 1, ArrowRight: 1, ArrowUp: -1, ArrowLeft: -1 };
+    const current = observations.findIndex((observation) => observation.id === selected?.id);
+
+    const target =
+      event.key === 'Home'
+        ? observations[0]
+        : event.key === 'End'
+          ? observations.at(-1)
+          : event.key in STEPS
+            ? observations[(current + STEPS[event.key]! + observations.length) % observations.length]
+            : undefined;
+
+    if (!target) return;
+
+    event.preventDefault();
+    setSelectedId(target.id);
+    document.getElementById(tabId(target.id))?.focus();
+  };
+
+  const file: ActiveFile = {
+    sessionId,
+    id: nominationFile.id,
+    name: nominationFile.content.nomMagistrat,
+  };
+  const formattedObservers = observants ? formatObservers(observants) : null;
+  const observersCount = (observants?.length ?? 0) + observations.length;
+
+  if (!isSg && observersCount === 0) return null;
+
+  return (
+    <div>
+      <div className="fr-mb-4v flex items-center justify-between gap-2">
+        <h3 className="fr-mb-0 text-xl font-semibold">
+          <FormattedMessage
+            defaultMessage="{count, plural, one {Observant} other {Observants}}"
+            values={{ count: observersCount }}
+          />
+        </h3>
+        {isSg && (
+          <Button
+            className="btn-compact"
+            onClick={() => open(file, 'create')}
+            priority="secondary"
+            size="small"
+          >
+            <FormattedMessage defaultMessage="Ajouter" />
+          </Button>
+        )}
+      </div>
+
+      {formattedObservers && (
+        <ul className="fr-raw-list fr-mt-2v fr-mb-5v flex flex-wrap gap-2">
+          {formattedObservers.map((observer, index) => (
+            <li key={`${observer}-${index}`}>
+              <Tag small>{observer}</Tag>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {selected && (
+        <div className="fr-mt-2v grid grid-cols-1 border border-(--border-default-grey) bg-(--background-default-grey) md:grid-cols-[fit-content(22rem)_1fr]">
+          <div
+            aria-label={intl.formatMessage({ defaultMessage: 'Observations reçues' })}
+            aria-orientation="vertical"
+            className="grid auto-rows-fr border-b border-(--border-default-grey) md:min-w-64 md:border-r md:border-b-0"
+            onKeyDown={selectWithArrows}
+            role="tablist"
+          >
+            {observations.map((observation) => {
+              const isSelected = observation.id === selected.id;
+              return (
+                <button
+                  aria-controls={panelId(observation.id)}
+                  aria-selected={isSelected}
+                  className={clsx(
+                    'flex h-full min-h-24 w-full flex-col items-start justify-center gap-2 border-b border-(--border-default-grey) px-4 py-3 text-left',
+                    isSelected ? 'bg-(--background-alt-blue-france)' : 'bg-(--background-default-grey)',
+                  )}
+                  id={tabId(observation.id)}
+                  key={observation.id}
+                  onClick={() => setSelectedId(observation.id)}
+                  role="tab"
+                  tabIndex={isSelected ? 0 : -1}
+                  type="button"
+                >
+                  {observation.followUp && (
+                    <span className="fr-mb-2v">
+                      <FollowUpTag followUp={observation.followUp} />
+                    </span>
+                  )}
+                  <span className="line-clamp-2 w-full text-base font-bold wrap-break-word">
+                    {observantName(observation, intl.formatMessage({ defaultMessage: 'Magistrat inconnu' }))}
+                  </span>
+                  {observation.magistrat?.currentPosition && (
+                    <span className="line-clamp-2 text-xs leading-5 text-(--text-mention-grey)">
+                      {observation.magistrat.currentPosition}
+                    </span>
+                  )}
+                  <span className="fr-mt-2v flex items-center gap-2 text-sm text-(--text-default-grey)">
+                    <FormattedMessage
+                      defaultMessage="Reçue le {date, date, dateOnlyShort}"
+                      values={{ date: new Date(observation.dateReception) }}
+                    />
+                    {observation.description && (
+                      <>
+                        <i
+                          aria-hidden
+                          className="ri-message-3-line flex items-center text-(--text-mention-grey) before:block before:size-4! before:content-['']"
+                        />
+                        <span className="fr-sr-only">
+                          <FormattedMessage defaultMessage="Contient un texte" />
+                        </span>
+                      </>
+                    )}
+                    {observation.files.length > 0 && (
+                      <>
+                        <i
+                          aria-hidden
+                          className="ri-attachment-2 flex items-center text-(--text-mention-grey) before:block before:size-4! before:content-['']"
+                        />
+                        <span className="fr-sr-only">
+                          <FormattedMessage defaultMessage="Contient une pièce jointe" />
+                        </span>
+                      </>
+                    )}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="grid">
+            {observations.map((observation) => {
+              const isSelected = observation.id === selected.id;
+              return (
+                <div
+                  aria-labelledby={tabId(observation.id)}
+                  className={clsx('col-start-1 row-start-1 flex', !isSelected && 'invisible')}
+                  id={panelId(observation.id)}
+                  inert={!isSelected}
+                  key={observation.id}
+                  role="tabpanel"
+                  tabIndex={isSelected ? 0 : -1}
+                >
+                  <ObservationReader file={file} observation={observation} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {!formattedObservers && observations.length === 0 && (
+        <div className="fr-mt-2v w-full leading-7 whitespace-pre-line text-(--text-mention-grey)">
+          <FormattedMessage defaultMessage="Aucun observant sur cette proposition" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-outcome/MagistratOutcome.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-outcome/MagistratOutcome.tsx
@@ -67,7 +67,7 @@ function MagistratOutcomeComment(props: {
         {props.comment || <FormattedMessage defaultMessage="Aucun commentaire" />}
       </p>
       <Button
-        className="relative -top-2 min-h-9! shrink-0 px-3.5! py-1.5! text-[0.9375rem]!"
+        className="relative -top-2 btn-compact shrink-0"
         onClick={edit}
         priority="secondary"
         size="small"

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-summary/MagistratSummary.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-summary/MagistratSummary.stories.tsx
@@ -36,6 +36,12 @@ const READERS = [
   { firstName: 'Paul', id: 'reader-2', lastName: 'Durand' },
 ];
 
+const ATTACHMENTS = [
+  { id: 'attachment-1', name: 'PV - 01/06/2026 - Commission.pdf', type: 'application/pdf' },
+  { id: 'attachment-2', name: 'entretien-camille-durand.docx', type: 'application/msword' },
+  { id: 'attachment-3', name: 'organigramme-juridiction.png', type: 'image/png' },
+];
+
 const VIEWS = ['sg', 'member'] as const;
 type View = (typeof VIEWS)[number];
 
@@ -80,6 +86,7 @@ function makeSummaryDetail(props: {
 }
 
 function MagistratSummaryStory(props: {
+  attachments: boolean;
   hasSummary: boolean;
   isArchived: boolean;
   readers: boolean;
@@ -99,6 +106,7 @@ function MagistratSummaryStory(props: {
         makeSummaryDetail({
           isArchived: props.isArchived,
           summary: {
+            attachments: props.attachments ? ATTACHMENTS : [],
             author:
               props.view === 'sg'
                 ? { firstName: SG_USER.firstName, id: SG_USER.id, lastName: SG_USER.lastName }
@@ -111,7 +119,10 @@ function MagistratSummaryStory(props: {
   };
 
   return (
-    <StoryQueryClient key={`${props.view}-${props.hasSummary}-${props.readers}`} seed={seed}>
+    <StoryQueryClient
+      key={`${props.view}-${props.hasSummary}-${props.readers}-${props.attachments}`}
+      seed={seed}
+    >
       <ArchivedSessionContext value={{ isArchived: props.isArchived, setIsArchived: () => {} }}>
         <MagistratSummary nominationFile={nominationFile} sessionId={SESSION_ID} />
       </ArchivedSessionContext>
@@ -125,12 +136,13 @@ const meta = {
   parameters: { layout: 'padded' },
   tags: ['autodocs'],
   argTypes: {
+    attachments: { control: 'boolean' },
     hasSummary: { control: 'boolean' },
     isArchived: { control: 'boolean' },
     readers: { control: 'boolean' },
     view: { control: 'inline-radio', options: VIEWS },
   },
-  args: { hasSummary: true, isArchived: false, readers: false, view: 'sg' },
+  args: { attachments: false, hasSummary: true, isArchived: false, readers: false, view: 'sg' },
 } satisfies Meta<typeof MagistratSummaryStory>;
 
 export default meta;
@@ -140,6 +152,10 @@ type Story = StoryObj<typeof meta>;
 export const Readable: Story = {};
 
 export const Shared: Story = { args: { readers: true } };
+
+export const WithAttachments: Story = { args: { attachments: true } };
+
+export const SharedWithAttachments: Story = { args: { attachments: true, readers: true } };
 
 export const Member: Story = { args: { view: 'member' } };
 

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-summary/MagistratSummary.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-summary/MagistratSummary.tsx
@@ -1,19 +1,19 @@
-import Card from '@codegouvfr/react-dsfr/Card';
+import Button from '@codegouvfr/react-dsfr/Button';
 import * as Sentry from '@sentry/react';
 import { useMemo, type ReactNode } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { useIsSg } from '@/features/auth/hooks/roles.hook';
 import { SummaryReaderSelector } from '@/features/summary/components/SummaryReaderSelector';
 import { SummaryContext } from '@/features/summary/context/SummaryContext';
 import { useArchivedSession } from '@/shared/context/archived-session';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
-import { capitalize } from '@/utils/string.utils';
 import { useUser } from '@queries/auth.queries';
 import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
-import { useSummaryQuery } from '@queries/summary.queries';
+import { useGenerateSummaryAttachmentPublicUrlMutation, useSummaryQuery } from '@queries/summary.queries';
 
 import { MagistratSummaryButton } from './MagistratSummaryButton';
+import { toPlainText } from './summary-text';
 
 export function MagistratSummary(props: { nominationFile: SessionNominationFile; sessionId: string }) {
   return (
@@ -95,33 +95,46 @@ function ReadableSummary(props: { nominationFile: SessionNominationFile; session
     >
       <SummarySection
         action={
-          <SummaryReaderSelector
-            className="min-h-9! px-3.5! py-1.5! text-[0.9375rem]!"
-            priority="secondary"
-            rounded={false}
-            size="small"
-            withCount={false}
-          />
+          <div className="flex shrink-0 items-center gap-2">
+            <SummaryReaderSelector
+              className="btn-compact"
+              priority="tertiary"
+              rounded={false}
+              size="small"
+              withCount={false}
+            />
+            <Button className="btn-compact" linkProps={{ to: link }} priority="secondary" size="small">
+              {canWriteSummary ? (
+                <FormattedMessage defaultMessage="Modifier" />
+              ) : (
+                <FormattedMessage defaultMessage="Ouvrir" />
+              )}
+            </Button>
+          </div>
         }
+        mention={<SharedWithMention count={data.summary.readers.length} />}
       >
-        <SummaryPreviewCard
+        <SummaryText
+          attachments={data.summary.attachments}
           content={data.summary.content}
-          link={link}
-          name={nominationFile.content.nomMagistrat}
-          readers={data.summary.readers}
+          nominationFileId={nominationFile.id}
+          sessionId={sessionId}
         />
       </SummarySection>
     </SummaryContext>
   );
 }
 
-function SummarySection(props: { action?: ReactNode; children: ReactNode }) {
+function SummarySection(props: { action?: ReactNode; children: ReactNode; mention?: ReactNode }) {
   return (
     <div>
-      <div className="fr-mb-4v flex items-center justify-between gap-2">
-        <h3 className="fr-mb-0 text-xl font-semibold">
-          <FormattedMessage defaultMessage="Synthèse" />
-        </h3>
+      <div className="fr-mb-4v flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <h3 className="fr-mb-0 text-xl font-semibold">
+            <FormattedMessage defaultMessage="Synthèse" />
+          </h3>
+          {props.mention}
+        </div>
         {props.action}
       </div>
       {props.children}
@@ -129,43 +142,89 @@ function SummarySection(props: { action?: ReactNode; children: ReactNode }) {
   );
 }
 
-function SummaryPreviewCard(props: {
-  name: string | null;
-  content: string;
-  readers: readonly { firstName: string; lastName: string }[];
-  link: string;
-}) {
-  const intl = useIntl();
-  const excerpt = useMemo(() => {
-    const el = document.createElement('div');
-    el.innerHTML = props.content;
-    return (el.textContent ?? '').trim();
-  }, [props.content]);
-
-  const sharedWith = useMemo(() => {
-    if (props.readers.length === 0) return null;
-    const names = props.readers.map(
-      (reader) =>
-        `${capitalize(reader.firstName.toLowerCase())} ${capitalize(reader.lastName.toLowerCase())}`,
-    );
-    return new Intl.ListFormat('fr', { type: 'conjunction' }).format(names);
-  }, [props.readers]);
+function SharedWithMention(props: { count: number }) {
+  if (props.count === 0) return null;
 
   return (
-    <Card
-      desc={excerpt ? <span className="line-clamp-2 text-base">{excerpt}</span> : undefined}
-      enlargeLink
-      linkProps={{ to: props.link }}
-      size="small"
-      start={
-        sharedWith ? (
-          <p className="fr-mb-2v flex items-center gap-2 text-sm text-(--text-mention-grey)">
-            <span aria-hidden className="fr-icon-user-star-line fr-icon--sm" />
-            <FormattedMessage defaultMessage="Partagée à {sharedWith}" values={{ sharedWith }} />
-          </p>
-        ) : undefined
-      }
-      title={intl.formatMessage({ defaultMessage: 'Proposition de {name}' }, { name: props.name ?? '' })}
-    />
+    <p className="fr-mb-0 flex items-center gap-2 text-sm-plus text-(--text-mention-grey)">
+      <span aria-hidden className="fr-icon-user-star-line fr-icon--sm" />
+      <FormattedMessage
+        defaultMessage="Partagée à {count, plural, one {# membre} other {# membres}}"
+        values={{ count: props.count }}
+      />
+    </p>
+  );
+}
+
+function SummaryText(props: {
+  attachments: readonly { id: string; name: string; type: string }[];
+  content: string;
+  nominationFileId: string;
+  sessionId: string;
+}) {
+  const text = useMemo(() => toPlainText(props.content), [props.content]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {text ? (
+        <p className="fr-mb-0 line-clamp-6 leading-7 whitespace-pre-line text-(--text-default-grey)">
+          {text}
+        </p>
+      ) : (
+        <p className="fr-mb-0 text-(--text-mention-grey)">
+          <FormattedMessage defaultMessage="Aucune synthèse rédigée" />
+        </p>
+      )}
+
+      {props.attachments.length > 0 && (
+        <SummaryAttachments
+          attachments={props.attachments}
+          nominationFileId={props.nominationFileId}
+          sessionId={props.sessionId}
+        />
+      )}
+    </div>
+  );
+}
+
+function attachmentIcon(type: string) {
+  if (type === 'application/pdf') return 'ri-file-pdf-2-line' as const;
+  if (type.startsWith('image/')) return 'ri-file-image-line' as const;
+  return 'ri-file-line' as const;
+}
+
+function SummaryAttachments(props: {
+  attachments: readonly { id: string; name: string; type: string }[];
+  nominationFileId: string;
+  sessionId: string;
+}) {
+  const { mutate: openAttachment, isPending } = useGenerateSummaryAttachmentPublicUrlMutation();
+  const { nominationFileId, sessionId } = props;
+
+  return (
+    <div>
+      <div className="fr-mb-2v fr-text--sm fr-text--bold">
+        <FormattedMessage
+          defaultMessage="{count, plural, one {Pièce jointe de la synthèse :} other {Pièces jointes de la synthèse :}}"
+          values={{ count: props.attachments.length }}
+        />
+      </div>
+      <ul className="fr-raw-list flex flex-col items-start">
+        {props.attachments.map(({ id, name, type }) => (
+          <li key={id}>
+            <Button
+              className="px-0!"
+              disabled={isPending}
+              iconId={attachmentIcon(type)}
+              onClick={() => openAttachment({ sessionId, nominationFileId, fileId: id })}
+              priority="tertiary no outline"
+              size="small"
+            >
+              {name}
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-summary/summary-text.test.ts
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-summary/summary-text.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { toPlainText } from './summary-text';
+
+describe('toPlainText', () => {
+  it('keeps paragraphs on separate lines', () => {
+    expect(toPlainText('<p>Bonjour</p><p>Monde</p>')).toBe('Bonjour\nMonde');
+  });
+
+  it('bullets list items wrapped in a paragraph, as the editor produces them', () => {
+    expect(toPlainText('<ul><li><p>un</p></li><li><p>deux</p></li></ul>')).toBe('• un\n• deux');
+  });
+
+  it('bullets bare list items', () => {
+    expect(toPlainText('<ul><li>un</li></ul>')).toBe('• un');
+  });
+
+  it('keeps headings and skips empty blocks', () => {
+    expect(toPlainText('<h2>Titre</h2><p></p><p>Corps</p>')).toBe('Titre\nCorps');
+  });
+
+  it('collapses the whitespace inside a block', () => {
+    expect(toPlainText('<p>Une\n  phrase   aérée</p>')).toBe('Une phrase aérée');
+  });
+
+  it('falls back to the raw text when the content has no block markup', () => {
+    expect(toPlainText('Juste du texte')).toBe('Juste du texte');
+  });
+
+  it('is empty when the summary holds no text', () => {
+    expect(toPlainText('<p></p>')).toBe('');
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-summary/summary-text.ts
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/magistrat-summary/summary-text.ts
@@ -1,0 +1,15 @@
+const BLOCK_SELECTOR = 'p, h1, h2, h3, h4, h5, h6, li, blockquote, pre';
+
+export function toPlainText(html: string): string {
+  const { body } = new DOMParser().parseFromString(html, 'text/html');
+
+  const lines = [...body.querySelectorAll(BLOCK_SELECTOR)]
+    .filter((block) => !block.querySelector(BLOCK_SELECTOR))
+    .map((block) => {
+      const line = (block.textContent ?? '').replace(/\s+/g, ' ').trim();
+      return line && block.closest('li') ? `• ${line}` : line;
+    })
+    .filter(Boolean);
+
+  return lines.length > 0 ? lines.join('\n') : (body.textContent ?? '').trim();
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/observations/MagistratCombobox.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/observations/MagistratCombobox.tsx
@@ -1,0 +1,166 @@
+import { Input } from '@codegouvfr/react-dsfr/Input';
+import Tag from '@codegouvfr/react-dsfr/Tag';
+import clsx from 'clsx';
+import { useEffect, useId, useState, type FocusEvent, type KeyboardEvent } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useDebounce } from 'use-debounce';
+
+import { Mandatory } from '@/shared/ui/Mandatory';
+import { toFullName } from '@/utils/user.utils';
+import { useSearchMagistratsQuery, type MagistratSearchResult } from '@queries/observations.queries';
+
+const searchTermFor = (magistrat: MagistratSearchResult) => `${magistrat.lastName} ${magistrat.firstName}`;
+
+const magistratDetails = (magistrat: MagistratSearchResult) =>
+  [magistrat.grade, magistrat.currentPosition]
+    .flatMap((detail) => {
+      const trimmed = detail?.trim();
+      return trimmed ? [trimmed] : [];
+    })
+    .join(' - ');
+
+export function MagistratCombobox(props: {
+  errorMessage?: string;
+  magistrat: MagistratSearchResult | null;
+  onChange: (magistrat: MagistratSearchResult | null) => void;
+}) {
+  const intl = useIntl();
+  const { magistrat, onChange } = props;
+
+  const id = useId();
+  const listboxId = `${id}-listbox`;
+  const optionId = (magistratId: string) => `${id}-option-${magistratId}`;
+
+  const [searchTerm, setSearchTerm] = useState(magistrat ? searchTermFor(magistrat) : '');
+  const [debouncedSearch] = useDebounce(searchTerm, 400);
+  const [showResults, setShowResults] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (magistrat) setSearchTerm(searchTermFor(magistrat));
+  }, [magistrat]);
+
+  const { data, isLoading: isSearching } = useSearchMagistratsQuery(debouncedSearch);
+  const results = data ?? [];
+  const isOpen = showResults && debouncedSearch.length >= 2;
+  const activeMagistrat = isOpen ? results[activeIndex] : undefined;
+
+  const select = (selected: MagistratSearchResult) => {
+    onChange(selected);
+    setSearchTerm(searchTermFor(selected));
+    setShowResults(false);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      setShowResults(false);
+      return;
+    }
+    if (!isOpen || results.length === 0) return;
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      const step = event.key === 'ArrowDown' ? 1 : -1;
+      setActiveIndex((index) => (index + step + results.length) % results.length);
+    } else if (event.key === 'Enter' && activeMagistrat) {
+      event.preventDefault();
+      select(activeMagistrat);
+    }
+  };
+
+  const closeOnFocusLeave = (event: FocusEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.contains(event.relatedTarget)) setShowResults(false);
+  };
+
+  return (
+    <div className="relative" onBlur={closeOnFocusLeave}>
+      <Input
+        classes={{ root: 'fr-mb-0' }}
+        hintText={intl.formatMessage({ defaultMessage: 'Nom, Prénom ou Adresse email pro' })}
+        iconId="fr-icon-search-line"
+        label={
+          <Mandatory>
+            <FormattedMessage defaultMessage="Magistrat observant" />
+          </Mandatory>
+        }
+        nativeInputProps={{
+          'aria-activedescendant': activeMagistrat ? optionId(activeMagistrat.id) : undefined,
+          'aria-autocomplete': 'list',
+          'aria-controls': listboxId,
+          'aria-expanded': isOpen,
+          onChange: (event) => {
+            setSearchTerm(event.target.value);
+            setShowResults(true);
+            setActiveIndex(0);
+            if (event.target.value === '') onChange(null);
+          },
+          onFocus: () => setShowResults(true),
+          onKeyDown,
+          placeholder: intl.formatMessage({ defaultMessage: 'Rechercher un magistrat' }),
+          role: 'combobox',
+          type: 'search',
+          value: searchTerm,
+        }}
+        state={props.errorMessage ? 'error' : 'default'}
+        stateRelatedMessage={props.errorMessage}
+      />
+
+      {isOpen && (
+        <div className="fr-mt-1v absolute z-[9999] max-h-60 w-full overflow-y-auto rounded-sm border bg-(--background-default-grey) shadow-lg">
+          {isSearching && (
+            <p className="fr-p-3v fr-mb-0 text-sm text-(--text-mention-grey)">
+              <FormattedMessage defaultMessage="Recherche…" />
+            </p>
+          )}
+          {!isSearching && results.length === 0 && (
+            <p className="fr-p-3v fr-mb-0 text-sm text-(--text-mention-grey)">
+              <FormattedMessage defaultMessage="Aucun résultat" />
+            </p>
+          )}
+          <div
+            aria-label={intl.formatMessage({ defaultMessage: 'Magistrats correspondants' })}
+            id={listboxId}
+            role="listbox"
+          >
+            {results.map((result, index) => (
+              <div
+                aria-selected={index === activeIndex}
+                className={clsx(
+                  'fr-p-3v cursor-pointer border-b text-left',
+                  index === activeIndex && 'bg-(--background-default-grey-hover)',
+                )}
+                id={optionId(result.id)}
+                key={result.id}
+                onClick={() => select(result)}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setActiveIndex(index)}
+                role="option"
+              >
+                <div className="font-medium">{toFullName(result)}</div>
+                <div className="text-xs text-(--text-mention-grey)">{magistratDetails(result)}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {magistrat && (
+        <div className="fr-mt-2v fr-p-2v flex items-center gap-2">
+          <Tag
+            as="button"
+            dismissible
+            nativeButtonProps={{
+              onClick: () => {
+                onChange(null);
+                setSearchTerm('');
+              },
+            }}
+          >
+            {toFullName(magistrat)}
+            {magistrat.currentPosition && ` - ${magistrat.currentPosition}`}
+          </Tag>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationExistingFiles.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationExistingFiles.tsx
@@ -1,0 +1,57 @@
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import type { Observation } from '@queries/observations.queries';
+
+export function ObservationExistingFiles(props: {
+  files: Observation['files'];
+  detachedFiles: Observation['files'];
+  onRemove: (fileId: string) => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <div>
+      <label className="fr-label fr-mb-2v block">
+        <FormattedMessage
+          defaultMessage={`{count, plural,
+            one {Fichier existant}
+            other {Fichiers existants}
+          }`}
+          values={{ count: props.files.length }}
+        />
+      </label>
+
+      <div className="flex flex-wrap gap-2">
+        {props.files.map((file) => (
+          <div
+            className="fr-px-3v fr-py-2v flex items-center gap-2 rounded-sm bg-(--background-contrast-grey)"
+            key={file.id}
+          >
+            <i className="ri-file-line" />
+            <span className="text-sm">{file.name}</span>
+            <button
+              className="fr-ml-2v text-(--text-default-error) hover:text-(--text-default-error)"
+              onClick={() => props.onRemove(file.id)}
+              title={intl.formatMessage({ defaultMessage: 'Supprimer {name}' }, { name: file.name })}
+              type="button"
+            >
+              <i className="ri-close-line" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {props.detachedFiles.length > 0 && (
+        <div className="fr-mt-2v text-sm text-(--text-default-warning)">
+          <FormattedMessage
+            defaultMessage={`{count, plural,
+              one {1 fichier sera supprimé}
+              other {{count} fichiers seront supprimés}
+            }`}
+            values={{ count: props.detachedFiles.length }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationForm.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationForm.test.tsx
@@ -1,0 +1,247 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MagistratSearchResult, Observation } from '@queries/observations.queries';
+
+import { ObservationForm } from './ObservationForm';
+
+const createObservation = vi.fn();
+const updateObservation = vi.fn();
+
+let searchResults: MagistratSearchResult[] = [];
+
+let linkableAttachments: { observationId: string; fileId: string; name: string }[] = [];
+
+vi.mock('@queries/observations.queries', () => ({
+  useCreateObservationMutation: () => ({ mutate: createObservation, reset: vi.fn(), error: null }),
+  useUpdateObservationMutation: () => ({ mutate: updateObservation, reset: vi.fn(), error: null }),
+  useSearchMagistratsQuery: () => ({ data: searchResults, isLoading: false }),
+  useListObservationsAttachments: () => ({ data: { items: linkableAttachments } }),
+}));
+
+const PV = { observationId: 'other-observation', fileId: 'file-a', name: 'pv.pdf' };
+const NOTE = { observationId: 'other-observation', fileId: 'file-b', name: 'note.pdf' };
+
+const MARTIN: MagistratSearchResult = {
+  currentPosition: 'Juge à Nantes',
+  firstName: 'Léa',
+  grade: null,
+  id: 'magistrat-1',
+  lastName: 'Martin',
+  usedName: '',
+};
+
+const DUPONT: MagistratSearchResult = {
+  currentPosition: 'Procureur à Rennes',
+  firstName: 'Marc',
+  grade: null,
+  id: 'magistrat-2',
+  lastName: 'Dupont',
+  usedName: '',
+};
+
+const OBSERVATION: Observation = {
+  createdAt: '2026-07-13',
+  createdBy: { firstName: 'Anne', id: 'user-1', lastName: 'Roy' },
+  dateReception: '2026-07-02T00:00:00.000Z',
+  description: 'Observation initiale',
+  files: [
+    { id: 'file-1', name: 'courrier.pdf' },
+    { id: 'file-2', name: 'annexe.docx' },
+  ],
+  followUp: null,
+  id: 'observation-1',
+  magistrat: {
+    currentPosition: null,
+    firstName: 'Léa',
+    id: 'magistrat-1',
+    lastName: 'Martin',
+    usedName: null,
+  },
+};
+
+function renderForm(observation?: Observation) {
+  return render(
+    <IntlProvider defaultLocale="fr" locale="fr">
+      <ObservationForm
+        nominationFileId="nomination-file"
+        observation={observation}
+        onPending={vi.fn()}
+        sessionId="session-1"
+      />
+      <button form="observation-form" type="submit">
+        Envoyer
+      </button>
+    </IntlProvider>,
+  );
+}
+
+const removeFileButton = (name: string) =>
+  screen.getByRole('button', { name: `Supprimer ${name}` }) as HTMLButtonElement;
+
+const searchInput = () => screen.getByRole('combobox');
+
+async function search(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(searchInput(), 'mar');
+  return screen.findAllByRole('option');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  searchResults = [];
+  linkableAttachments = [];
+});
+
+describe('ObservationForm linkable attachments', () => {
+  it('links an attachment coming from another observation', async () => {
+    const user = userEvent.setup();
+    linkableAttachments = [PV];
+    renderForm(OBSERVATION);
+
+    await user.click(screen.getByRole('button', { name: /pv\.pdf/ }));
+
+    expect(screen.getByRole('button', { name: /pv\.pdf/ })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('unlinks one attachment without dropping the other one from the same observation', async () => {
+    const user = userEvent.setup();
+    linkableAttachments = [PV, NOTE];
+    renderForm(OBSERVATION);
+
+    await user.click(screen.getByRole('button', { name: /pv\.pdf/ }));
+    await user.click(screen.getByRole('button', { name: /note\.pdf/ }));
+    await user.click(screen.getByRole('button', { name: /pv\.pdf/ }));
+
+    expect(screen.getByRole('button', { name: /pv\.pdf/ })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: /note\.pdf/ })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('submits the linked attachments', async () => {
+    const user = userEvent.setup();
+    linkableAttachments = [PV, NOTE];
+    renderForm(OBSERVATION);
+
+    await user.click(screen.getByRole('button', { name: /note\.pdf/ }));
+    await user.click(screen.getByRole('button', { name: 'Envoyer' }));
+
+    expect(updateObservation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        linkedObservationsAttachments: [{ observationId: NOTE.observationId, fileId: NOTE.fileId }],
+      }),
+      expect.anything(),
+    );
+  });
+});
+
+describe('ObservationForm magistrat combobox', () => {
+  it('exposes the results as options of a listbox', async () => {
+    const user = userEvent.setup();
+    searchResults = [MARTIN, DUPONT];
+    renderForm();
+
+    const options = await search(user);
+
+    expect(options).toHaveLength(2);
+    expect(searchInput()).toHaveAttribute('aria-expanded', 'true');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('points aria-activedescendant at the option the arrow keys reach', async () => {
+    const user = userEvent.setup();
+    searchResults = [MARTIN, DUPONT];
+    renderForm();
+
+    const options = await search(user);
+    await user.keyboard('{ArrowDown}');
+
+    expect(searchInput()).toHaveAttribute('aria-activedescendant', options[1]!.id);
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('selects the active option with Enter', async () => {
+    const user = userEvent.setup();
+    searchResults = [MARTIN, DUPONT];
+    renderForm();
+
+    await search(user);
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(screen.getByText(/dupont/i)).toBeInTheDocument();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes the listbox when the focus leaves the combobox', async () => {
+    const user = userEvent.setup();
+    searchResults = [MARTIN, DUPONT];
+    renderForm();
+
+    await search(user);
+    await user.click(screen.getByLabelText(/Date de réception/));
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes the listbox with Escape', async () => {
+    const user = userEvent.setup();
+    searchResults = [MARTIN, DUPONT];
+    renderForm();
+
+    await search(user);
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(searchInput()).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+describe('ObservationForm', () => {
+  it('detaches the removed file and keeps the other one', async () => {
+    const user = userEvent.setup();
+    renderForm(OBSERVATION);
+
+    await user.click(removeFileButton('courrier.pdf'));
+    await user.click(screen.getByRole('button', { name: 'Envoyer' }));
+
+    expect(updateObservation).toHaveBeenCalledWith(
+      expect.objectContaining({ observationId: 'observation-1', detachFileIds: ['file-1'] }),
+      expect.anything(),
+    );
+  });
+
+  it('detaches nothing when the user removes no file', async () => {
+    const user = userEvent.setup();
+    renderForm(OBSERVATION);
+
+    await user.click(screen.getByRole('button', { name: 'Envoyer' }));
+
+    expect(updateObservation).toHaveBeenCalledWith(
+      expect.objectContaining({ detachFileIds: [] }),
+      expect.anything(),
+    );
+  });
+
+  it('stops the submission when the last file is removed and no text is left', async () => {
+    const user = userEvent.setup();
+    renderForm({ ...OBSERVATION, description: '', files: [{ id: 'file-1', name: 'courrier.pdf' }] });
+
+    await user.click(removeFileButton('courrier.pdf'));
+    await user.click(screen.getByRole('button', { name: 'Envoyer' }));
+
+    expect(updateObservation).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Renseignez l'historique observant ou joignez une pièce jointe"),
+    ).toBeInTheDocument();
+  });
+
+  it('accepts an observation carrying only an attachment', async () => {
+    const user = userEvent.setup();
+    renderForm({ ...OBSERVATION, description: '' });
+
+    await user.click(screen.getByRole('button', { name: 'Envoyer' }));
+
+    expect(updateObservation).toHaveBeenCalled();
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationForm.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationForm.test.tsx
@@ -223,19 +223,6 @@ describe('ObservationForm', () => {
     );
   });
 
-  it('stops the submission when the last file is removed and no text is left', async () => {
-    const user = userEvent.setup();
-    renderForm({ ...OBSERVATION, description: '', files: [{ id: 'file-1', name: 'courrier.pdf' }] });
-
-    await user.click(removeFileButton('courrier.pdf'));
-    await user.click(screen.getByRole('button', { name: 'Envoyer' }));
-
-    expect(updateObservation).not.toHaveBeenCalled();
-    expect(
-      screen.getByText("Renseignez l'historique observant ou joignez une pièce jointe"),
-    ).toBeInTheDocument();
-  });
-
   it('accepts an observation carrying only an attachment', async () => {
     const user = userEvent.setup();
     renderForm({ ...OBSERVATION, description: '' });
@@ -243,5 +230,18 @@ describe('ObservationForm', () => {
     await user.click(screen.getByRole('button', { name: 'Envoyer' }));
 
     expect(updateObservation).toHaveBeenCalled();
+  });
+
+  it('accepts an observation left without text nor attachment as the domain allows it', async () => {
+    const user = userEvent.setup();
+    renderForm({ ...OBSERVATION, description: '', files: [{ id: 'file-1', name: 'courrier.pdf' }] });
+
+    await user.click(removeFileButton('courrier.pdf'));
+    await user.click(screen.getByRole('button', { name: 'Envoyer' }));
+
+    expect(updateObservation).toHaveBeenCalledWith(
+      expect.objectContaining({ detachFileIds: ['file-1'] }),
+      expect.anything(),
+    );
   });
 });

--- a/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationForm.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationForm.tsx
@@ -1,46 +1,69 @@
 import { Input } from '@codegouvfr/react-dsfr/Input';
-import Tag from '@codegouvfr/react-dsfr/Tag';
 import { Upload } from '@codegouvfr/react-dsfr/Upload';
 import { zodResolver } from '@hookform/resolvers/zod';
-import React, { useEffect, useRef, useState, type FC } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { FormattedMessage } from 'react-intl';
-import { useDebounce } from 'use-debounce';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { z } from 'zod';
 
 import { Mandatory } from '@/shared/ui/Mandatory';
-import { toFullName } from '@/utils/user.utils';
 import {
   useCreateObservationMutation,
   useListObservationsAttachments,
-  useSearchMagistratsQuery,
   useUpdateObservationMutation,
   type MagistratSearchResult,
   type Observation,
 } from '@queries/observations.queries';
 
+import { MagistratCombobox } from './MagistratCombobox';
+import { ObservationExistingFiles } from './ObservationExistingFiles';
+import { ObservationLinkableAttachments } from './ObservationLinkableAttachments';
+
 const ACCEPTED_FILE_TYPES = '.jpg,.jpeg,.png,.pdf,.doc,.docx';
 
-const observationFormSchema = z.object({
-  magistratId: z.string().min(1, 'Champ obligatoire'),
-  dateReception: z.string().min(1, 'Champ obligatoire'),
-  description: z.string().optional(),
-  files: z.array(z.instanceof(File)).optional(),
-  linkedFiles: z
-    .array(z.object({ observationId: z.string(), fileId: z.string(), name: z.string() }))
-    .optional(),
-});
+const observationFormSchema = z
+  .object({
+    magistratId: z.string().min(1, 'Champ obligatoire'),
+    dateReception: z.string().min(1, 'Champ obligatoire'),
+    description: z.string().optional(),
+    files: z.array(z.instanceof(File)).optional(),
+    linkedFiles: z
+      .array(z.object({ observationId: z.string(), fileId: z.string(), name: z.string() }))
+      .optional(),
+    keptFileIds: z.array(z.string()).optional(),
+  })
+  .superRefine((values, ctx) => {
+    const hasContent =
+      !!values.description?.trim() ||
+      !!values.files?.length ||
+      !!values.linkedFiles?.length ||
+      !!values.keptFileIds?.length;
+
+    if (!hasContent) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['description'],
+        message: "Renseignez l'historique observant ou joignez une pièce jointe",
+      });
+    }
+  });
 
 type FormSchema = z.infer<typeof observationFormSchema>;
 
-export const ObservationForm: FC<{
-  sessionId: string;
+export function ObservationForm({
+  nominationFileId,
+  observation,
+  onPending,
+  onSuccess,
+  sessionId,
+}: {
   nominationFileId: string;
-  nominationFileName: string;
   observation?: Observation;
-  onSuccess?: () => void;
   onPending: (isPending: boolean) => unknown;
-}> = ({ sessionId, nominationFileId, observation, onSuccess, onPending }) => {
+  onSuccess?: () => void;
+  sessionId: string;
+}) {
+  const intl = useIntl();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isEditing = !!observation;
 
@@ -49,7 +72,6 @@ export const ObservationForm: FC<{
     handleSubmit: handleFormSubmit,
     reset,
     setValue,
-    getValues,
     watch,
     formState: { errors },
   } = useForm<FormSchema>({
@@ -60,18 +82,18 @@ export const ObservationForm: FC<{
       description: observation?.description,
       files: [],
       linkedFiles: [],
+      keptFileIds: observation?.files.map(({ id }) => id) ?? [],
     },
     mode: 'onChange',
   });
 
-  const [searchTerm, setSearchTerm] = useState('');
-  const [debouncedSearch] = useDebounce(searchTerm, 400);
   const [selectedMagistrat, setSelectedMagistrat] = useState<MagistratSearchResult | null>(null);
-  const [showResults, setShowResults] = useState(false);
-  const [existingFiles, setExistingFiles] = useState<Observation['files']>(observation?.files ?? []);
-  const [filesToDetach, setFilesToDetach] = useState<string[]>([]);
 
-  const { data: displayedMagistrats, isLoading: isSearching } = useSearchMagistratsQuery(debouncedSearch);
+  const keptFileIds = watch('keptFileIds') ?? [];
+  const attachedFiles = observation?.files ?? [];
+  const existingFiles = attachedFiles.filter(({ id }) => keptFileIds.includes(id));
+  const filesToDetach = attachedFiles.filter(({ id }) => !keptFileIds.includes(id));
+
   const { data: observationsAttachments } = useListObservationsAttachments({
     sessionId,
     excludeObservationId: observation?.id,
@@ -101,22 +123,25 @@ export const ObservationForm: FC<{
         grade: null,
         currentPosition: observation.magistrat.currentPosition ?? null,
       });
-      setSearchTerm(`${observation.magistrat.lastName} ${observation.magistrat.firstName}`);
     }
   }, [observation]);
 
+  const handleMagistratChange = (magistrat: MagistratSearchResult | null) => {
+    setSelectedMagistrat(magistrat);
+    setValue('magistratId', magistrat?.id ?? '', { shouldValidate: true });
+  };
+
   const handleRemoveExistingFile = (fileId: string) => {
-    setExistingFiles((prev) => prev.filter((f) => f.id !== fileId));
-    setFilesToDetach((prev) => [...prev, fileId]);
+    setValue(
+      'keptFileIds',
+      keptFileIds.filter((id) => id !== fileId),
+      { shouldValidate: true },
+    );
   };
 
   const resetForm = () => {
     reset();
-    setSearchTerm('');
     setSelectedMagistrat(null);
-    setShowResults(false);
-    setExistingFiles([]);
-    setFilesToDetach([]);
     resetCreateMutation();
     resetUpdateMutation();
     if (fileInputRef.current) {
@@ -136,7 +161,7 @@ export const ObservationForm: FC<{
           dateReception: data.dateReception,
           description: data.description,
           files: data.files,
-          detachFileIds: filesToDetach,
+          detachFileIds: filesToDetach.map(({ id }) => id),
           linkedObservationsAttachments: (data.linkedFiles ?? []).map(({ observationId, fileId }) => ({
             observationId,
             fileId,
@@ -179,233 +204,109 @@ export const ObservationForm: FC<{
     }
   };
 
-  const handleMagistratSelect = (magistrat: MagistratSearchResult) => {
-    setSelectedMagistrat(magistrat);
-    setValue('magistratId', magistrat.id);
-    setSearchTerm(`${magistrat.lastName} ${magistrat.firstName}`);
-    setShowResults(false);
-  };
-
-  const handleMagistratClear = () => {
-    setSelectedMagistrat(null);
-    setValue('magistratId', '');
-    setSearchTerm('');
-  };
-
-  const linkedFiles = watch('linkedFiles');
-  const viewObservationAttachments = React.useMemo(() => {
-    return ([] as { observationId: string; fileId: string; name: string }[]).concat(
-      observationsAttachments?.items ?? [],
-      (linkedFiles ?? []).filter((value) => {
-        const items = observationsAttachments?.items ?? [];
-        return !items.some(
-          (item) => item.observationId === value.observationId && item.fileId === value.fileId,
-        );
-      }),
-    );
-  }, [linkedFiles, observationsAttachments]);
-
-  const onLinkFileClicked = React.useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault();
-
-      const fileId = e.currentTarget.dataset.fileId;
-      const observationId = e.currentTarget.dataset.observationId;
-      const name = e.currentTarget.dataset.name;
-
-      if (!fileId || !observationId || !name) return;
-
-      const current = getValues('linkedFiles') ?? [];
-      const isPressed = e.currentTarget.getAttribute('aria-pressed') !== 'false';
-      if (isPressed) {
-        setValue('linkedFiles', current.concat({ fileId, observationId, name }));
-      } else {
-        setValue(
-          'linkedFiles',
-          current.filter((x) => x.fileId !== fileId && x.observationId !== observationId),
-        );
-      }
-    },
-    [getValues, setValue],
-  );
+  const linkedFiles = watch('linkedFiles') ?? [];
+  const searchedAttachments = observationsAttachments?.items ?? [];
+  const linkableAttachments = [
+    ...searchedAttachments,
+    ...linkedFiles.filter(
+      (linked) =>
+        !searchedAttachments.some(
+          (attachment) =>
+            attachment.observationId === linked.observationId && attachment.fileId === linked.fileId,
+        ),
+    ),
+  ];
 
   return (
-    <form id="observation-form" onSubmit={handleFormSubmit(onSubmit)} className="flex flex-col gap-6">
+    <form className="flex flex-col gap-6" id="observation-form" onSubmit={handleFormSubmit(onSubmit)}>
       {createError || updateError ? (
         <p className="fr-mb-0 text-(--text-default-error)">
           {createError?.message ||
             updateError?.message ||
-            (isEditing ? `Erreur pendant la mise à jour` : `Erreur à la création`)}
+            (isEditing ? (
+              <FormattedMessage defaultMessage="Erreur pendant la mise à jour" />
+            ) : (
+              <FormattedMessage defaultMessage="Erreur à la création" />
+            ))}
         </p>
       ) : null}
+      <MagistratCombobox
+        errorMessage={errors.magistratId?.message}
+        magistrat={selectedMagistrat}
+        onChange={handleMagistratChange}
+      />
+
       <Controller
-        name="dateReception"
         control={control}
+        name="dateReception"
         render={({ field }) => (
           <Input
+            classes={{ root: 'fr-mb-0' }}
             label={
               <Mandatory>
                 <FormattedMessage defaultMessage="Date de réception" />
               </Mandatory>
             }
-            state={errors.dateReception || updateError || createError ? 'error' : 'default'}
-            stateRelatedMessage={errors.dateReception?.message}
-            classes={{ root: 'fr-mb-0' }}
             nativeInputProps={{
+              'aria-required': true,
+              onChange: field.onChange,
               type: 'date',
               value: field.value,
-              onChange: field.onChange,
-              required: true,
             }}
+            state={errors.dateReception ? 'error' : 'default'}
+            stateRelatedMessage={errors.dateReception?.message}
           />
         )}
       />
 
-      <div className="relative">
-        <Input
-          label={
-            <Mandatory>
-              <FormattedMessage defaultMessage="Magistrat observant" />
-            </Mandatory>
-          }
-          classes={{ root: 'fr-mb-0' }}
-          iconId="fr-icon-search-line"
-          hintText="Nom, Prénom ou Adresse email pro"
-          state={errors.magistratId || updateError || createError ? 'error' : 'default'}
-          stateRelatedMessage={errors.magistratId ? errors.magistratId.message : null}
-          nativeInputProps={{
-            type: 'search',
-            role: 'combobox',
-            value: searchTerm,
-            onFocus: () => setShowResults(true),
-            placeholder: 'Rechercher un magistrat',
-            'aria-expanded': showResults && debouncedSearch.length >= 2,
-            'aria-controls': 'magistrat-listbox',
-            'aria-autocomplete': 'list',
-            onChange: (e) => {
-              setSearchTerm(e.target.value);
-              setShowResults(true);
-              if (e.target.value === '') {
-                setSelectedMagistrat(null);
-                setValue('magistratId', '');
-              }
-            },
-          }}
-        />
-        {showResults && debouncedSearch.length >= 2 && (
-          <div
-            id="magistrat-listbox"
-            role="listbox"
-            className="fr-mt-1v absolute max-h-60 w-full overflow-y-auto rounded-sm border bg-(--background-default-grey) shadow-lg"
-            style={{ zIndex: 9999 }}
-          >
-            {isSearching ? (
-              <div className="fr-p-3v text-sm text-(--text-mention-grey)">Recherche...</div>
-            ) : (displayedMagistrats ?? []).length === 0 ? (
-              <div className="fr-p-3v text-sm text-(--text-mention-grey)">Aucun résultat</div>
-            ) : (
-              (displayedMagistrats ?? []).map((magistrat) => (
-                <button
-                  key={magistrat.id}
-                  type="button"
-                  role="option"
-                  aria-selected={selectedMagistrat?.id === magistrat.id}
-                  className="fr-p-3v w-full cursor-pointer border-b text-left hover:bg-(--background-default-grey-hover)"
-                  onClick={() => handleMagistratSelect(magistrat)}
-                >
-                  <div className="font-medium">{toFullName(magistrat)}</div>
-                  <div className="text-xs text-(--text-mention-grey)">
-                    {[magistrat.grade, magistrat.currentPosition]
-                      .flatMap((x) => {
-                        const trimmed = x?.trim();
-                        return trimmed ? [trimmed] : [];
-                      })
-                      .join(' - ')}
-                  </div>
-                </button>
-              ))
-            )}
-          </div>
-        )}
-        {selectedMagistrat && (
-          <div className="fr-mt-2v fr-p-2v flex items-center gap-2">
-            <Tag dismissible nativeButtonProps={{ onClick: handleMagistratClear }} as="button">
-              {toFullName(selectedMagistrat)}
-              {selectedMagistrat.currentPosition && ` - ${selectedMagistrat.currentPosition}`}
-            </Tag>
-          </div>
-        )}
-      </div>
-
       {isEditing && existingFiles.length > 0 && (
-        <div>
-          <label className="fr-label fr-mb-2v block">
-            <FormattedMessage
-              values={{ count: existingFiles.length }}
-              defaultMessage={`{count, plural,
-                one {Fichier existant}  
-                other {Fichiers existants}  
-              }`}
-            />
-          </label>
-          <div className="flex flex-wrap gap-2">
-            {existingFiles.map((file) => (
-              <div
-                key={file.id}
-                className="fr-px-3v fr-py-2v flex items-center gap-2 rounded-sm bg-(--background-contrast-grey)"
-              >
-                <i className="ri-file-line" />
-                <span className="text-sm">{file.name}</span>
-                <button
-                  type="button"
-                  className="fr-ml-2v text-(--text-default-error) hover:text-(--text-default-error)"
-                  onClick={() => handleRemoveExistingFile(file.id)}
-                  title="Supprimer ce fichier"
-                >
-                  <i className="ri-close-line" />
-                </button>
-              </div>
-            ))}
-          </div>
-          {filesToDetach.length > 0 && (
-            <div className="fr-mt-2v text-sm text-(--text-default-warning)">
-              {filesToDetach.length > 1
-                ? `${filesToDetach.length} fichiers seront supprimés`
-                : `1 fichier sera supprimé`}
-            </div>
-          )}
-        </div>
+        <ObservationExistingFiles
+          detachedFiles={filesToDetach}
+          files={existingFiles}
+          onRemove={handleRemoveExistingFile}
+        />
       )}
 
       <Controller
-        name="description"
         control={control}
+        name="description"
         render={({ field }) => (
           <Input
-            textArea
             classes={{ root: 'fr-mb-0' }}
-            label="Historique observant"
-            nativeTextAreaProps={{ value: field.value as string, onChange: field.onChange }}
+            hintText={intl.formatMessage({
+              defaultMessage: "Renseignez le texte de l'observation ou joignez une pièce jointe ci-dessous",
+            })}
+            label={<FormattedMessage defaultMessage="Historique observant" />}
+            nativeTextAreaProps={{ onChange: field.onChange, value: field.value as string }}
+            state={errors.description ? 'error' : 'default'}
+            stateRelatedMessage={errors.description?.message}
+            textArea
           />
         )}
       />
 
       <Controller
-        name="files"
         control={control}
+        name="files"
         render={({ field }) => (
           <Upload
-            label={isEditing ? 'Ajouter des fichiers' : 'Pièces jointes'}
-            hint="Formats acceptés: JPEG, PNG, PDF, Word"
+            hint={intl.formatMessage({ defaultMessage: 'Formats acceptés : JPEG, PNG, PDF, Word' })}
+            label={
+              isEditing ? (
+                <FormattedMessage defaultMessage="Ajouter des fichiers" />
+              ) : (
+                <FormattedMessage defaultMessage="Pièces jointes" />
+              )
+            }
             nativeInputProps={{
-              ref: fileInputRef,
-              multiple: true,
               accept: ACCEPTED_FILE_TYPES,
+              multiple: true,
               onChange: (e) => {
                 if (e.target.files) {
                   field.onChange(Array.from(e.target.files));
                 }
               },
+              ref: fileInputRef,
             }}
           />
         )}
@@ -413,44 +314,26 @@ export const ObservationForm: FC<{
       {files.length > 0 && (
         <div className="text-sm text-(--text-mention-grey)">
           <FormattedMessage
-            values={{ count: files.length }}
             defaultMessage={`{count, plural,
               one {{count} nouveau fichier sélectionné}
               other {{count} nouveaux fichiers sélectionnés}
             }`}
+            values={{ count: files.length }}
           />
         </div>
       )}
 
       <Controller
-        name="linkedFiles"
         control={control}
+        name="linkedFiles"
         render={({ field }) => (
-          <ul className="fr-m-0 fr-p-0 flex list-none flex-row flex-wrap gap-x-2">
-            <li></li>
-            {viewObservationAttachments.map((item) => (
-              <li key={`${item.observationId}_${item.fileId}`}>
-                <Tag
-                  small
-                  title={`Lier "${item.name}"`}
-                  iconId="fr-icon-file-fill"
-                  nativeButtonProps={{
-                    onClick: onLinkFileClicked,
-                    'data-name': item.name,
-                    'data-file-id': item.fileId,
-                    'data-observation-id': item.observationId,
-                  }}
-                  pressed={field.value?.some(
-                    (x) => x.observationId === item.observationId && x.fileId === item.fileId,
-                  )}
-                >
-                  {item.name}
-                </Tag>
-              </li>
-            ))}
-          </ul>
+          <ObservationLinkableAttachments
+            attachments={linkableAttachments}
+            linked={field.value ?? []}
+            onToggle={field.onChange}
+          />
         )}
       />
     </form>
   );
-};
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationForm.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationForm.tsx
@@ -21,32 +21,16 @@ import { ObservationLinkableAttachments } from './ObservationLinkableAttachments
 
 const ACCEPTED_FILE_TYPES = '.jpg,.jpeg,.png,.pdf,.doc,.docx';
 
-const observationFormSchema = z
-  .object({
-    magistratId: z.string().min(1, 'Champ obligatoire'),
-    dateReception: z.string().min(1, 'Champ obligatoire'),
-    description: z.string().optional(),
-    files: z.array(z.instanceof(File)).optional(),
-    linkedFiles: z
-      .array(z.object({ observationId: z.string(), fileId: z.string(), name: z.string() }))
-      .optional(),
-    keptFileIds: z.array(z.string()).optional(),
-  })
-  .superRefine((values, ctx) => {
-    const hasContent =
-      !!values.description?.trim() ||
-      !!values.files?.length ||
-      !!values.linkedFiles?.length ||
-      !!values.keptFileIds?.length;
-
-    if (!hasContent) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['description'],
-        message: "Renseignez l'historique observant ou joignez une pièce jointe",
-      });
-    }
-  });
+const observationFormSchema = z.object({
+  magistratId: z.string().min(1, 'Champ obligatoire'),
+  dateReception: z.string().min(1, 'Champ obligatoire'),
+  description: z.string().optional(),
+  files: z.array(z.instanceof(File)).optional(),
+  linkedFiles: z
+    .array(z.object({ observationId: z.string(), fileId: z.string(), name: z.string() }))
+    .optional(),
+  keptFileIds: z.array(z.string()).optional(),
+});
 
 type FormSchema = z.infer<typeof observationFormSchema>;
 
@@ -278,8 +262,6 @@ export function ObservationForm({
             })}
             label={<FormattedMessage defaultMessage="Historique observant" />}
             nativeTextAreaProps={{ onChange: field.onChange, value: field.value as string }}
-            state={errors.description ? 'error' : 'default'}
-            stateRelatedMessage={errors.description?.message}
             textArea
           />
         )}

--- a/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationLinkableAttachments.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/observations/ObservationLinkableAttachments.tsx
@@ -1,0 +1,41 @@
+import Tag from '@codegouvfr/react-dsfr/Tag';
+import { useIntl } from 'react-intl';
+
+export type LinkableAttachment = { observationId: string; fileId: string; name: string };
+
+const isSameAttachment = (a: LinkableAttachment, b: LinkableAttachment) =>
+  a.observationId === b.observationId && a.fileId === b.fileId;
+
+export function ObservationLinkableAttachments(props: {
+  attachments: readonly LinkableAttachment[];
+  linked: readonly LinkableAttachment[];
+  onToggle: (attachments: LinkableAttachment[]) => void;
+}) {
+  const intl = useIntl();
+  const { attachments, linked, onToggle } = props;
+
+  const toggle = (attachment: LinkableAttachment) =>
+    onToggle(
+      linked.some((candidate) => isSameAttachment(candidate, attachment))
+        ? linked.filter((candidate) => !isSameAttachment(candidate, attachment))
+        : [...linked, attachment],
+    );
+
+  return (
+    <ul className="fr-m-0 fr-p-0 flex list-none flex-row flex-wrap gap-x-2">
+      {attachments.map((attachment) => (
+        <li key={`${attachment.observationId}_${attachment.fileId}`}>
+          <Tag
+            iconId="fr-icon-file-fill"
+            nativeButtonProps={{ onClick: () => toggle(attachment) }}
+            pressed={linked.some((candidate) => isSameAttachment(candidate, attachment))}
+            small
+            title={intl.formatMessage({ defaultMessage: 'Lier "{name}"' }, { name: attachment.name })}
+          >
+            {attachment.name}
+          </Tag>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/observations/context/ObservationsModalProvider.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/observations/context/ObservationsModalProvider.tsx
@@ -249,7 +249,6 @@ export const ObservationsModalProvider: FC<PropsWithChildren> = ({ children }) =
           ) : (
             <ObservationForm
               nominationFileId={state.file.id}
-              nominationFileName={state.file.name}
               observation={state.status === 'edit' ? state.observation : undefined}
               onPending={onPendingChange}
               onSuccess={() => dispatch({ type: 'exit' })}

--- a/apps/client/src/shared/components/audition-banner/AuditionBanner.tsx
+++ b/apps/client/src/shared/components/audition-banner/AuditionBanner.tsx
@@ -25,11 +25,11 @@ export function AuditionBanner(props: {
   return (
     <div
       className={clsx(
-        'flex items-center gap-3 bg-(--background-contrast-info) font-medium text-(--text-default-info)',
+        'flex items-center gap-2 bg-(--background-contrast-info) text-sm-plus font-medium text-(--text-default-info)',
         props.className,
       )}
     >
-      <span aria-hidden className="fr-icon-info-fill shrink-0" />
+      <span aria-hidden className="fr-icon-info-fill shrink-0 before:[--icon-size:1.25rem]" />
       <span>
         {isPast ? (
           <FormattedMessage defaultMessage="Une audition a eu lieu le {date} à {time}" values={values} />

--- a/apps/client/src/shared/ui/comment-editor/CommentEditor.tsx
+++ b/apps/client/src/shared/ui/comment-editor/CommentEditor.tsx
@@ -100,7 +100,7 @@ export function CommentEditor(props: {
         <div className="overflow-hidden">
           <div className="flex justify-end gap-2">
             <Button
-              className="min-h-9! px-3.5! py-1.5! text-[0.9375rem]!"
+              className="btn-compact"
               disabled={!isDirty || isPending}
               onClick={cancel}
               priority="secondary"
@@ -109,7 +109,7 @@ export function CommentEditor(props: {
               <FormattedMessage defaultMessage="Annuler" />
             </Button>
             <Button
-              className="min-h-9! px-3.5! py-1.5! text-[0.9375rem]!"
+              className="btn-compact"
               disabled={!isDirty || isPending}
               onClick={save}
               priority="primary"

--- a/apps/client/src/styles/index.css
+++ b/apps/client/src/styles/index.css
@@ -4,11 +4,17 @@
 @import 'tailwindcss/utilities.css' layer(utilities) important;
 
 @theme {
+  --text-sm-plus: 0.9375rem;
+
   --breakpoint-sm: 36rem;
   --breakpoint-md: 48rem;
   --breakpoint-lg: 62rem;
   --breakpoint-xl: 78rem;
   --breakpoint-2xl: 94rem;
+}
+
+@utility btn-compact {
+  @apply min-h-9! px-3.5! py-1.5! text-sm-plus!;
 }
 
 /*


### PR DESCRIPTION
- Observations are now shown in the side panel (observer list + reading pane)
- An observation must carry a text or an attachment to be submitted
- The summary and its attachments are displayed in the side panel
- ARIA patterns applied: tabs on the observation list, combobox on the magistrat search
- `ObservationForm` split: combobox, attachment linking and existing files extracted

#### ⚠️ Pending PO / design

Two implementations of the observer card coexist, waiting wait for PO and design feedback