### PR TITLE
refactor(FON-513): moves the member layouts into the router and the magistrat details out of the transparence path

### DIFF
--- a/apps/client/src/pages/spaces/member/MemberContentLayout.tsx
+++ b/apps/client/src/pages/spaces/member/MemberContentLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router';
+
+import { PageContentLayout } from '@/shared/ui/PageContentLayout';
+
+export function MemberContentLayout() {
+  return (
+    <PageContentLayout>
+      <Outlet />
+    </PageContentLayout>
+  );
+}

--- a/apps/client/src/pages/spaces/member/MemberLayout.tsx
+++ b/apps/client/src/pages/spaces/member/MemberLayout.tsx
@@ -1,24 +1,12 @@
-import { Outlet, useLocation, useParams } from 'react-router';
+import { Outlet } from 'react-router';
 
 import { AuthGuard } from '@/features/auth/components/AuthGuard';
 import { AUTHORIZED_ROLES } from '@/features/auth/constants/authorized-roles.constants';
-import { PageContentLayout } from '@/shared/ui/PageContentLayout';
 
 export function MemberLayout() {
-  const params = useParams();
-  const { pathname } = useLocation();
-
-  const isReportOverview = !!params.id;
-
-  let children = (
-    <PageContentLayout fullBackgroundOrange={isReportOverview}>
+  return (
+    <AuthGuard authorizedRoles={AUTHORIZED_ROLES.MEMBER}>
       <Outlet />
-    </PageContentLayout>
+    </AuthGuard>
   );
-
-  if (pathname.includes('observations') || pathname.includes('magistrats')) {
-    children = <Outlet />;
-  }
-
-  return <AuthGuard authorizedRoles={AUTHORIZED_ROLES.MEMBER}>{children}</AuthGuard>;
 }

--- a/apps/client/src/pages/spaces/member/MemberReportOverviewLayout.tsx
+++ b/apps/client/src/pages/spaces/member/MemberReportOverviewLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router';
+
+import { PageContentLayout } from '@/shared/ui/PageContentLayout';
+
+export function MemberReportOverviewLayout() {
+  return (
+    <PageContentLayout fullBackgroundOrange>
+      <Outlet />
+    </PageContentLayout>
+  );
+}

--- a/apps/client/src/router.tsx
+++ b/apps/client/src/router.tsx
@@ -4,7 +4,7 @@ import { createBrowserRouter } from 'react-router';
 import { RootLayout } from '@/layout/RootLayout';
 import { LoginPage } from '@/pages/auth/LoginPage';
 import { ErrorPage } from '@/pages/error/ErrorPage';
-import { ROUTE_PATHS } from '@/utils/route-path.utils';
+import { redirectToMemberMagistratDetails, ROUTE_PATHS } from '@/utils/route-path.utils';
 
 const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV7(createBrowserRouter);
 export const router = sentryCreateBrowserRouter([
@@ -48,32 +48,47 @@ export const router = sentryCreateBrowserRouter([
           })),
       },
       {
-        path: ROUTE_PATHS.TRANSPARENCES.DASHBOARD,
         lazy: () =>
           import('@/pages/spaces/member/MemberLayout').then(({ MemberLayout }) => ({
             Component: MemberLayout,
           })),
         children: [
           {
-            index: true,
             lazy: () =>
-              import('@/pages/transparence/SessionsPage').then(({ SessionsPage }) => ({
-                Component: SessionsPage,
+              import('@/pages/spaces/member/MemberContentLayout').then(({ MemberContentLayout }) => ({
+                Component: MemberContentLayout,
               })),
+            children: [
+              {
+                path: ROUTE_PATHS.TRANSPARENCES.DASHBOARD,
+                lazy: () =>
+                  import('@/pages/transparence/SessionsPage').then(({ SessionsPage }) => ({
+                    Component: SessionsPage,
+                  })),
+              },
+              {
+                path: ROUTE_PATHS.TRANSPARENCES.DETAIL_SESSION_GDS,
+                lazy: () =>
+                  import('@/pages/reports/ReportListPage').then(({ default: ReportListPage }) => ({
+                    Component: ReportListPage,
+                  })),
+              },
+            ],
           },
           {
-            path: ROUTE_PATHS.TRANSPARENCES.DETAIL_SESSION_GDS,
             lazy: () =>
-              import('@/pages/reports/ReportListPage').then(({ default: ReportListPage }) => ({
-                Component: ReportListPage,
-              })),
-          },
-          {
-            path: ROUTE_PATHS.TRANSPARENCES.DETAILS_REPORTS,
-            lazy: () =>
-              import('@/pages/reports/ReportOverviewPage').then(({ default: ReportOverviewPage }) => ({
-                Component: ReportOverviewPage,
-              })),
+              import('@/pages/spaces/member/MemberReportOverviewLayout').then(
+                ({ MemberReportOverviewLayout }) => ({ Component: MemberReportOverviewLayout }),
+              ),
+            children: [
+              {
+                path: ROUTE_PATHS.TRANSPARENCES.DETAILS_REPORTS,
+                lazy: () =>
+                  import('@/pages/reports/ReportOverviewPage').then(({ default: ReportOverviewPage }) => ({
+                    Component: ReportOverviewPage,
+                  })),
+              },
+            ],
           },
           {
             path: ROUTE_PATHS.TRANSPARENCES.OBSERVATION_DETAILS,
@@ -83,11 +98,15 @@ export const router = sentryCreateBrowserRouter([
               })),
           },
           {
-            path: ROUTE_PATHS.TRANSPARENCES.MAGISTRAT_DETAILS,
+            path: ROUTE_PATHS.MEMBER.MAGISTRAT_DETAILS,
             lazy: () =>
               import('@/pages/magistrats/MagistratDetailsPage').then(({ MagistratDetailsPage }) => ({
                 Component: MagistratDetailsPage,
               })),
+          },
+          {
+            path: ROUTE_PATHS.TRANSPARENCES.MAGISTRAT_DETAILS,
+            loader: redirectToMemberMagistratDetails,
           },
         ],
       },

--- a/apps/client/src/shared/components/details-link/DetailsLink.test.tsx
+++ b/apps/client/src/shared/components/details-link/DetailsLink.test.tsx
@@ -38,7 +38,7 @@ describe('DetailsLink', () => {
 
     expect(screen.getByRole('link', { name: 'Fiche détails du magistrat' })).toHaveAttribute(
       'href',
-      '/transparences/pouvoir-de-proposition-du-garde-des-sceaux/magistrats/magistrat-1',
+      '/magistrats/magistrat-1',
     );
   });
 

--- a/apps/client/src/utils/route-path.utils.test.ts
+++ b/apps/client/src/utils/route-path.utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { redirectToMemberMagistratDetails } from './route-path.utils';
+
+describe('redirectToMemberMagistratDetails', () => {
+  it('redirects the old transparence URL to the member magistrat details page', () => {
+    const response = redirectToMemberMagistratDetails({
+      params: { magistratId: 'magistrat-1' },
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/magistrats/magistrat-1');
+  });
+});

--- a/apps/client/src/utils/route-path.utils.ts
+++ b/apps/client/src/utils/route-path.utils.ts
@@ -1,4 +1,4 @@
-import { generatePath } from 'react-router';
+import { generatePath, redirect } from 'react-router';
 
 export const ROUTE_PATHS = {
   LOGIN: '/login',
@@ -11,6 +11,9 @@ export const ROUTE_PATHS = {
     OBSERVATION_DETAILS:
       '/transparences/pouvoir-de-proposition-du-garde-des-sceaux/sessions/:sessionId/dossiers/:nominationFileId/observations/:observationId',
     MAGISTRAT_DETAILS: '/transparences/pouvoir-de-proposition-du-garde-des-sceaux/magistrats/:magistratId',
+  },
+  MEMBER: {
+    MAGISTRAT_DETAILS: '/magistrats/:magistratId',
   },
   SG: {
     DASHBOARD: '/secretariat-general',
@@ -98,9 +101,13 @@ export const getObservationDetailsPath = (props: {
   });
 };
 
+// TODO: remove once the old member URL has faded from bookmarks and shared links
+export const redirectToMemberMagistratDetails = ({ params }: { params: { magistratId?: string } }) =>
+  redirect(getMagistratDetailsPath({ context: 'membre', magistratId: params.magistratId ?? '' }));
+
 export const getMagistratDetailsPath = (props: { magistratId: string; context: 'sg' | 'membre' }) => {
   if (props.context === 'membre') {
-    return generatePath(ROUTE_PATHS.TRANSPARENCES.MAGISTRAT_DETAILS, { magistratId: props.magistratId });
+    return generatePath(ROUTE_PATHS.MEMBER.MAGISTRAT_DETAILS, { magistratId: props.magistratId });
   }
 
   return generatePath(ROUTE_PATHS.SG.MAGISTRAT_DETAILS, { magistratId: props.magistratId });


### PR DESCRIPTION
- `MemberLayout` only keeps the `AuthGuard`: layouts are picked by the router through three pathless groups
- Adding a full-frame page no longer touches the layout: bare route + its own background through `DetailsPageLayout`
- Member magistrat details moves to `/magistrats/:magistratId` (SG mirror)
- Legacy URL redirects through a data-mode loader (TODO for removal)

### Note

- `PageContentLayout` keeps its background props: they go away with the observation details and report overview reworks (existing FIXME)