### PR TITLE
fix(FON-502): pre-bundle tiptap deps to prevent stale optimize-dep 504 on lazy routes

### DIFF
--- a/apps/client/src/pages/error/ErrorPage.tsx
+++ b/apps/client/src/pages/error/ErrorPage.tsx
@@ -2,6 +2,7 @@ import type { ButtonProps } from '@codegouvfr/react-dsfr/Button';
 import ButtonsGroup from '@codegouvfr/react-dsfr/ButtonsGroup';
 import { cx } from '@codegouvfr/react-dsfr/fr/cx';
 import TechnicalError from '@codegouvfr/react-dsfr/picto/TechnicalError';
+import { isRouteErrorResponse, useRouteError } from 'react-router';
 
 import { useIsSg } from '@/features/auth/hooks/roles.hook';
 import { PageLayout } from '@/layout/PageLayout';
@@ -12,6 +13,7 @@ import { useUser } from '@queries/auth.queries';
 export function ErrorPage() {
   const { user } = useUser();
   const isSg = useIsSg();
+  const error = useRouteError();
 
   const buttons: ButtonProps[] = [];
 
@@ -61,7 +63,9 @@ export function ErrorPage() {
         >
           <div className={cx('fr-py-0', 'fr-col-12', 'fr-col-md-6')}>
             <h1>Erreur inattendue</h1>
-            <p className={cx('fr-text--sm', 'fr-mb-6v')}>Erreur 500</p>
+            <p className={cx('fr-text--sm', 'fr-mb-6v')}>
+              {isRouteErrorResponse(error) ? `Erreur ${error.status}` : 'Erreur applicative'}
+            </p>
             <p className={cx('fr-text--lead', 'fr-mb-6v')}>
               Désolé, le service rencontre un problème, nous travaillons pour le résoudre le plus rapidement
               possible.

--- a/apps/client/src/queries/observations.queries.ts
+++ b/apps/client/src/queries/observations.queries.ts
@@ -168,7 +168,7 @@ export function useDeleteObservationMutation() {
     }): Promise<void> => {
       await $api.observations.deleteObservation({
         path: {
-          sessionId: mutation.nominationFileId,
+          sessionId: mutation.sessionId,
           nominationFileId: mutation.nominationFileId,
           observationId: mutation.observationId,
         },

--- a/apps/client/tsconfig.node.json
+++ b/apps/client/tsconfig.node.json
@@ -8,6 +8,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -6,6 +6,8 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+import pkg from './package.json' with { type: 'json' };
+
 process.env.VITE_FAVICON = process.env.VITE_DEPLOY_ENV === 'production' ? 'favicon' : 'favicon.staging';
 
 // https://vite.dev/config/
@@ -30,6 +32,14 @@ export default defineConfig({
     formatjs({ ast: true }),
   ],
   css: { lightningcss: { errorRecovery: true } },
+  // TipTap is only reached through lazy routes: pre-bundling it avoids a mid-session
+  // re-optimization (504 "Outdated Optimize Dep" on navigation). @tiptap/pm is
+  // excluded because it only has subpath exports
+  optimizeDeps: {
+    include: Object.keys(pkg.dependencies).filter(
+      (dep) => dep.startsWith('@tiptap/') && dep !== '@tiptap/pm',
+    ),
+  },
   build: {
     commonjsOptions: {
       include: [/node_modules/],

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -5,6 +5,8 @@ import viteConfig from './vite.config';
 export default mergeConfig(
   viteConfig,
   defineConfig({
+    // Two Vite processes sharing node_modules/.vite corrupt each other's optimized deps
+    cacheDir: 'node_modules/.vitest',
     test: {
       globals: true,
       environment: 'jsdom',


### PR DESCRIPTION
- vite.config.ts: pre-bundle all `@tiptap/*` dependencies at startup (`optimizeDeps.include` derived from `package.json`, `@tiptap/pm` excluded as it only has subpath exports)
- vitest.config.ts: dedicated `cacheDir` so vitest no longer shares `node_modules/.vite` with the dev server
- ErrorPage.tsx: display the actual HTTP status via `useRouteError()` instead of a hardcoded "Erreur 500" (front crashes no longer masquerade as server errors)
- observations.queries.ts: `useDeleteObservationMutation` passed `nominationFileId` as `sessionId` in the delete path
- tsconfig.node.json: enable `resolveJsonModule` for the `package.json` import in the Vite config
