### PR TITLE
chore(FON-000): use rm -rf over node fs.rmSync in predev cache clear

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -16,7 +16,7 @@
     "test": "vitest",
     "test:watch": "vitest",
     "update-icons": "react-dsfr update-icons",
-    "predev": "pnpm run update-icons && node -e \"fs.rmSync('node_modules/.vite-app', { recursive: true, force: true })\"",
+    "predev": "pnpm run update-icons && rm -rf node_modules/.vite-app",
     "prebuild": "pnpm run update-icons",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",


### PR DESCRIPTION
Use a plain rm -rf instead of the node fs.rmSync one-liner in the predev cache clear (review follow-up, more readable, team is unix-only)