### PR TITLE
feat(FON-514): audit public endpoints on push to develop

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Create buckets if necessary
         run: node apps/api/scripts/init-buckets.js
 
-      - name: Generate OpenAPI clients
+      - name: Generate OpenAPI clients and check public endpoints
         shell: bash
         run: |
           setsid pnpm --filter api start:e2e &
@@ -86,6 +86,7 @@ jobs:
           timeout 90 bash -c 'until curl -sf http://localhost:3000/openapi/root.json > /dev/null; do sleep 1; done'
 
           pnpm run openapi:generate
+          node apps/api/scripts/check-public-endpoints.mjs
         env:
           PORT: '3000'
 
@@ -119,3 +120,36 @@ jobs:
             --head "$branch" \
             --title "chore(FON-000): sync generated OpenAPI clients" \
             --body "Generated OpenAPI clients drifted from the contract on \`develop\`. This PR regenerates them via \`pnpm run openapi:generate\`."
+
+      - name: Open a pull request when public endpoints allowlist drifts
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_ACTOR: ${{ github.actor }}
+          GIT_ACTOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+        run: |
+          if [ -z "$(git status --porcelain -- apps/api/public-endpoints.json)" ]; then
+            echo "Public endpoints allowlist is already up to date."
+            exit 0
+          fi
+
+          branch="chore/openapi-public-endpoints"
+          git config user.name "$GIT_ACTOR"
+          git config user.email "$GIT_ACTOR_EMAIL"
+          git stash push -- apps/api/public-endpoints.json
+          git checkout -B "$branch" origin/develop
+          git stash pop
+          git add apps/api/public-endpoints.json
+          git commit -m "chore(FON-000): sync public endpoints allowlist"
+          git push --force origin "$branch"
+
+          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            echo "An open pull request already tracks $branch; it now points at the fresh commit."
+            exit 0
+          fi
+
+          gh pr create \
+            --base develop \
+            --head "$branch" \
+            --title "chore(FON-000): sync public endpoints allowlist" \
+            --body "The public endpoints allowlist at \`apps/api/public-endpoints.json\` drifted from the OpenAPI document on \`develop\`. Review the diff carefully: **any new entry means an endpoint is now exposed without authentication requirement**. Confirm this is intentional, and add a comment above the entry explaining why it must stay public."

--- a/apps/api/public-endpoints.json
+++ b/apps/api/public-endpoints.json
@@ -1,0 +1,16 @@
+{
+  "endpoints": [
+    {
+      "operation": "callback",
+      "reason": "openid auth"
+    },
+    {
+      "operation": "listOpenIdProviders",
+      "reason": "openid auth"
+    },
+    {
+      "operation": "prepareOpenIdRequest",
+      "reason": "openid auth"
+    }
+  ]
+}

