### PR TITLE
fix(FON-525): render tooltips in the top layer to stop table clipping

### DIFF
--- a/apps/client/.storybook/preview.tsx
+++ b/apps/client/.storybook/preview.tsx
@@ -5,6 +5,7 @@ import addonA11y from '@storybook/addon-a11y';
 import addonDocs from '@storybook/addon-docs';
 import { definePreview } from '@storybook/react-vite';
 import addonMsw from 'msw-storybook-addon';
+import { NuqsAdapter } from 'nuqs/adapters/react-router/v7';
 import { IntlProvider } from 'react-intl';
 import { Link, MemoryRouter, Route, Routes } from 'react-router';
 
@@ -23,15 +24,17 @@ export default definePreview({
       const router = context.parameters.router as { initialEntries?: string[]; path?: string } | undefined;
       return (
         <MemoryRouter initialEntries={router?.initialEntries}>
-          <IntlProvider defaultLocale="fr" formats={frFormat} locale="fr">
-            {router?.path ? (
-              <Routes>
-                <Route element={<Story />} path={router.path} />
-              </Routes>
-            ) : (
-              <Story />
-            )}
-          </IntlProvider>
+          <NuqsAdapter>
+            <IntlProvider defaultLocale="fr" formats={frFormat} locale="fr">
+              {router?.path ? (
+                <Routes>
+                  <Route element={<Story />} path={router.path} />
+                </Routes>
+              ) : (
+                <Story />
+              )}
+            </IntlProvider>
+          </NuqsAdapter>
         </MemoryRouter>
       );
     },

--- a/apps/client/src/features/members/components/JurisdictionSelector.tsx
+++ b/apps/client/src/features/members/components/JurisdictionSelector.tsx
@@ -2,8 +2,9 @@ import Button from '@codegouvfr/react-dsfr/Button';
 import { createModal } from '@codegouvfr/react-dsfr/Modal';
 import { useIsModalOpen } from '@codegouvfr/react-dsfr/Modal/useIsModalOpen';
 import Tag from '@codegouvfr/react-dsfr/Tag';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import { useState } from 'react';
+
+import { Tooltip } from '@/shared/ui/tooltip';
 
 import { JuridictionAutocomplete } from './JurisdictionAutocomplete';
 
@@ -22,7 +23,7 @@ function JurisdictionSelectorSelected(props: { selected: readonly { id: string; 
           <li className="shrink-0 whitespace-nowrap">
             <Tooltip
               className="shrink-0"
-              title={
+              label={
                 <ul>
                   {props.selected.map(({ label, id }) => (
                     <li key={`excluded_jurisdictions_tooltip_${id}`}>{label ?? id}</li>

--- a/apps/client/src/features/nomination-files-table/components/ExcludedJurisdictionIcon.tsx
+++ b/apps/client/src/features/nomination-files-table/components/ExcludedJurisdictionIcon.tsx
@@ -1,8 +1,9 @@
 import { colors } from '@codegouvfr/react-dsfr';
 import { cx } from '@codegouvfr/react-dsfr/fr/cx';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import clsx from 'clsx';
 import { useIntl } from 'react-intl';
+
+import { Tooltip } from '@/shared/ui/tooltip';
 
 const ICON_CLASS = clsx(cx('fr-icon-warning-fill'), 'fr-icon--sm', 'shrink-0', 'align-middle');
 const ICON_STYLE = { color: colors.decisions.text.default.warning.default };
@@ -13,7 +14,7 @@ export function ExcludedJurisdictionIcon(props: { title?: string }) {
   if (!props.title) return <i aria-hidden className={ICON_CLASS} style={ICON_STYLE} />;
 
   return (
-    <Tooltip title={props.title}>
+    <Tooltip label={props.title}>
       <i
         aria-label={formatMessage({ defaultMessage: 'Juridiction exclue' })}
         className={ICON_CLASS}

--- a/apps/client/src/features/nomination-files-table/components/MemberSessionFilesTable.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/MemberSessionFilesTable.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { AlertsProvider } from '@/shared/context/alerts';
+import { authHandlers } from '@/shared/storybook/msw.handlers';
+import { sessionFiles, sessionMemberReports } from '@/shared/storybook/session-files.fixtures';
+import { makeSessionHandlers, type SessionDataset } from '@/shared/storybook/session.handlers';
+import { StoryQueryClient } from '@/shared/storybook/StoryQueryClient';
+import { makeSessionOutcomes } from '@/test-utils/factories/session-outcomes.factory';
+import { FormationEnum } from '@/types/enums.types';
+
+import { MemberSessionFilesTable } from './MemberSessionFilesTable';
+
+const sessions: Record<string, SessionDataset> = {
+  'with-reports': { files: sessionFiles, memberReports: sessionMemberReports },
+  'without-report': { files: sessionFiles },
+  empty: { files: [] },
+};
+
+function MemberSessionFilesTableStory(props: { formation: FormationEnum; sessionId: string }) {
+  return (
+    <StoryQueryClient key={`${props.formation}-${props.sessionId}`}>
+      <AlertsProvider>
+        <div className="fr-container fr-py-4v">
+          <MemberSessionFilesTable
+            formation={props.formation}
+            outcomes={makeSessionOutcomes(props.formation)}
+            sessionId={props.sessionId}
+          />
+        </div>
+      </AlertsProvider>
+    </StoryQueryClient>
+  );
+}
+
+const meta = {
+  title: 'Features/Session/MemberSessionFilesTable',
+  component: MemberSessionFilesTableStory,
+  beforeEach: ({ msw }) => {
+    msw.use(...authHandlers, ...makeSessionHandlers(sessions));
+  },
+  parameters: {
+    layout: 'fullscreen',
+    router: {
+      initialEntries: ['/transparences/pouvoir-de-proposition-du-garde-des-sceaux/sessions/with-reports'],
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    formation: { control: 'inline-radio', options: Object.values(FormationEnum) },
+    sessionId: { control: 'inline-radio', options: Object.keys(sessions) },
+  },
+  args: { formation: FormationEnum.SIEGE, sessionId: 'with-reports' },
+} satisfies Meta<typeof MemberSessionFilesTableStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoReportStarted: Story = {
+  args: { sessionId: 'without-report' },
+};
+
+export const Empty: Story = {
+  args: { sessionId: 'empty' },
+};

--- a/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { AlertsProvider } from '@/shared/context/alerts';
+import { ConfirmationProvider } from '@/shared/context/confirmation';
+import { sgAuthHandlers } from '@/shared/storybook/msw.handlers';
+import { sessionFiles, sessionMembers } from '@/shared/storybook/session-files.fixtures';
+import { makeSessionHandlers, type SessionDataset } from '@/shared/storybook/session.handlers';
+import { StoryQueryClient } from '@/shared/storybook/StoryQueryClient';
+import { makeSessionOutcomes } from '@/test-utils/factories/session-outcomes.factory';
+import { FormationEnum } from '@/types/enums.types';
+
+import { SgSessionFilesTable } from './SgSessionFilesTable';
+
+const sessions: Record<string, SessionDataset> = {
+  draft: { files: sessionFiles, members: sessionMembers },
+  published: {
+    affectationsVersion: {
+      '@type': 'fr.csm.fondation.affectations.version.some',
+      author: { id: 'user-sg', firstName: 'Claire', lastName: 'Mercier' },
+      id: 'affectations-version-2',
+      publicationDate: '2026-06-02T09:00:00.000Z',
+      status: 'PUBLIEE',
+      version: 2,
+    },
+    files: sessionFiles,
+    members: sessionMembers,
+  },
+  empty: { files: [] },
+};
+
+function SgSessionFilesTableStory(props: {
+  canManage: boolean;
+  formation: FormationEnum;
+  sessionId: string;
+}) {
+  return (
+    <StoryQueryClient key={`${props.canManage}-${props.formation}-${props.sessionId}`}>
+      <AlertsProvider>
+        <ConfirmationProvider>
+          <div className="fr-container fr-py-4v">
+            <SgSessionFilesTable
+              canManage={props.canManage}
+              formation={props.formation}
+              outcomes={makeSessionOutcomes(props.formation)}
+              sessionId={props.sessionId}
+            />
+          </div>
+        </ConfirmationProvider>
+      </AlertsProvider>
+    </StoryQueryClient>
+  );
+}
+
+const meta = {
+  title: 'Features/Session/SgSessionFilesTable',
+  component: SgSessionFilesTableStory,
+  beforeEach: ({ msw }) => {
+    msw.use(...sgAuthHandlers, ...makeSessionHandlers(sessions));
+  },
+  parameters: {
+    layout: 'fullscreen',
+    router: { initialEntries: ['/secretariat-general/session/draft'] },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    canManage: { control: 'boolean' },
+    formation: { control: 'inline-radio', options: Object.values(FormationEnum) },
+    sessionId: { control: 'inline-radio', options: Object.keys(sessions) },
+  },
+  args: { canManage: true, formation: FormationEnum.SIEGE, sessionId: 'draft' },
+} satisfies Meta<typeof SgSessionFilesTableStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const PublishedAffectations: Story = {
+  args: { sessionId: 'published' },
+};
+
+export const Archived: Story = {
+  args: { canManage: false },
+};
+
+export const Empty: Story = {
+  args: { sessionId: 'empty' },
+};

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/SidePanelTrigger.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/SidePanelTrigger.tsx
@@ -1,5 +1,4 @@
 import Button from '@codegouvfr/react-dsfr/Button';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import clsx from 'clsx';
 import { useEffect, useId, useRef } from 'react';
 import { useIntl } from 'react-intl';
@@ -8,6 +7,7 @@ import { SIDE_PANEL_ID, useSidePanel } from '../context/side-panel.context';
 import { useAuditionExpectation } from '../hooks/use-audition-expectation/use-audition-expectation.hook';
 import { GradeAndPosition } from '@/shared/components/GradeAndPosition';
 import { MissingEvaluationIcon } from '@/shared/components/missing-evaluation';
+import { Tooltip } from '@/shared/ui/tooltip';
 import { isPastSchedule, type PlainTimeOnly } from '@/utils/time-only.util';
 import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
 
@@ -60,7 +60,7 @@ export function SidePanelTrigger(props: { nominationFile: SessionNominationFile 
       aria-current={isActive ? 'true' : undefined}
       aria-describedby={auditionExpectedLabel ? expectationId : undefined}
       className={clsx(
-        'group fr-px-0 text-left! font-normal! uppercase! hover:bg-transparent!',
+        'group fr-px-0 text-left! font-normal! hover:bg-transparent!',
         auditionExpectedLabel
           ? 'text-(--text-default-warning)! no-underline!'
           : 'text-(--text-action-high-blue-france)! underline! underline-offset-4 hover:decoration-2',
@@ -71,9 +71,9 @@ export function SidePanelTrigger(props: { nominationFile: SessionNominationFile 
       size="small"
     >
       <span>
-        {leadingWords && <span className={nameUnderline}>{`${leadingWords} `}</span>}
+        {leadingWords && <span className={clsx('uppercase!', nameUnderline)}>{`${leadingWords} `}</span>}
         <span className="whitespace-nowrap">
-          <span className={nameUnderline}>
+          <span className={clsx('uppercase!', nameUnderline)}>
             {lastWord}
             {auditionExpectedLabel && (
               <i
@@ -82,9 +82,9 @@ export function SidePanelTrigger(props: { nominationFile: SessionNominationFile 
               />
             )}
           </span>
-          <span className="inline-flex items-center align-middle [&_span[id^=tooltip-owner]]:inline-flex">
+          <span className="inline-flex items-center align-middle">
             {props.nominationFile.auditionDate && (
-              <Tooltip kind="hover" title={auditionLabel}>
+              <Tooltip label={auditionLabel}>
                 <i
                   aria-label={auditionLabel}
                   className="fr-icon-speak-line fr-icon--sm fr-ml-1v text-(--text-action-high-blue-france)"
@@ -94,19 +94,19 @@ export function SidePanelTrigger(props: { nominationFile: SessionNominationFile 
             )}
             {props.nominationFile.missingEvaluation && <MissingEvaluationIcon className="fr-ml-1v" />}
             {hasAnnotations && (
-              <Tooltip kind="hover" title={annotationsLabel}>
+              <Tooltip label={annotationsLabel}>
                 <i
                   aria-label={annotationsLabel}
-                  className="ri-message-3-line fr-ml-1v relative -top-0.5 text-(--text-action-high-blue-france) before:size-4! before:content-['']"
+                  className="ri-message-3-line fr-icon--sm fr-ml-1v text-(--text-action-high-blue-france)"
                   role="img"
                 />
               </Tooltip>
             )}
             {props.nominationFile.hasAttachment && (
-              <Tooltip kind="hover" title={attachmentLabel}>
+              <Tooltip label={attachmentLabel}>
                 <i
                   aria-label={attachmentLabel}
-                  className="ri-file-line fr-ml-1v relative -top-0.5 text-(--text-action-high-blue-france) before:size-4! before:content-['']"
+                  className="ri-file-line fr-icon--sm fr-ml-1v text-(--text-action-high-blue-france)"
                   role="img"
                 />
               </Tooltip>
@@ -122,7 +122,7 @@ export function SidePanelTrigger(props: { nominationFile: SessionNominationFile 
       <div className="text-left leading-4">
         {auditionExpectedLabel ? (
           <>
-            <Tooltip title={auditionExpectedLabel}>{magistratLink}</Tooltip>
+            <Tooltip label={auditionExpectedLabel}>{magistratLink}</Tooltip>
             <span className="fr-sr-only" id={expectationId}>
               {auditionExpectedLabel}
             </span>

--- a/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcome.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/nomination-file-outcome/NominationFileOutcome.tsx
@@ -1,7 +1,7 @@
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import { useMemo, type CSSProperties } from 'react';
 
 import { useNominationFilesTable } from '@/features/nomination-files-table/context/files-table.context';
+import { Tooltip } from '@/shared/ui/tooltip';
 import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
 
 import { sessionOutcomeLabel } from './nomination-file-outcome.utils';
@@ -20,10 +20,10 @@ export function NominationFileOutcome(props: { nominationFile: SessionNomination
   }
 
   return (
-    <Tooltip kind="hover" title={outcome.comment}>
+    <Tooltip label={outcome.comment}>
       <div className="flex flex-col items-center" style={{ '--icon-size': '10px' } as CSSProperties}>
         <NominationFileOutcomeBadge acronym formation={formation} label={label} outcome={outcome.value} />
-        <i className="ri-message-3-line text-(--text-action-high-blue-france) before:size-4! before:content-['']" />
+        <i className="ri-message-3-line fr-icon--sm text-(--text-action-high-blue-france)" />
       </div>
     </Tooltip>
   );

--- a/apps/client/src/features/nomination-files-table/components/cells/reporters/ExcludedJurisdictionAlert.css
+++ b/apps/client/src/features/nomination-files-table/components/cells/reporters/ExcludedJurisdictionAlert.css
@@ -1,5 +1,0 @@
-/* Nested tooltips: hovering the excluded-jurisdiction icon opens its own tooltip
-   (which already names the reporter), so hide the reporter-list tooltip it overlaps */
-span:has(ul .excluded-jurisdiction-alert:hover) + .fr-tooltip {
-  visibility: hidden;
-}

--- a/apps/client/src/features/nomination-files-table/components/cells/reporters/ExcludedJurisdictionAlert.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/reporters/ExcludedJurisdictionAlert.tsx
@@ -1,12 +1,10 @@
 import { colors } from '@codegouvfr/react-dsfr';
 import { cx } from '@codegouvfr/react-dsfr/fr/cx';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import clsx from 'clsx';
-
-import './ExcludedJurisdictionAlert.css';
 
 import { useExcludedJurisdictionTitles } from '@/features/nomination-files-table/context/excluded-jurisdictions.context';
 import { type ExcludedJurisdictionConflict } from '@/features/nomination-files-table/context/member-excluded-jurisdictions';
+import { Tooltip } from '@/shared/ui/tooltip';
 
 export function ExcludedJurisdictionAlert(props: { conflicts: readonly ExcludedJurisdictionConflict[] }) {
   const titles = useExcludedJurisdictionTitles(props.conflicts);
@@ -15,10 +13,9 @@ export function ExcludedJurisdictionAlert(props: { conflicts: readonly ExcludedJ
   const title = [...titles.values()].join(' - ');
 
   return (
-    /** @warning ".excluded-jurisdiction-alert" is used by {@link ExcludedJurisdictionAlert.css} */
-    <Tooltip title={title}>
+    <Tooltip label={title}>
       <i
-        className={clsx(cx('fr-icon-warning-fill'), 'excluded-jurisdiction-alert fr-icon--sm shrink-0')}
+        className={clsx(cx('fr-icon-warning-fill'), 'fr-icon--sm shrink-0')}
         style={{ color: colors.decisions.text.default.warning.default }}
       />
     </Tooltip>

--- a/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionCell.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionCell.tsx
@@ -1,11 +1,11 @@
 import { colors } from '@codegouvfr/react-dsfr';
 import Button from '@codegouvfr/react-dsfr/Button';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import { useCallback, useContext } from 'react';
 import { useIntl } from 'react-intl';
 
 import { useIsSg } from '@/features/auth/hooks/roles.hook';
 import { GradeAndPosition } from '@/shared/components/GradeAndPosition';
+import { Tooltip } from '@/shared/ui/tooltip';
 import { unaccent } from '@/utils/string.utils';
 import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
 
@@ -56,7 +56,7 @@ export function NominationFileTargetPositionCell(props: { nominationFile: Sessio
   if (!hasAlert) return label;
 
   return (
-    <Tooltip title={formatMessage({ defaultMessage: 'Fiche de juridiction requise' })}>
+    <Tooltip label={formatMessage({ defaultMessage: 'Fiche de juridiction requise' })}>
       <Button
         aria-controls={nominationFileTargetPositionModal.id}
         className="group fr-px-0"

--- a/apps/client/src/features/observations/components/ObservationLinks.tsx
+++ b/apps/client/src/features/observations/components/ObservationLinks.tsx
@@ -1,7 +1,7 @@
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from 'react-router';
 
+import { Tooltip } from '@/shared/ui/tooltip';
 import { getObservationDetailsPath } from '@/utils/route-path.utils';
 import { fullNameUpperCase } from '@/utils/user.utils';
 
@@ -20,7 +20,7 @@ function ObservationAnnotationsIcon(props: { hasDescription: boolean; hasUserCom
   );
 
   return (
-    <Tooltip kind="hover" title={label}>
+    <Tooltip label={label}>
       <i
         aria-label={label}
         className="ri-message-3-line fr-ml-1v relative -top-1 inline-block align-middle text-(--text-action-high-blue-france) before:size-4! before:content-['']"

--- a/apps/client/src/features/summary/components/SummaryReaderSelector.tsx
+++ b/apps/client/src/features/summary/components/SummaryReaderSelector.tsx
@@ -3,7 +3,6 @@ import { Checkbox } from '@codegouvfr/react-dsfr/Checkbox';
 import { createModal } from '@codegouvfr/react-dsfr/Modal';
 import { useIsModalOpen } from '@codegouvfr/react-dsfr/Modal/useIsModalOpen';
 import { SearchBar } from '@codegouvfr/react-dsfr/SearchBar';
-import { Tooltip } from '@codegouvfr/react-dsfr/Tooltip';
 import clsx from 'clsx';
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -11,6 +10,7 @@ import { useDebounce } from 'use-debounce';
 
 import { useSummary } from '@/features/summary/context/SummaryContext';
 import { Marked } from '@/shared/ui/Marked';
+import { Tooltip } from '@/shared/ui/tooltip';
 import { capitalize } from '@/utils/string.utils';
 import { useSearchSummaryReadersQuery, useUpdateSummaryReadersMutation } from '@queries/summary.queries';
 
@@ -69,7 +69,7 @@ export function SummaryReaderSelector(
 
       {withCount && readersCount > 0 ? (
         <Tooltip
-          title={summary.summary.readers
+          label={summary.summary.readers
             .map(({ firstName, lastName }) => `${capitalize(firstName)} ${lastName.toUpperCase()}`)
             .join(', ')}
         >

--- a/apps/client/src/layout/header/Avatar.tsx
+++ b/apps/client/src/layout/header/Avatar.tsx
@@ -1,10 +1,10 @@
 import { Badge } from '@codegouvfr/react-dsfr/Badge';
 import Button from '@codegouvfr/react-dsfr/Button';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import type { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router';
 
+import { Tooltip } from '@/shared/ui/tooltip';
 import { RoleEnumLabels } from '@/types/enums.types';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import { memberFullName, toInitials } from '@/utils/user.utils';
@@ -34,7 +34,7 @@ export const Avatar: FC = () => {
       <Button className="fr-mb-0" onClick={onClickLogout}>
         <div className="fr-py-2v flex items-center gap-8 rounded-sm">
           <div className="flex items-center gap-2">
-            <Tooltip title={memberFullName(user)}>
+            <Tooltip label={memberFullName(user)}>
               <span className="inline-flex size-8 items-center justify-center rounded-full bg-(--background-default-grey-active) text-sm font-medium text-(--text-default-grey)">
                 {toInitials(user)}
               </span>

--- a/apps/client/src/shared/components/details-link/DetailsLink.tsx
+++ b/apps/client/src/shared/components/details-link/DetailsLink.tsx
@@ -1,8 +1,8 @@
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import clsx from 'clsx';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router';
 
+import { Tooltip } from '@/shared/ui/tooltip';
 import { getMagistratDetailsPath } from '@/utils/route-path.utils';
 
 export function DetailsLink(props: {
@@ -18,7 +18,7 @@ export function DetailsLink(props: {
   const label = formatMessage({ defaultMessage: 'Vers la fiche magistrat' });
 
   return (
-    <Tooltip kind="hover" title={label}>
+    <Tooltip label={label}>
       <Link
         aria-label={label}
         className={clsx(

--- a/apps/client/src/shared/components/lolfi-link/LolfiLink.tsx
+++ b/apps/client/src/shared/components/lolfi-link/LolfiLink.tsx
@@ -1,8 +1,8 @@
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import clsx from 'clsx';
 import { useIntl } from 'react-intl';
 import { generatePath, Link } from 'react-router';
 
+import { Tooltip } from '@/shared/ui/tooltip';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 
 type LolfiTarget = { href: string } | { name?: string | null; nominationFileId: string; sessionId: string };
@@ -18,7 +18,7 @@ export function LolfiLink(props: { className?: string; small?: boolean } & Lolfi
   );
 
   return (
-    <Tooltip kind="hover" title={label}>
+    <Tooltip label={label}>
       {'href' in props ? (
         <a
           aria-label={label}

--- a/apps/client/src/shared/components/missing-evaluation/MissingEvaluationIcon.tsx
+++ b/apps/client/src/shared/components/missing-evaluation/MissingEvaluationIcon.tsx
@@ -1,6 +1,7 @@
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import clsx from 'clsx';
 import { useIntl } from 'react-intl';
+
+import { Tooltip } from '@/shared/ui/tooltip';
 
 export function MissingEvaluationIcon(props: { className?: string }) {
   const { formatMessage } = useIntl();
@@ -10,7 +11,7 @@ export function MissingEvaluationIcon(props: { className?: string }) {
   });
 
   return (
-    <Tooltip kind="hover" title={label}>
+    <Tooltip label={label}>
       <i
         aria-label={label}
         className={clsx(

--- a/apps/client/src/shared/components/report-state-tag/ReportStateTag.tsx
+++ b/apps/client/src/shared/components/report-state-tag/ReportStateTag.tsx
@@ -28,7 +28,7 @@ export function ReportStateTag(props: { state: ReportStatusEnum }) {
 
   return (
     <Tag
-      className="min-h-7! py-0! text-[0.8125rem] text-nowrap"
+      className="min-h-7! py-0.5! text-center text-[0.8125rem] leading-tight whitespace-normal!"
       style={{ backgroundColor: activeSpec.backgroundColor, color: activeSpec.color }}
     >
       <span className={cx('fr-text--bold')} style={{ color: activeSpec.color }}>

--- a/apps/client/src/shared/components/reporter-tag/ReporterTag.stories.tsx
+++ b/apps/client/src/shared/components/reporter-tag/ReporterTag.stories.tsx
@@ -1,13 +1,14 @@
 import { colors } from '@codegouvfr/react-dsfr';
 import { cx } from '@codegouvfr/react-dsfr/fr/cx';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import clsx from 'clsx';
+
+import { Tooltip } from '@/shared/ui/tooltip';
 
 import { ReporterTag } from './ReporterTag';
 
 const excludedJurisdictionIcon = (
-  <Tooltip title="Juridiction exclue pour Honorine VALROSE : Cour d'appel de Lyon">
+  <Tooltip label="Juridiction exclue pour Honorine VALROSE : Cour d'appel de Lyon">
     <i
       className={clsx(cx('fr-icon-warning-fill'), 'fr-icon--sm shrink-0')}
       style={{ color: colors.decisions.text.default.warning.default }}

--- a/apps/client/src/shared/components/reporter-tag/ReporterTag.test.tsx
+++ b/apps/client/src/shared/components/reporter-tag/ReporterTag.test.tsx
@@ -20,13 +20,13 @@ describe('ReporterTag', () => {
   it('describes the tag with the reporter full name', () => {
     renderTag();
 
-    expect(screen.getByRole('tooltip')).toHaveTextContent('Honorine VALROSE');
+    expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Honorine VALROSE');
   });
 
   it('drops the tooltip when it is disabled', () => {
     renderTag(false);
 
-    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull();
   });
 });
 
@@ -38,7 +38,7 @@ describe('ReporterTagList', () => {
       </IntlProvider>,
     );
 
-    expect(screen.getAllByRole('tooltip')).toHaveLength(1);
+    expect(screen.getAllByRole('tooltip', { hidden: true })).toHaveLength(1);
   });
 
   it('drops the tooltip when it is disabled', () => {
@@ -48,6 +48,6 @@ describe('ReporterTagList', () => {
       </IntlProvider>,
     );
 
-    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull();
   });
 });

--- a/apps/client/src/shared/components/reporter-tag/ReporterTag.tsx
+++ b/apps/client/src/shared/components/reporter-tag/ReporterTag.tsx
@@ -1,10 +1,10 @@
 import { colors } from '@codegouvfr/react-dsfr';
 import { cx } from '@codegouvfr/react-dsfr/fr/cx';
 import Tag from '@codegouvfr/react-dsfr/Tag';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 
+import { Tooltip } from '@/shared/ui/tooltip';
 import { memberFullName, toInitials } from '@/utils/user.utils';
 
 const currentUserStyle = {
@@ -34,6 +34,6 @@ export function ReporterTag(props: {
   return props.enableTooltip === false ? (
     tag
   ) : (
-    <Tooltip title={memberFullName(props.reporter)}>{tag}</Tooltip>
+    <Tooltip label={memberFullName(props.reporter)}>{tag}</Tooltip>
   );
 }

--- a/apps/client/src/shared/components/reporter-tag/ReporterTagList.tsx
+++ b/apps/client/src/shared/components/reporter-tag/ReporterTagList.tsx
@@ -1,8 +1,8 @@
 import Tag from '@codegouvfr/react-dsfr/Tag';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import type { ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 
+import { Tooltip } from '@/shared/ui/tooltip';
 import { memberFullName } from '@/utils/user.utils';
 
 import { ReporterTag } from './ReporterTag';
@@ -47,6 +47,6 @@ export function ReporterTagList(props: {
   return props.enableTooltip === false ? (
     list
   ) : (
-    <Tooltip title={intl.formatList(reporters.map(memberFullName), { type: 'conjunction' })}>{list}</Tooltip>
+    <Tooltip label={intl.formatList(reporters.map(memberFullName), { type: 'conjunction' })}>{list}</Tooltip>
   );
 }

--- a/apps/client/src/shared/components/title-name-icons/TitleNameIcons.tsx
+++ b/apps/client/src/shared/components/title-name-icons/TitleNameIcons.tsx
@@ -17,7 +17,7 @@ export function TitleNameIcons(props: {
   return (
     <>
       {start && `${start} `}
-      <span className="inline-flex items-center whitespace-nowrap [&_span[id^=tooltip-owner]]:inline-flex">
+      <span className="inline-flex items-center whitespace-nowrap">
         {tail}
         <span className="ml-2 inline-flex items-center">
           {props.detailsLink && (

--- a/apps/client/src/shared/storybook/msw.handlers.ts
+++ b/apps/client/src/shared/storybook/msw.handlers.ts
@@ -16,17 +16,29 @@ const FILE_URL = 'about:blank';
 const STORY_USER: DetailedUserResponseDto = {
   displayTitle: null,
   duty: null,
-  firstName: 'Inès',
+  firstName: 'Nadia',
   gender: 'FEMALE',
   isImpersonated: false,
-  lastName: 'Fontaine',
+  lastName: 'Lemoine',
   role: 'MEMBRE_COMMUN',
   title: null,
   userId: 'user-1',
 };
 
+const STORY_SG_USER: DetailedUserResponseDto = {
+  ...STORY_USER,
+  firstName: 'Claire',
+  lastName: 'Mercier',
+  role: 'ADJOINT_SECRETAIRE_GENERAL',
+  userId: 'user-sg',
+};
+
 export const authHandlers = [
   http.get('*/api/auth/v2/introspect', () => HttpResponse.json<DetailedUserResponseDto>(STORY_USER)),
+];
+
+export const sgAuthHandlers = [
+  http.get('*/api/auth/v2/introspect', () => HttpResponse.json<DetailedUserResponseDto>(STORY_SG_USER)),
 ];
 
 export const sidePanelHandlers = [

--- a/apps/client/src/shared/storybook/session-files.fixtures.ts
+++ b/apps/client/src/shared/storybook/session-files.fixtures.ts
@@ -1,0 +1,119 @@
+import { makeSessionNominationFile } from '@/test-utils/factories/session-nomination-file.factory';
+import type { ListedMemberSessionReportsDto, PaginatedMemberListItemDto } from '@api/types';
+
+/** `user-1` is the member logged in by `authHandlers` so the member view shows their own reports */
+export const sessionReporters = {
+  bernard: { id: 'user-2', firstName: 'Rachel', lastName: 'Bernard' },
+  lemoine: { id: 'user-1', firstName: 'Nadia', lastName: 'Lemoine' },
+  roche: { id: 'user-3', firstName: 'Antoine', lastName: 'Roche' },
+};
+
+export const sessionFiles = [
+  makeSessionNominationFile({
+    content: {
+      grade: 'I',
+      gradeCible: 'HH',
+      nomMagistrat: 'KOFFI Aminata',
+      numeroDeDossier: 1,
+      outcome: { comment: null, value: 'WAITING_DSJ' },
+      posteActuel: 'Présidente du tribunal judiciaire de VALENCIENNES',
+      posteCible: 'Première présidente CA DOUAI',
+      status: { value: 'DSJ_PLANNED', date: { year: 2026, month: 6, day: 1 } },
+    },
+    hasAttachment: true,
+    id: 'dossier-1',
+    reporters: [sessionReporters.bernard, sessionReporters.lemoine],
+  }),
+
+  makeSessionNominationFile({
+    content: {
+      grade: 'I',
+      gradeCible: 'HH',
+      nomMagistrat: 'VALROSE Honorine',
+      numeroDeDossier: 2,
+      outcome: { comment: null, value: 'VALIDATED' },
+      posteActuel: 'Conseillère à la cour d’appel de Lyon',
+      posteCible: 'Président de chambre CA AIX EN PROVENCE',
+      status: { value: 'DSJ_REPORTED', date: { year: 2026, month: 6, day: 8 } },
+    },
+    id: 'dossier-2',
+    priorities: ['ETOILE'],
+    reporters: [sessionReporters.bernard, sessionReporters.roche],
+  }),
+
+  makeSessionNominationFile({
+    content: {
+      grade: 'II',
+      gradeCible: 'I',
+      nomMagistrat: 'AUBRY Gaspard',
+      numeroDeDossier: 3,
+      observants: ['CSM'],
+      posteActuel: 'Juge au tribunal judiciaire de Poitiers',
+      posteCible: 'Juge au tribunal judiciaire de BORDEAUX',
+      status: { value: 'DSJ_PLANNED', date: { year: 2026, month: 6, day: 1 } },
+    },
+    id: 'dossier-3',
+    priorities: ['OUTRE_MER'],
+    reporters: [sessionReporters.lemoine],
+  }),
+
+  makeSessionNominationFile({
+    content: {
+      grade: 'II',
+      gradeCible: 'II',
+      nomMagistrat: 'BENALI Sofia',
+      numeroDeDossier: 4,
+      outcome: { comment: 'Le profil ne correspond pas au poste.', value: 'NON_VALIDATED' },
+      posteActuel: 'Substitut du procureur TJ AMIENS',
+      posteCible: 'Substitut du procureur TJ LILLE',
+      status: { value: 'TO_REPORT', date: null },
+    },
+    id: 'dossier-4',
+    reporters: [sessionReporters.roche, sessionReporters.lemoine],
+  }),
+
+  makeSessionNominationFile({
+    content: {
+      grade: 'I',
+      gradeCible: 'G3',
+      nomMagistrat: 'PEREIRA Lucas',
+      numeroDeDossier: 5,
+      posteActuel: 'Vice-président TJ TOULON',
+      posteCible: 'Premier vice-président TJ MARSEILLE',
+      status: { value: 'TO_REPORT', date: null },
+    },
+    id: 'dossier-5',
+    reporters: [],
+  }),
+
+  makeSessionNominationFile({
+    content: {
+      grade: 'I',
+      gradeCible: 'G2',
+      nomMagistrat: 'DELAUNAY Mathis',
+      numeroDeDossier: 6,
+      posteActuel: 'Juge des enfants TJ RENNES',
+      posteCible: 'Vice-président TJ NANTES',
+      status: { value: 'TO_REPORT', date: null },
+    },
+    id: 'dossier-6',
+    missingEvaluation: true,
+    priorities: ['PROFILE'],
+    reporters: [],
+  }),
+];
+
+export const sessionMembers: PaginatedMemberListItemDto['items'] = [
+  {
+    ...sessionReporters.bernard,
+    excludedJurisdictions: [{ id: 'jurisdiction-1', label: 'CA AIX EN PROVENCE' }],
+    role: 'MEMBRE_DU_SIEGE',
+    stats: [],
+  },
+];
+
+export const sessionMemberReports: ListedMemberSessionReportsDto['items'] = [
+  { nominationFileId: 'dossier-1', report: { id: 'report-1', state: 'READY_TO_SUPPORT' } },
+  { nominationFileId: 'dossier-3', report: { id: 'report-2', state: 'IN_PROGRESS' } },
+  { nominationFileId: 'dossier-4', report: { id: 'report-3', state: 'SUPPORTED' } },
+];

--- a/apps/client/src/shared/storybook/session.handlers.ts
+++ b/apps/client/src/shared/storybook/session.handlers.ts
@@ -1,0 +1,184 @@
+import { http, HttpResponse } from 'msw';
+
+import { GradeEnum } from '@/types/enums.types';
+import type {
+  CountedUnaffectedFilesDto,
+  ListedCurrentlyAffectedReportersDto,
+  ListedMemberSessionReportsDto,
+  NominationFilesStatusCountDto,
+  PaginatedMemberListItemDto,
+  PaginatedNominationFiles,
+  SomeAffectationVersion,
+} from '@api/types';
+import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
+
+type ListedMember = PaginatedMemberListItemDto['items'][number];
+
+export type SessionDataset = {
+  affectationsVersion?: SomeAffectationVersion;
+  files: readonly SessionNominationFile[];
+  memberReports?: ListedMemberSessionReportsDto['items'];
+  members?: readonly ListedMember[];
+};
+
+const DEFAULT_PAGE_SIZE = 100;
+
+const NO_VALUE = 'null';
+
+/** mirrors `gradeEnumToSortableTargetedGrade` on the API which the list query sorts on */
+const SORTABLE_TARGETED_GRADE: Record<GradeEnum, number> = {
+  G1: 32,
+  G2: 31,
+  G3: 30,
+  G3sup: 29,
+  HH: 10,
+  I: 20,
+  II: 30,
+  III: 10,
+};
+
+const sortValues = {
+  fileNumber: (file: SessionNominationFile) => file.content.numeroDeDossier ?? 0,
+  name: (file: SessionNominationFile) => file.content.nomMagistrat,
+  targetedGrade: (file: SessionNominationFile) =>
+    file.content.gradeCible ? SORTABLE_TARGETED_GRADE[file.content.gradeCible] : 0,
+  targetedPosition: (file: SessionNominationFile) => file.content.posteCible ?? '',
+};
+
+function isSortable(sortBy: string | null): sortBy is keyof typeof sortValues {
+  return !!sortBy && sortBy in sortValues;
+}
+
+function compare(a: number | string, b: number | string) {
+  return a > b ? 1 : a < b ? -1 : 0;
+}
+
+function matchesSearch(file: SessionNominationFile, search: string) {
+  return [file.content.nomMagistrat, file.content.posteCible, `${file.content.numeroDeDossier}`].some(
+    (value) => value?.toLowerCase().includes(search),
+  );
+}
+
+function matchesAny(values: readonly string[], selected: readonly string[]) {
+  return (values.length ? values : [NO_VALUE]).some((value) => selected.includes(value));
+}
+
+function matchesFilters(file: SessionNominationFile, query: URLSearchParams) {
+  const search = query.get('search')?.trim().toLowerCase();
+  const priorities = query.getAll('priorities');
+  const reporterIds = query.getAll('reporterIds');
+  const outcomes = query.get('outcomes')?.split(',').filter(Boolean) ?? [];
+  const fileReporterIds = file.reporters.map(({ id }) => id);
+
+  if (search && !matchesSearch(file, search)) return false;
+  if (priorities.length && !matchesAny(file.priorities, priorities)) return false;
+  if (reporterIds.length && !matchesAny(fileReporterIds, reporterIds)) return false;
+  if (outcomes.length && !outcomes.includes(file.content.outcome?.value ?? NO_VALUE)) return false;
+
+  return true;
+}
+
+const draftAffectationsVersion: SomeAffectationVersion = {
+  '@type': 'fr.csm.fondation.affectations.version.some',
+  author: null,
+  id: 'affectations-version-1',
+  publicationDate: null,
+  status: 'BROUILLON',
+  version: 1,
+};
+
+/**
+ * Serves the whole session screen from in-memory datasets keyed by session id: the paginated list applies
+ * the search, the filters, the sorting and the pagination, and the surrounding widgets count that same list.
+ *
+ * @warning a docs page renders every story against the same worker, so the dataset must come from the
+ * requested session rather than from a per-story `msw.use()`, which the last rendered story would win.
+ */
+export function makeSessionHandlers(sessions: Record<string, SessionDataset>) {
+  const datasetOf = (sessionId: string | readonly string[] | undefined): SessionDataset =>
+    sessions[String(sessionId)] ?? { files: [] };
+
+  const allMembers = [
+    ...new Map(
+      Object.values(sessions)
+        .flatMap(({ members = [] }) => members)
+        .map((member) => [member.id, member]),
+    ).values(),
+  ];
+
+  return [
+    http.get('*/api/sessions/v2/:sessionId/files', ({ params, request }) => {
+      const query = new URL(request.url).searchParams;
+      const filtered = datasetOf(params.sessionId).files.filter((file) => matchesFilters(file, query));
+
+      const sortBy = query.get('sortBy');
+      const direction = query.get('sortDesc') === 'true' ? -1 : 1;
+      const valueOf = isSortable(sortBy) ? sortValues[sortBy] : sortValues.fileNumber;
+      const sorted = [...filtered].sort(
+        (a, b) =>
+          compare(valueOf(a), valueOf(b)) * direction ||
+          compare(sortValues.fileNumber(a), sortValues.fileNumber(b)),
+      );
+
+      const limit = Number(query.get('limit')) || DEFAULT_PAGE_SIZE;
+      const page = Number(query.get('page')) || 1;
+
+      return HttpResponse.json<PaginatedNominationFiles>({
+        currentPageIndex: page,
+        items: sorted.slice((page - 1) * limit, page * limit),
+        nextPageIndex: page * limit < sorted.length ? page + 1 : undefined,
+        totalCount: sorted.length,
+      });
+    }),
+
+    http.get('*/api/sessions/v2/:sessionId/files/status-counts', ({ params }) => {
+      const { files } = datasetOf(params.sessionId);
+
+      return HttpResponse.json<NominationFilesStatusCountDto>({
+        inProgress: files.filter(({ content, reporters }) => reporters.length && !content.outcome).length,
+        unaffected: files.filter(({ reporters }) => !reporters.length).length,
+        withOutcome: files.filter(({ content }) => !!content.outcome).length,
+      });
+    }),
+
+    http.get('*/api/sessions/v2/:sessionId/files/reporters/versions/last', ({ params }) =>
+      HttpResponse.json<SomeAffectationVersion>(
+        datasetOf(params.sessionId).affectationsVersion ?? draftAffectationsVersion,
+      ),
+    ),
+
+    http.get('*/api/sessions/v2/:sessionId/files/reporters/versions/last/unaffected-count', ({ params }) =>
+      HttpResponse.json<CountedUnaffectedFilesDto>({
+        count: datasetOf(params.sessionId).files.filter(({ reporters }) => !reporters.length).length,
+      }),
+    ),
+
+    http.get('*/api/sessions/v2/:sessionId/files/reporters/versions/last/members', ({ params }) =>
+      HttpResponse.json<ListedCurrentlyAffectedReportersDto>({
+        items: [
+          ...new Map(
+            datasetOf(params.sessionId)
+              .files.flatMap(({ reporters }) => reporters)
+              .map((reporter) => [reporter.id, reporter]),
+          ).values(),
+        ],
+      }),
+    ),
+
+    http.get(
+      '*/api/members/v1/:userId/sessions/transparence/garde-des-sceaux/:sessionId/reports',
+      ({ params }) =>
+        HttpResponse.json<ListedMemberSessionReportsDto>({
+          items: datasetOf(params.sessionId).memberReports ?? [],
+        }),
+    ),
+
+    http.get('*/api/members/v1', () =>
+      HttpResponse.json<PaginatedMemberListItemDto>({
+        currentPageIndex: 1,
+        items: allMembers,
+        totalCount: allMembers.length,
+      }),
+    ),
+  ];
+}

--- a/apps/client/src/shared/ui/doc-block-editor/DocBlockDriftBanner.tsx
+++ b/apps/client/src/shared/ui/doc-block-editor/DocBlockDriftBanner.tsx
@@ -1,9 +1,10 @@
 import Badge from '@codegouvfr/react-dsfr/Badge';
 import ButtonsGroup from '@codegouvfr/react-dsfr/ButtonsGroup';
-import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import { type ReactNodeViewProps } from '@tiptap/react';
 import clsx from 'clsx';
 import { FormattedMessage, useIntl } from 'react-intl';
+
+import { Tooltip } from '@/shared/ui/tooltip';
 
 function DocBlockDriftBannerTooltip() {
   const { formatMessage } = useIntl();
@@ -42,7 +43,9 @@ export function DocBlockDriftBanner(props: ReactNodeViewProps) {
       <Badge as="p" severity="new" small className="fr-mr-1v">
         <FormattedMessage defaultMessage="MODIFICATION" />
       </Badge>
-      <Tooltip title={<DocBlockDriftBannerTooltip />} />
+      <Tooltip label={<DocBlockDriftBannerTooltip />}>
+        <i aria-hidden className="fr-icon-question-line fr-icon--sm text-(--text-action-high-blue-france)" />
+      </Tooltip>
       <div className="fr-mt-1v">
         <div dangerouslySetInnerHTML={{ __html: generatedHtml }} />
       </div>

--- a/apps/client/src/shared/ui/tooltip/Tooltip.stories.tsx
+++ b/apps/client/src/shared/ui/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Tooltip } from './Tooltip';
+
+function TooltipStory(props: { label: string }) {
+  return (
+    <div className="flex justify-center py-16">
+      <Tooltip label={props.label}>
+        <button className="fr-btn fr-btn--secondary fr-btn--sm" type="button">
+          Survolez-moi
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
+function ClippedTooltipStory(props: { label: string }) {
+  return (
+    <div className="relative overflow-auto border border-(--border-contrast-grey) p-4">
+      <div className="flex justify-between">
+        <Tooltip label={props.label}>
+          <button className="fr-btn fr-btn--secondary fr-btn--sm" type="button">
+            Bord gauche
+          </button>
+        </Tooltip>
+        <Tooltip label={props.label}>
+          <button className="fr-btn fr-btn--secondary fr-btn--sm" type="button">
+            Bord droit
+          </button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Shared/Tooltip',
+  component: TooltipStory,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  argTypes: { label: { control: 'text' } },
+  args: { label: 'Le profil ne correspond pas aux attentes de la formation pour ce poste.' },
+} satisfies Meta<typeof TooltipStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Survol: Story = {};
+
+export const TexteCourt: Story = { args: { label: 'Évaluation manquante' } };
+
+export const DansUnConteneurQuiRogne: Story = { render: (args) => <ClippedTooltipStory {...args} /> };

--- a/apps/client/src/shared/ui/tooltip/Tooltip.stories.tsx
+++ b/apps/client/src/shared/ui/tooltip/Tooltip.stories.tsx
@@ -46,8 +46,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Survol: Story = {};
+export const Default: Story = {};
 
-export const TexteCourt: Story = { args: { label: 'Évaluation manquante' } };
+export const ShortText: Story = { args: { label: 'Évaluation manquante' } };
 
-export const DansUnConteneurQuiRogne: Story = { render: (args) => <ClippedTooltipStory {...args} /> };
+export const InsideClippingContainer: Story = { render: (args) => <ClippedTooltipStory {...args} /> };

--- a/apps/client/src/shared/ui/tooltip/Tooltip.tsx
+++ b/apps/client/src/shared/ui/tooltip/Tooltip.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 
 const ARROW_GAP = 10;
 const SAFE_MARGIN = 16;
 
-/** nested anchors are both hovered at once, so only the innermost tooltip stays open */
 let openedTooltip: (() => void) | null = null;
 
 export function Tooltip(props: { children: ReactNode; className?: string; label: ReactNode }) {

--- a/apps/client/src/shared/ui/tooltip/Tooltip.tsx
+++ b/apps/client/src/shared/ui/tooltip/Tooltip.tsx
@@ -1,0 +1,97 @@
+import clsx from 'clsx';
+import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react';
+
+const ARROW_GAP = 10;
+const SAFE_MARGIN = 16;
+
+/** nested anchors are both hovered at once, so only the innermost tooltip stays open */
+let openedTooltip: (() => void) | null = null;
+
+export function Tooltip(props: { children: ReactNode; className?: string; label: ReactNode }) {
+  const bubbleId = useId();
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const bubbleRef = useRef<HTMLDivElement>(null);
+  const [isShown, setIsShown] = useState(false);
+  const [arrowX, setArrowX] = useState(0);
+  const [isUnder, setIsUnder] = useState(false);
+
+  const hide = useCallback(() => {
+    bubbleRef.current?.hidePopover?.();
+    if (openedTooltip === hide) openedTooltip = null;
+    setIsShown(false);
+  }, []);
+
+  const show = useCallback(() => {
+    const anchor = anchorRef.current;
+    const bubble = bubbleRef.current;
+    if (!anchor || !bubble?.showPopover) return;
+
+    openedTooltip?.();
+    openedTooltip = hide;
+
+    bubble.showPopover();
+    const from = anchor.getBoundingClientRect();
+    const { height, width } = bubble.getBoundingClientRect();
+
+    const under = from.top - height - ARROW_GAP < SAFE_MARGIN;
+    const left = Math.min(
+      Math.max(from.left + from.width / 2 - width / 2, SAFE_MARGIN),
+      window.innerWidth - SAFE_MARGIN - width,
+    );
+
+    bubble.style.left = `${left}px`;
+    bubble.style.top = `${under ? from.bottom + ARROW_GAP : from.top - height - ARROW_GAP}px`;
+
+    setArrowX(from.left + from.width / 2 - left);
+    setIsUnder(under);
+    setIsShown(true);
+  }, [hide]);
+
+  useEffect(() => {
+    if (!isShown) return;
+
+    window.addEventListener('pointerdown', hide, { capture: true });
+    window.addEventListener('scroll', hide, { capture: true });
+    window.addEventListener('resize', hide);
+    return () => {
+      window.removeEventListener('pointerdown', hide, { capture: true });
+      window.removeEventListener('scroll', hide, { capture: true });
+      window.removeEventListener('resize', hide);
+    };
+  }, [hide, isShown]);
+
+  return (
+    <>
+      <span
+        aria-describedby={bubbleId}
+        className={clsx('inline-flex cursor-default', props.className)}
+        onBlur={hide}
+        onFocus={show}
+        onKeyDown={(event) => event.key === 'Escape' && hide()}
+        onPointerEnter={show}
+        onPointerLeave={hide}
+        ref={anchorRef}
+      >
+        {props.children}
+      </span>
+
+      <div
+        className="fixed m-0 max-w-[min(24rem,calc((100vw-2rem)*2/3))] overflow-visible border border-(--border-default-grey) bg-(--background-overlap-grey) p-2 text-left text-xs leading-5 text-wrap text-(--text-default-grey) shadow-[var(--overlap-shadow)]"
+        id={bubbleId}
+        popover="manual"
+        ref={bubbleRef}
+        role="tooltip"
+      >
+        {props.label}
+        <span
+          aria-hidden
+          className={clsx(
+            'absolute size-2 rotate-45 border-(--border-default-grey) bg-(--background-overlap-grey)',
+            isUnder ? '-top-1 border-t border-l' : '-bottom-1 border-r border-b',
+          )}
+          style={{ left: arrowX - 4 }}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/client/src/shared/ui/tooltip/index.ts
+++ b/apps/client/src/shared/ui/tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip } from './Tooltip';

--- a/apps/client/src/styles/index.css
+++ b/apps/client/src/styles/index.css
@@ -62,10 +62,6 @@ li {
   padding: 0;
 }
 
-[data-fr-js-tooltip-referent] {
-  cursor: default;
-}
-
 /* doubled class: this file loads before the DSFR stylesheet, so it needs to win on specificity */
 .fr-container.fr-container {
   max-width: var(--fondation-container-max-width);
@@ -73,17 +69,6 @@ li {
 
 .fr-table__content table tbody td {
   padding: 1rem;
-}
-
-.fr-tooltip {
-  transition: opacity 0.1s;
-}
-
-/* A DSFR tooltip only closes on mouseout, focusout or Escape: opening a dialog fires
-   none of them, so it stays open and draws beside it. `visibility` and not `display`,
-   as DSFR ends its hiding on a `transitionend` a display-none element never fires. */
-:root:has([aria-modal='true']:not([inert])) .fr-tooltip:not(:where([aria-modal='true'] *)) {
-  visibility: hidden;
 }
 
 .editor-resizable-image {


### PR DESCRIPTION
- New `shared/ui/tooltip` on the popover API: top layer, so no `overflow` or `z-index` clips it
- Placement in JS: flips below the anchor, slides within the viewport, arrow follows
- Closes on pointer leave, blur, `Escape`, scroll, resize, `pointerdown`
- One bubble open at a time, so nested anchors no longer stack
- Same look as DSFR, reusing its tokens
- Migrated all 15 usages, dropped the CSS workarounds they needed
