### PR TITLE
fix(FON-500): isolate storybook queries from network with infinite staleTime

### DIFF
--- a/apps/client/src/shared/storybook/StoryQueryClient.tsx
+++ b/apps/client/src/shared/storybook/StoryQueryClient.tsx
@@ -4,7 +4,10 @@ import { useState, type ReactNode } from 'react';
 export function StoryQueryClient(props: { children: ReactNode; seed?: (client: QueryClient) => void }) {
   const [client] = useState(() => {
     const client = new QueryClient({
-      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false, staleTime: Infinity },
+      },
     });
     props.seed?.(client);
     return client;


### PR DESCRIPTION
Observation stories showed seeded data in dev but rendered empty on the deployed Storybook