--- a/apps/api/scripts/check-public-endpoints.mjs
+++ b/apps/api/scripts/check-public-endpoints.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import previous from '../public-endpoints.json' with { type: 'json' };
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ALLOWLIST_PATH = join(HERE, '..', 'public-endpoints.json');
+const OPENAPI_URL = process.env.OPENAPI_URL || 'http://localhost:3000/openapi/root.json';
+const MISSING_REASON = 'TODO — explain why this endpoint must stay public';
+
+async function main() {
+  const doc = await fetchOpenApiDocument();
+  const discovered = collectPublicOperationIds(doc);
+  const previousByOperation = new Map(previous.endpoints.map((entry) => [entry.operation, entry.reason]));
+
+  const nextEndpoints = discovered.toSorted().map((operation) => ({
+    operation,
+    reason: previousByOperation.get(operation) ?? MISSING_REASON,
+  }));
+
+  const serialized = JSON.stringify({ endpoints: nextEndpoints }, null, 2) + '\n';
+  const previousSerialized = JSON.stringify(previous, null, 2) + '\n';
+
+  if (serialized === previousSerialized) {
+    console.log(`No drift — ${discovered.size} public endpoint(s) still match ${ALLOWLIST_PATH}.`);
+    return;
+  }
+
+  await writeFile(ALLOWLIST_PATH, serialized);
+  const added = discovered.filter((id) => !previousByOperation.has(id)).sort();
+  const removed = [...previousByOperation.keys()].filter((id) => !discovered.has(id)).sort();
+  console.log(`Rewrote ${ALLOWLIST_PATH}.`);
+  if (added.length) console.log(`  Added:   ${added.join(', ')}`);
+  if (removed.length) console.log(`  Removed: ${removed.join(', ')}`);
+}
+
+async function fetchOpenApiDocument() {
+  const response = await fetch(OPENAPI_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${OPENAPI_URL}: HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace']);
+
+function collectPublicOperationIds(doc) {
+  const globalSecurity = Array.isArray(doc.security) ? doc.security : [];
+  const publicOperationIds = new Set();
+  for (const [path, item] of Object.entries(doc.paths ?? {})) {
+    for (const [method, operation] of Object.entries(item ?? {})) {
+      if (!HTTP_METHODS.has(method)) continue;
+      if (!operation || typeof operation !== 'object') continue;
+      const security = Array.isArray(operation.security) ? operation.security : globalSecurity;
+      if (security.length > 0) continue;
+      const operationId = operation.operationId;
+      if (!operationId) {
+        throw new Error(`Public operation without operationId: ${method.toUpperCase()} ${path}`);
+      }
+      publicOperationIds.add(operationId);
+    }
+  }
+  return publicOperationIds;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/api/src/modules/docs/presentation-plan/presentation-plans.controller.ts
+++ b/apps/api/src/modules/docs/presentation-plan/presentation-plans.controller.ts
@@ -45,6 +45,7 @@ import { PresentationPlansService } from './presentation-plans.service';
 export class PresentationPlansController {
   constructor(private readonly presentationPlans: PresentationPlansService) {}
 
+  @HasRole('ADJOINT_SECRETAIRE_GENERAL')
   @Get('/presentation-plans/agendas')
   @ApiQuery({ name: 'ignore', required: false, type: 'string', format: 'uuid' })
   @ZodResponse({ status: HttpStatus.OK, type: FoundAgendasDto })

--- a/apps/api/src/modules/framework/files/files.controller.ts
+++ b/apps/api/src/modules/framework/files/files.controller.ts
@@ -1,12 +1,15 @@
 import { Controller, Get, Param, ParseUUIDPipe, Query, Res, StreamableFile } from '@nestjs/common';
 import type { Response as ExpressResponse } from 'express';
 
+import { HasRole } from 'src/modules/simple-auth';
+
 import { Files } from './files';
 
 @Controller('/api/files/v1')
 export class FilesController {
   constructor(private readonly files: Files) {}
 
+  @HasRole()
   @Get('/:fileUrlId')
   async getFileByFileUrl(
     @Res({ passthrough: true }) res: ExpressResponse,

--- a/apps/api/src/modules/observation/magistrat.controller.ts
+++ b/apps/api/src/modules/observation/magistrat.controller.ts
@@ -39,6 +39,7 @@ export class MagistratController {
     });
   }
 
+  @HasRole()
   @Get('fullname')
   searchFullName(@Query('search') search: string) {
     return this.prisma.$queryRawTyped(findMagistratExternalIdByFullName(unaccent(search.toLowerCase())));

--- a/apps/api/src/modules/session/summaries/summary.controller.ts
+++ b/apps/api/src/modules/session/summaries/summary.controller.ts
@@ -185,6 +185,7 @@ export class SummaryController {
     });
   }
 
+  @HasRole('ADJOINT_SECRETAIRE_GENERAL')
   @Get('/readers')
   @ZodResponse({ status: HttpStatus.OK, type: FoundSummaryReadersDto })
   @UsePipes(ZodValidationPipe)


### PR DESCRIPTION
## Summary

- Add `apps/api/scripts/check-public-endpoints.mjs`, run on every push to `develop` after client generation. It fetches `/openapi/root.json`, collects every `operationId` whose `security` is missing or empty, and syncs `apps/api/public-endpoints.json`. The script imports the current allowlist as a JSON dependency — no custom parser.
- When the allowlist drifts, the workflow opens (or updates) a separate PR on `chore/openapi-public-endpoints`. Any new entry there is a red flag: an endpoint is publicly reachable without authentication.
- The initial run surfaced four endpoints that were unintentionally public. This PR protects them at the source:
  - `getFileByFileUrl`, `searchFullName` → `@HasRole()`
  - `listPresentationPlanAgendas`, `searchSummaryReaders` → `@HasRole('ADJOINT_SECRETAIRE_GENERAL')`
- Seed `apps/api/public-endpoints.json` with the three legitimate OIDC entry points (`callback`, `listOpenIdProviders`, `prepareOpenIdRequest`), each with `reason: openid auth`.

## Why

There was no automated signal when a Nest handler landed on `develop` without a `@HasRole` (or explicit `@ApiBearerAuth` / `@ApiBasicAuth`). Since security in the OpenAPI document is driven by those decorators (see `simple-auth.decorator.ts` and `framework/openapi.ts`), a missing decorator = a publicly reachable route. The audit turns that silent failure mode into a PR to review.

## How it fits together

- The check reuses the existing `openapi.yml` job — the API is already booted and `/openapi/root.json` already served, so it's a single extra step, no duplicated boot cost.
- Failure model: the script never fails on drift, it rewrites the file. It's the `git status` in the workflow that triggers the PR (same pattern as the existing client-sync PR).

## Test plan

- [ ] CI green on this PR (types, lint, build).
- [ ] After merge, verify the `openapi.yml` run on `develop`:
  - [ ] It runs the check step without failing.
  - [ ] `apps/api/public-endpoints.json` still contains only the three OIDC entries → no drift PR opened.
- [ ] Follow-up validation (separate PR, not required here): introduce a new `@Get` without `@HasRole` on a branch, merge to `develop`, confirm a `chore/openapi-public-endpoints` PR is opened with the new operationId and a `TODO` reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)