### PR TITLE
fix(FON-000): keeps the session on technical errors in the role guard

### DIFF
--- a/apps/client/src/features/auth/guards/role-guard.test.ts
+++ b/apps/client/src/features/auth/guards/role-guard.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AUTHORIZED_ROLES } from '../constants/authorized-roles.constants';
+import { sessionQueryOptions } from '@queries/auth.queries';
+import { queryClient } from '@queries/query-client';
 
-import { isAuthorized } from './role-guard';
+import { isAuthorized, roleGuard } from './role-guard';
 
 describe('isAuthorized', () => {
   it('rejects an anonymous user', () => {
@@ -22,5 +24,49 @@ describe('isAuthorized', () => {
 
   it('always accepts the admin, even with an empty allowlist', () => {
     expect(isAuthorized({ role: 'ADMIN' }, AUTHORIZED_ROLES.NONE)).toBe(true);
+  });
+});
+
+describe('roleGuard', () => {
+  const member = {
+    id: '5f6478c1-46a1-4b64-8cbd-4a0d67101d7e',
+    role: 'MEMBRE_DU_SIEGE' as const,
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    isImpersonated: false,
+    civility: 'Madame LOVELACE',
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    queryClient.clear();
+  });
+
+  it('lets an authorized user through', async () => {
+    vi.spyOn(queryClient, 'ensureQueryData').mockResolvedValue(member);
+
+    await expect(roleGuard(AUTHORIZED_ROLES.MEMBER)()).resolves.toBeNull();
+  });
+
+  it('redirects an unauthenticated user to the login page', async () => {
+    vi.spyOn(queryClient, 'ensureQueryData').mockResolvedValue(null);
+
+    const response = await roleGuard(AUTHORIZED_ROLES.MEMBER)();
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+  });
+
+  it('keeps the cached session on a technical error', async () => {
+    vi.spyOn(queryClient, 'ensureQueryData').mockRejectedValue(new Error('network down'));
+    queryClient.setQueryData(sessionQueryOptions.queryKey, member);
+
+    await expect(roleGuard(AUTHORIZED_ROLES.MEMBER)()).resolves.toBeNull();
+  });
+
+  it('rethrows a technical error when no session is cached', async () => {
+    vi.spyOn(queryClient, 'ensureQueryData').mockRejectedValue(new Error('network down'));
+
+    await expect(roleGuard(AUTHORIZED_ROLES.MEMBER)()).rejects.toThrow('network down');
   });
 });

--- a/apps/client/src/features/auth/guards/role-guard.ts
+++ b/apps/client/src/features/auth/guards/role-guard.ts
@@ -13,7 +13,11 @@ export function isAuthorized(
 
 export function roleGuard(authorizedRoles: readonly unknown[]) {
   return async () => {
-    const user = await queryClient.ensureQueryData(sessionQueryOptions).catch(() => null);
+    const user = await queryClient.ensureQueryData(sessionQueryOptions).catch((error) => {
+      const cached = queryClient.getQueryData(sessionQueryOptions.queryKey);
+      if (cached === undefined) throw error;
+      return cached;
+    });
 
     if (isAuthorized(user, authorizedRoles)) return null;
 

--- a/apps/client/src/pages/help/HelpPage.tsx
+++ b/apps/client/src/pages/help/HelpPage.tsx
@@ -1,4 +1,5 @@
 import Button from '@codegouvfr/react-dsfr/Button';
+import { FormattedMessage } from 'react-intl';
 
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 
@@ -6,23 +7,25 @@ export function HelpPage() {
   return (
     <article className="fr-container fr-py-10v mx-auto w-5/12 min-w-4xl">
       <h1 className="flex justify-between">
-        <span>Aide au traitement des dossiers</span>
+        <span>
+          <FormattedMessage defaultMessage="Aide au traitement des dossiers" />
+        </span>
         <Button
-          size="large"
-          priority="tertiary no outline"
-          linkProps={{ to: ROUTE_PATHS.USER_MANUAL }}
           iconId="fr-icon-booklet-fill"
+          linkProps={{ to: ROUTE_PATHS.USER_MANUAL }}
+          priority="tertiary no outline"
+          size="large"
         >
-          Manuel utilisateur
+          <FormattedMessage defaultMessage="Manuel utilisateur" />
         </Button>
       </h1>
 
       <iframe
-        src="https://pineapple-passive-82f.notion.site/ebd//29ba2ff25f15805d8ffaf36cb60c54f9"
         allowFullScreen
-        width="100%"
+        className="border-0"
         height="600"
-        frameBorder="0"
+        src="https://pineapple-passive-82f.notion.site/ebd//29ba2ff25f15805d8ffaf36cb60c54f9"
+        width="100%"
       />
     </article>
   );

--- a/apps/client/src/pages/help/HelpPageButton.tsx
+++ b/apps/client/src/pages/help/HelpPageButton.tsx
@@ -1,4 +1,5 @@
 import Button from '@codegouvfr/react-dsfr/Button';
+import { FormattedMessage } from 'react-intl';
 
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import { useUser } from '@queries/auth.queries';
@@ -10,11 +11,11 @@ export function HelpPageButton() {
 
   return (
     <Button
-      linkProps={{ to: ROUTE_PATHS.HELP }}
-      iconId="fr-icon-questionnaire-line"
       className="fr-mb-0 self-center"
+      iconId="fr-icon-questionnaire-line"
+      linkProps={{ to: ROUTE_PATHS.HELP }}
     >
-      Centre d'aide
+      <FormattedMessage defaultMessage="Centre d'aide" />
     </Button>
   );
 }

--- a/apps/client/src/pages/help/UserManualPage.tsx
+++ b/apps/client/src/pages/help/UserManualPage.tsx
@@ -1,3 +1,5 @@
+import { FormattedMessage } from 'react-intl';
+
 import { useIsSg } from '@/features/auth/hooks/roles.hook';
 
 export function UserManualPage() {
@@ -10,11 +12,13 @@ export function UserManualPage() {
   );
 }
 
-function UserManualHeading(props: { children: string }) {
+function UserManualHeading(props: { children: React.ReactNode }) {
   return (
     <header className="fr-mb-8v">
       <h1 className="flex items-center justify-center">
-        <span>Manuel utilisateur</span>
+        <span>
+          <FormattedMessage defaultMessage="Manuel utilisateur" />
+        </span>
         <span className="fr-h3 fr-my-0 fr-ml-2v fr-pl-2v border-y-0 border-r-0 border-l-2 border-solid">
           {props.children}
         </span>
@@ -26,14 +30,16 @@ function UserManualHeading(props: { children: string }) {
 function MemberUserManual() {
   return (
     <>
-      <UserManualHeading>Membre</UserManualHeading>
+      <UserManualHeading>
+        <FormattedMessage defaultMessage="Membre" />
+      </UserManualHeading>
 
       <iframe
+        allowFullScreen
+        className="border-0"
+        height="600"
         src="https://pineapple-passive-82f.notion.site/ebd/2a2a2ff25f158025be23dd4e924eb9ec"
         width="100%"
-        height="600"
-        frameBorder={0}
-        allowFullScreen
       />
     </>
   );
@@ -42,13 +48,15 @@ function MemberUserManual() {
 function SGUserManual() {
   return (
     <>
-      <UserManualHeading>Secrétariat Général</UserManualHeading>
+      <UserManualHeading>
+        <FormattedMessage defaultMessage="Secrétariat Général" />
+      </UserManualHeading>
       <iframe
+        allowFullScreen
+        className="border-0"
+        height="600"
         src="https://pineapple-passive-82f.notion.site/ebd/2a2a2ff25f1580a7a9e0f4c88a308d5a"
         width="100%"
-        height="600"
-        frameBorder={0}
-        allowFullScreen
       />
     </>
   );


### PR DESCRIPTION
Follow-up of FON-515 (#528): a technical failure of `introspectSession` (API restarting, network error) was treated as "not authenticated" and redirected to the login page

- `roleGuard` redirects to login only on a genuine 401 (the query fn already resolves it to `null`)
- Technical errors propagate to the router's `ErrorPage` instead of faking a logout (with a cached-session fallback for in-flight races)
