### PR TITLE
fix(FON-500): remove obsolete sheetjs step from storybook workflow

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -33,10 +33,6 @@ jobs:
           node-version: '24.12.0'
           cache: 'pnpm'
 
-      - name: install sheetjs
-        shell: bash
-        run: ./scripts/sheetjs.sh
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
Removes the obsolete `install sheetjs` step, matching the other workflows
