### PR TITLE
fix(FON-502): move vite cache out of react-dsfr update-icons clear path

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -16,7 +16,7 @@
     "test": "vitest",
     "test:watch": "vitest",
     "update-icons": "react-dsfr update-icons",
-    "predev": "pnpm run update-icons",
+    "predev": "pnpm run update-icons && node -e \"fs.rmSync('node_modules/.vite-app', { recursive: true, force: true })\"",
     "prebuild": "pnpm run update-icons",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
     formatjs({ ast: true }),
   ],
   css: { lightningcss: { errorRecovery: true } },
+  // react-dsfr update-icons (predev / prestorybook hook) deletes node_modules/.vite:
+  // keep the dev server cache out of its reach so launching storybook does not
+  // corrupt a running dev server (predev clears this cache instead)
+  cacheDir: 'node_modules/.vite-app',
   // TipTap is only reached through lazy routes: pre-bundling it avoids a mid-session
   // re-optimization (504 "Outdated Optimize Dep" on navigation). @tiptap/pm is
   // excluded because it only has subpath exports

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -5,7 +5,8 @@ import viteConfig from './vite.config';
 export default mergeConfig(
   viteConfig,
   defineConfig({
-    // Two Vite processes sharing node_modules/.vite corrupt each other's optimized deps
+    // Without this override vitest inherits the dev server cacheDir and two Vite
+    // processes sharing a cache corrupt each other's optimized deps
     cacheDir: 'node_modules/.vitest',
     test: {
       globals: true,


### PR DESCRIPTION
Follow-up to #487: the error came back after every Storybook launch.

react-dsfr's `update-icons` (a `prestorybook` hook) deletes `node_modules/.vite` wiping the running dev server's cache. Lazy pages then fail with a 504 until Vite rebuilds, hence the "fails every other time".

Fix: move the dev cache to `node_modules/.vite-app` out of the script's reach. `predev` still clears it at startup
