### PR TITLE
feat(FON-387): tag the files attached to a proposal

### DIFF
--- a/apps/api-e2e/src/generated/api/types.ts
+++ b/apps/api-e2e/src/generated/api/types.ts
@@ -517,6 +517,9 @@ export type DetailedNominationSessionAttachmentDto = {
 
 export type UploadNominationFileAttachmentsDto = {
     files?: Array<Blob | File>;
+    form: {
+        type: 'AUTRE' | 'FICHE_DE_JURIDICTION' | 'NOTE_INTENTION';
+    };
 };
 
 export type ListedNominationFileAttachmentDto = {
@@ -524,6 +527,8 @@ export type ListedNominationFileAttachmentDto = {
         id: string;
         name: string;
         size: number | null;
+        type: 'AUTRE' | 'FICHE_DE_JURIDICTION' | 'NOTE_INTENTION';
+        addedAt: string;
     }>;
 };
 

--- a/apps/api-e2e/src/specs/session.e2e-spec.ts
+++ b/apps/api-e2e/src/specs/session.e2e-spec.ts
@@ -6,7 +6,11 @@ import { fileURLToPath } from 'node:url';
 import type { LolfiData } from 'lolfi';
 
 import { test } from '../fixtures.ts';
-import type { ImportNominationSessionFromLodamXlsxDto, PaginatedNominationFiles } from '../generated/api/types.ts';
+import type {
+  ImportNominationSessionFromLodamXlsxDto,
+  PaginatedNominationFiles,
+  UploadNominationFileAttachmentsDto,
+} from '../generated/api/types.ts';
 import { makeFile } from '../utils/files.ts';
 import * as seed from '../utils/seed.ts';
 
@@ -33,6 +37,10 @@ function lodamForm(): ImportNominationSessionFromLodamXlsxDto['form'] {
     ],
     { type: 'application/json' },
   ) as any;
+}
+
+function attachmentForm(form: UploadNominationFileAttachmentsDto['form']): UploadNominationFileAttachmentsDto['form'] {
+  return new Blob([JSON.stringify(form)], { type: 'application/json' }) as any;
 }
 
 const TREVOUX_SESSION: LolfiData['sessions'][number] = {
@@ -226,7 +234,7 @@ test.describe('Session E2E', () => {
       const fileToAttach = makeFile({ type: 'application/pdf', name: 'note.pdf' });
       const uploadRes = await agent.sessions.uploadNominationFileAttachments({
         path: { sessionId, nominationFileId },
-        body: { files: [fileToAttach] },
+        body: { files: [fileToAttach], form: attachmentForm({ type: 'FICHE_DE_JURIDICTION' }) },
       });
       expect(uploadRes.response?.status).toBe(204);
 
@@ -235,7 +243,13 @@ test.describe('Session E2E', () => {
       });
       expect(attachments.response?.status).toBe(200);
       expect(attachments.data!.items).toEqual([
-        { id: expect.any(String), name: fileToAttach.name, size: fileToAttach.size },
+        {
+          id: expect.any(String),
+          name: fileToAttach.name,
+          size: fileToAttach.size,
+          type: 'FICHE_DE_JURIDICTION',
+          addedAt: expect.any(String),
+        },
       ]);
 
       const filesAfter = await agent.sessions.listNominationFiles({ path: { sessionId } });

--- a/apps/api/prisma/migrations/20260813114022_adds_nomination_file_attachment_type/migration.sql
+++ b/apps/api/prisma/migrations/20260813114022_adds_nomination_file_attachment_type/migration.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- CreateEnum
+CREATE TYPE "nominations_context"."nomination_file_attachment_type_enum" AS ENUM ('FICHE_DE_JURIDICTION', 'NOTE_INTENTION', 'AUTRE');
+
+-- AlterTable
+ALTER TABLE "nominations_context"."nomination_file_attachment"
+ADD COLUMN "type" "nominations_context"."nomination_file_attachment_type_enum" NOT NULL DEFAULT 'AUTRE',
+ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE "nominations_context"."nomination_file_attachment" ALTER COLUMN "type" DROP DEFAULT;
+
+UPDATE "nominations_context"."nomination_file_attachment" AS a
+SET created_at = f.created_at
+FROM "files_context"."files" AS f
+WHERE f.id = a.file_id;
+
+COMMIT;

--- a/apps/api/prisma/schemas/nominations.prisma
+++ b/apps/api/prisma/schemas/nominations.prisma
@@ -118,14 +118,25 @@ model DossierDeNomination {
 }
 
 model NominationFileAttachment {
-  nominationFileId String @map("nomination_file_id") @db.Uuid
-  fileId           String @map("file_id") @db.Uuid
+  nominationFileId String                                 @map("nomination_file_id") @db.Uuid
+  fileId           String                                 @map("file_id") @db.Uuid
+  type             PrismaNominationFileAttachmentTypeEnum
+  createdAt        DateTime                               @default(now()) @map("created_at")
 
   nominationFile DossierDeNomination @relation(fields: [nominationFileId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   file           File                @relation(fields: [fileId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@id([nominationFileId, fileId], name: "primaryKey")
   @@map("nomination_file_attachment")
+  @@schema("nominations_context")
+}
+
+enum PrismaNominationFileAttachmentTypeEnum {
+  FICHE_DE_JURIDICTION
+  NOTE_INTENTION
+  AUTRE
+
+  @@map("nomination_file_attachment_type_enum")
   @@schema("nominations_context")
 }
 

--- a/apps/api/src/modules/session/transparence/domain/session-transparence.spec.ts
+++ b/apps/api/src/modules/session/transparence/domain/session-transparence.spec.ts
@@ -771,15 +771,20 @@ describe('SessionTransparence', () => {
     session.addNominationFileAttachments({
       nominationFileId: 'nomination-file-id-1',
       files: [{ id: 'file-1' }, { id: 'file-2' }],
+      type: 'FICHE_DE_JURIDICTION',
     });
 
     expect(session.messages).toEqual([
-      new SessionTransparenceFileAttachmentAdded('nomination-file-id-1', {
-        id: 'file-1',
-      }),
-      new SessionTransparenceFileAttachmentAdded('nomination-file-id-1', {
-        id: 'file-2',
-      }),
+      new SessionTransparenceFileAttachmentAdded(
+        'nomination-file-id-1',
+        { id: 'file-1' },
+        'FICHE_DE_JURIDICTION',
+      ),
+      new SessionTransparenceFileAttachmentAdded(
+        'nomination-file-id-1',
+        { id: 'file-2' },
+        'FICHE_DE_JURIDICTION',
+      ),
     ]);
   });
 
@@ -830,6 +835,7 @@ describe('SessionTransparence', () => {
       session.addNominationFileAttachments({
         nominationFileId: 'nomination-file-id-1',
         files: [{ id: 'file-1' }],
+        type: 'AUTRE',
       }),
     ).toThrow(CantUpdateNominationFiles);
   });
@@ -873,6 +879,7 @@ describe('SessionTransparence', () => {
       session.addNominationFileAttachments({
         nominationFileId: 'unknown-nomination-file',
         files: [{ id: 'file-1' }],
+        type: 'AUTRE',
       }),
     ).toThrow(CantUpdateNominationFiles);
   });

--- a/apps/api/src/modules/session/transparence/domain/session-transparence.ts
+++ b/apps/api/src/modules/session/transparence/domain/session-transparence.ts
@@ -4,6 +4,7 @@ import { NominationFileDocsSnapshot } from '../../shared/types/nomination-file';
 import { NominationFileOutcome, NominationFileOutcomeEnum } from '../../shared/types/nomination-file-outcome';
 import * as policies from 'src/modules/session/shared/policies/nomination-file.policies';
 import { FormationEnum } from 'src/modules/shared/formation.enum';
+import { NominationFileAttachmentTypeEnum } from 'src/modules/shared/nomination-file-attachment-type.enum';
 import { PriorityEnum } from 'src/modules/shared/priority.enum';
 import { TypeDeSaisineEnum } from 'src/modules/shared/type-de-saisine.enum';
 import { DateOnly } from 'src/utils/date-only';
@@ -109,6 +110,7 @@ export class SessionTransparenceFileAttachmentAdded {
   constructor(
     readonly nominationFileId: string,
     readonly file: { id: string },
+    readonly type: NominationFileAttachmentTypeEnum,
   ) {}
 }
 
@@ -610,11 +612,17 @@ export class SessionTransparence {
     this.#messages.push(new SessionTransparenceFileAlertHidden(this.id, command.nominationFileId));
   }
 
-  addNominationFileAttachments(command: { nominationFileId: string; files: { id: string }[] }) {
+  addNominationFileAttachments(command: {
+    nominationFileId: string;
+    files: { id: string }[];
+    type: NominationFileAttachmentTypeEnum;
+  }) {
     this.assertsCanUpdateFiles(command.nominationFileId);
 
     for (const file of command.files) {
-      this.#messages.push(new SessionTransparenceFileAttachmentAdded(command.nominationFileId, file));
+      this.#messages.push(
+        new SessionTransparenceFileAttachmentAdded(command.nominationFileId, file, command.type),
+      );
     }
   }
 

--- a/apps/api/src/modules/session/transparence/infrastructure/dtos/transparence-session.dto.ts
+++ b/apps/api/src/modules/session/transparence/infrastructure/dtos/transparence-session.dto.ts
@@ -5,6 +5,7 @@ import { NominationFileOutcome } from '../../../shared/types/nomination-file-out
 import { FILE_MIME_TYPES } from 'src/modules/framework/files';
 import { createSortableDto } from 'src/modules/framework/sorting';
 import { FormationEnum } from 'src/modules/shared/formation.enum';
+import { NominationFileAttachmentTypeEnum } from 'src/modules/shared/nomination-file-attachment-type.enum';
 import { DateOnly } from 'src/utils/date-only';
 import { isDefined } from 'src/utils/is-defined';
 
@@ -66,6 +67,7 @@ export class UploadSessionAttachmentsDto extends createZodDto(
 export class UploadNominationFileAttachmentsDto extends createZodDto(
   z.object({
     files: z.preprocess((x) => ([] as unknown[]).concat(x), z.array(z.file())),
+    form: z.object({ type: z.enum(NominationFileAttachmentTypeEnum) }),
   }),
 ) {}
 

--- a/apps/api/src/modules/session/transparence/infrastructure/queries/list-nomination-file-attachments.query.ts
+++ b/apps/api/src/modules/session/transparence/infrastructure/queries/list-nomination-file-attachments.query.ts
@@ -3,6 +3,7 @@ import { createZodDto } from 'nestjs-zod';
 import z from 'zod';
 
 import { Db } from 'src/modules/framework/database';
+import { NominationFileAttachmentTypeEnum } from 'src/modules/shared/nomination-file-attachment-type.enum';
 
 @Injectable()
 export class ListNominationFileAttachmentsQuery {
@@ -16,18 +17,24 @@ export class ListNominationFileAttachmentsQuery {
       where: { id: query.nominationFileId, sessionId: query.sessionId },
       select: {
         attachments: {
-          select: { file: { select: { id: true, name: true, sizeInBytes: true } } },
-          orderBy: { file: { createdAt: 'desc' } },
+          select: {
+            type: true,
+            createdAt: true,
+            file: { select: { id: true, name: true, sizeInBytes: true } },
+          },
+          orderBy: { createdAt: 'desc' },
         },
       },
     });
 
     if (!nominationFile) throw new NotFoundException();
     return {
-      items: nominationFile.attachments.map(({ file }) => ({
+      items: nominationFile.attachments.map(({ createdAt, file, type }) => ({
         id: file.id,
         name: file.name,
         size: file.sizeInBytes,
+        type,
+        addedAt: createdAt.toISOString(),
       })),
     };
   }
@@ -40,6 +47,8 @@ export class ListedNominationFileAttachmentDto extends createZodDto(
         id: z.string(),
         name: z.string(),
         size: z.number().int().nullable(),
+        type: z.enum(NominationFileAttachmentTypeEnum),
+        addedAt: z.iso.datetime(),
       }),
     ),
   }),

--- a/apps/api/src/modules/session/transparence/infrastructure/repositories/session-transparence.repository.ts
+++ b/apps/api/src/modules/session/transparence/infrastructure/repositories/session-transparence.repository.ts
@@ -498,7 +498,7 @@ export class SessionTransparenceRepository {
     message: SessionTransparenceFileAttachmentAdded,
   ) {
     await this.db.tx.nominationFileAttachment.create({
-      data: { nominationFileId: message.nominationFileId, fileId: message.file.id },
+      data: { nominationFileId: message.nominationFileId, fileId: message.file.id, type: message.type },
     });
   }
 

--- a/apps/api/src/modules/session/transparence/infrastructure/transparence.service.ts
+++ b/apps/api/src/modules/session/transparence/infrastructure/transparence.service.ts
@@ -13,6 +13,7 @@ import { Sortable } from 'src/modules/framework/sorting';
 import { MembersService } from 'src/modules/members';
 import { roleToFormation } from 'src/modules/members/infrastructure/member.utils';
 import { FormationEnum } from 'src/modules/shared/formation.enum';
+import { NominationFileAttachmentTypeEnum } from 'src/modules/shared/nomination-file-attachment-type.enum';
 import { PriorityEnum } from 'src/modules/shared/priority.enum';
 import type { RoleEnum } from 'src/modules/shared/role.enum';
 import { TypeDeSaisineEnum } from 'src/modules/shared/type-de-saisine.enum';
@@ -384,12 +385,14 @@ export class TransparenceService {
     sessionId: string;
     nominationFileId: string;
     files: { id: string }[];
+    type: NominationFileAttachmentTypeEnum;
   }): Promise<void> {
     const session = await this.nominationSessionRepository.find(command.sessionId);
 
     session.addNominationFileAttachments({
       nominationFileId: command.nominationFileId,
       files: command.files,
+      type: command.type,
     });
     await this.nominationSessionRepository.persist(session);
   }

--- a/apps/api/src/modules/session/transparence/transparence.controller.ts
+++ b/apps/api/src/modules/session/transparence/transparence.controller.ts
@@ -448,9 +448,14 @@ export class SessionController {
   async uploadNominationFileAttachments(
     @Param('sessionId') sessionId: string,
     @Param('nominationFileId') nominationFileId: string,
-    @Body() { files }: Multipart<typeof UploadNominationFileAttachmentsDto>,
+    @Body() { files, form }: Multipart<typeof UploadNominationFileAttachmentsDto>,
   ) {
-    await this.sessions.addNominationFileAttachments({ sessionId, nominationFileId, files });
+    await this.sessions.addNominationFileAttachments({
+      sessionId,
+      nominationFileId,
+      files,
+      type: form.type,
+    });
   }
 
   @HasRole('ADJOINT_SECRETAIRE_GENERAL')

--- a/apps/api/src/modules/shared/mappers/report-file-usage.mapper.ts
+++ b/apps/api/src/modules/shared/mappers/report-file-usage.mapper.ts
@@ -14,16 +14,3 @@ export function prismaReportFileUsageEnumToReportFileUsage(
       return assertNever(value);
   }
 }
-
-export function reportFileUsageToPrismaReportFileUsageEnum(
-  value: PrismaReportFileUsageEnum,
-): ReportFileUsageEnum {
-  switch (value) {
-    case 'ATTACHMENT':
-      return 'ATTACHMENT';
-    case 'EMBEDDED_SCREENSHOT':
-      return 'EMBEDDED_SCREENSHOT';
-    default:
-      return assertNever(value);
-  }
-}

--- a/apps/api/src/modules/shared/nomination-file-attachment-type.enum.ts
+++ b/apps/api/src/modules/shared/nomination-file-attachment-type.enum.ts
@@ -1,0 +1,7 @@
+export const NominationFileAttachmentTypeEnum = {
+  AUTRE: 'AUTRE',
+  FICHE_DE_JURIDICTION: 'FICHE_DE_JURIDICTION',
+  NOTE_INTENTION: 'NOTE_INTENTION',
+} as const;
+export type NominationFileAttachmentTypeEnum =
+  (typeof NominationFileAttachmentTypeEnum)[keyof typeof NominationFileAttachmentTypeEnum];

--- a/apps/client/src/features/nomination-files-table/components/SessionFilesTable.tsx
+++ b/apps/client/src/features/nomination-files-table/components/SessionFilesTable.tsx
@@ -20,6 +20,7 @@ import {
   type SessionNominationFile,
 } from '@queries/nomination-sessions.queries';
 
+import { AddNominationFileAttachmentModalProvider } from './cells/magistrat-side-panel/components/attachments/context/AddNominationFileAttachmentModalProvider';
 import { MagistratSidePanel } from './cells/magistrat-side-panel/components/MagistratSidePanel';
 import { useSidePanel } from './cells/magistrat-side-panel/context/side-panel.context';
 import { SidePanelProvider } from './cells/magistrat-side-panel/context/SidePanelProvider';
@@ -147,26 +148,28 @@ export function SessionFilesTable(
       >
         <NominationFileOutcomeCommentModalProvider>
           <NominationFileTargetPositionProvider sessionId={sessionId}>
-            <MagistratSidePanel sessionId={sessionId} />
-            <div className="flex flex-col gap-y-4">
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex items-center gap-6">
-                  <ReactTableFilterColumn table={table} />
-                  {props.filtersEnd}
+            <AddNominationFileAttachmentModalProvider>
+              <MagistratSidePanel sessionId={sessionId} />
+              <div className="flex flex-col gap-y-4">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-6">
+                    <ReactTableFilterColumn table={table} />
+                    {props.filtersEnd}
+                  </div>
+                  <SearchInput
+                    className="w-72"
+                    onChange={(value) => {
+                      setSearch(value);
+                      updateGlobalFilter(value);
+                    }}
+                    onClear={clearSearch}
+                    value={search}
+                  />
                 </div>
-                <SearchInput
-                  className="w-72"
-                  onChange={(value) => {
-                    setSearch(value);
-                    updateGlobalFilter(value);
-                  }}
-                  onClear={clearSearch}
-                  value={search}
-                />
+                {props.children}
+                <SessionFilesNewTable isLoading={isLoading} onEndReached={fetchNextFilesPage} table={table} />
               </div>
-              {props.children}
-              <SessionFilesNewTable isLoading={isLoading} onEndReached={fetchNextFilesPage} table={table} />
-            </div>
+            </AddNominationFileAttachmentModalProvider>
           </NominationFileTargetPositionProvider>
         </NominationFileOutcomeCommentModalProvider>
       </SidePanelProvider>

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/AddNominationFileAttachmentModal.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/AddNominationFileAttachmentModal.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { axe } from 'vitest-axe';
+
+import { AddNominationFileAttachmentModal } from './AddNominationFileAttachmentModal';
+
+const mocks = vi.hoisted(() => ({ add: vi.fn() }));
+
+vi.mock('@queries/nomination-sessions.queries', () => ({
+  useAddNominationFileAttachmentsMutation: () => ({
+    mutate: mocks.add,
+    isPending: false,
+    isError: false,
+    reset: vi.fn(),
+  }),
+}));
+
+const submitButton = () => screen.getByRole('button', { hidden: true, name: 'Ajouter à la proposition' });
+
+const typeSelect = () => screen.getByRole('combobox', { hidden: true });
+
+const TARGET = { nominationFileId: 'nf-1', sessionId: 'session-1' };
+
+function renderModal(target: typeof TARGET | null = TARGET) {
+  return render(
+    <IntlProvider defaultLocale="fr" locale="fr">
+      <AddNominationFileAttachmentModal target={target} />
+    </IntlProvider>,
+  );
+}
+
+async function selectFile(container: HTMLElement, user: ReturnType<typeof userEvent.setup>) {
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+  await user.upload(input, new File(['data'], 'new.pdf', { type: 'application/pdf' }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AddNominationFileAttachmentModal', () => {
+  it('uploads the selected files with the chosen type', async () => {
+    const user = userEvent.setup();
+    const { container } = renderModal();
+
+    await selectFile(container, user);
+    await user.selectOptions(typeSelect(), 'NOTE_INTENTION');
+    await user.click(submitButton());
+
+    expect(mocks.add).toHaveBeenCalledWith(
+      expect.objectContaining({ nominationFileId: 'nf-1', sessionId: 'session-1', type: 'NOTE_INTENTION' }),
+      expect.any(Object),
+    );
+    expect(mocks.add.mock.calls[0][0].files).toHaveLength(1);
+  });
+
+  it('applies the chosen type to every file of the batch', async () => {
+    const user = userEvent.setup();
+    const { container } = renderModal();
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, [
+      new File(['a'], 'a.pdf', { type: 'application/pdf' }),
+      new File(['b'], 'b.pdf', { type: 'application/pdf' }),
+    ]);
+    await user.selectOptions(typeSelect(), 'FICHE_DE_JURIDICTION');
+    await user.click(submitButton());
+
+    expect(mocks.add.mock.calls[0][0].files).toHaveLength(2);
+    expect(mocks.add.mock.calls[0][0].type).toBe('FICHE_DE_JURIDICTION');
+  });
+
+  it('keeps the submission disabled until a type is chosen', async () => {
+    const user = userEvent.setup();
+    const { container } = renderModal();
+
+    await selectFile(container, user);
+
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('keeps the submission disabled until a file is selected', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.selectOptions(typeSelect(), 'AUTRE');
+
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('does not upload when no nomination file is targeted', async () => {
+    const user = userEvent.setup();
+    const { container } = renderModal(null);
+
+    await selectFile(container, user);
+    await user.selectOptions(typeSelect(), 'AUTRE');
+    await user.click(submitButton());
+
+    expect(mocks.add).not.toHaveBeenCalled();
+  });
+
+  it('passes basic accessibility checks', async () => {
+    const { container } = renderModal();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/AddNominationFileAttachmentModal.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/AddNominationFileAttachmentModal.tsx
@@ -1,0 +1,129 @@
+import { Alert } from '@codegouvfr/react-dsfr/Alert';
+import { createModal } from '@codegouvfr/react-dsfr/Modal';
+import { useIsModalOpen } from '@codegouvfr/react-dsfr/Modal/useIsModalOpen';
+import Select from '@codegouvfr/react-dsfr/Select';
+import { Upload } from '@codegouvfr/react-dsfr/Upload';
+import { useCallback, useRef, useState, type ChangeEvent } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import type { NominationFileAttachmentTypeEnum } from '@/types/enums.types';
+import { useAddNominationFileAttachmentsMutation } from '@queries/nomination-sessions.queries';
+
+import type { AttachmentTarget } from './context/AddNominationFileAttachmentModalContext';
+import {
+  NOMINATION_FILE_ATTACHMENT_TYPES,
+  useNominationFileAttachmentTypeLabel,
+} from './nomination-file-attachment-type';
+
+export const addNominationFileAttachmentModal = createModal({
+  id: 'modal-add-nomination-file-attachment',
+  isOpenedByDefault: false,
+});
+
+export function AddNominationFileAttachmentModal(props: { target: AttachmentTarget | null }) {
+  const { formatMessage } = useIntl();
+  const label = useNominationFileAttachmentTypeLabel();
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<readonly File[]>([]);
+  const [type, setType] = useState<NominationFileAttachmentTypeEnum | ''>('');
+  const { mutate: add, isPending, isError, reset } = useAddNominationFileAttachmentsMutation();
+
+  const clear = useCallback(() => {
+    if (inputRef.current) inputRef.current.value = '';
+    setFiles([]);
+    setType('');
+    reset();
+  }, [reset]);
+
+  useIsModalOpen(addNominationFileAttachmentModal, { onConceal: clear });
+
+  const onChangeFiles = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setFiles([...(event.target.files ?? [])]);
+  }, []);
+
+  const onSubmit = useCallback(() => {
+    if (!props.target || files.length === 0 || !type) return;
+
+    add({ ...props.target, files, type }, { onSuccess: () => addNominationFileAttachmentModal.close() });
+  }, [add, files, props.target, type]);
+
+  return (
+    <addNominationFileAttachmentModal.Component
+      buttons={[
+        {
+          children: formatMessage({ defaultMessage: 'Annuler' }),
+          nativeButtonProps: { disabled: isPending },
+          onClick: clear,
+          priority: 'secondary',
+        },
+        {
+          children: formatMessage({ defaultMessage: 'Ajouter à la proposition' }),
+          doClosesModal: false,
+          nativeButtonProps: { disabled: files.length === 0 || !type || isPending, onClick: onSubmit },
+        },
+      ]}
+      title={formatMessage({ defaultMessage: 'Ajouter une pièce jointe' })}
+    >
+      <div className="fr-p-4v bg-(--background-alt-grey)">
+        <Upload
+          disabled={isPending}
+          hint={formatMessage({ defaultMessage: 'Formats supportés : png, jpeg et pdf.' })}
+          label={formatMessage({ defaultMessage: 'Importer un fichier' })}
+          multiple
+          nativeInputProps={{
+            accept: 'image/png,image/jpeg,application/pdf',
+            onChange: onChangeFiles,
+            ref: inputRef,
+          }}
+        />
+        {isPending && (
+          <p aria-live="polite" className="fr-mt-2v fr-mb-0 text-sm text-(--text-mention-grey)">
+            <span aria-hidden="true" className="fr-icon-refresh-line fr-icon--sm fr-mr-1v" />
+            <FormattedMessage defaultMessage="Import du fichier en cours..." />
+          </p>
+        )}
+      </div>
+
+      <Select
+        className="fr-mt-4v"
+        label={
+          <>
+            <FormattedMessage defaultMessage="Type de document" />
+            <span aria-hidden="true" className="text-(--text-default-error)">
+              &nbsp;*
+            </span>
+          </>
+        }
+        nativeSelectProps={{
+          disabled: isPending,
+          onChange: (event) => setType(event.target.value as NominationFileAttachmentTypeEnum),
+          required: true,
+          value: type,
+        }}
+      >
+        <option disabled value="">
+          {formatMessage({ defaultMessage: 'Choisir un type' })}
+        </option>
+        {NOMINATION_FILE_ATTACHMENT_TYPES.map((attachmentType) => (
+          <option key={attachmentType} value={attachmentType}>
+            {label(attachmentType)}
+          </option>
+        ))}
+      </Select>
+
+      {isError && (
+        <Alert
+          className="fr-mt-2v"
+          closable
+          description={formatMessage({
+            defaultMessage: "L'ajout de la pièce jointe a échoué. Veuillez réessayer.",
+          })}
+          onClose={reset}
+          severity="error"
+          small
+        />
+      )}
+    </addNominationFileAttachmentModal.Component>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.stories.tsx
@@ -9,13 +9,26 @@ import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import type { ListedNominationFileAttachmentDto } from '@api/types';
 
 import { Attachments } from './Attachments';
+import { AddNominationFileAttachmentModalProvider } from './context/AddNominationFileAttachmentModalProvider';
 
 const SESSION_ID = 'session-1';
 
 const SAMPLE_FILES: ListedNominationFileAttachmentDto['items'] = [
-  { id: 'a1', name: 'cv-camille-durand.pdf', size: 248_900 },
-  { id: 'a2', name: 'lettre-de-motivation.pdf', size: 51_200 },
-  { id: 'a3', name: 'photo-identite.png', size: null },
+  {
+    id: 'a1',
+    name: 'cv-camille-durand.pdf',
+    size: 248_900,
+    type: 'FICHE_DE_JURIDICTION',
+    addedAt: '2026-06-18T09:30:00.000Z',
+  },
+  {
+    id: 'a2',
+    name: 'lettre-de-motivation.pdf',
+    size: 51_200,
+    type: 'NOTE_INTENTION',
+    addedAt: '2026-06-18T10:05:00.000Z',
+  },
+  { id: 'a3', name: 'photo-identite.png', size: null, type: 'AUTRE', addedAt: '2026-06-19T08:00:00.000Z' },
 ];
 
 const VIEWS = ['sg', 'member'] as const;
@@ -40,10 +53,18 @@ const attachmentHandlers = [
     '*/api/sessions/v2/:sessionId/files/:nominationFileId/attachments',
     async ({ params, request }) => {
       const nominationFileId = String(params.nominationFileId);
-      const uploaded = (await request.formData())
+      const formData = await request.formData();
+      const { type } = JSON.parse(await (formData.get('form') as Blob).text());
+      const uploaded = formData
         .getAll('files')
         .filter((file): file is File => file instanceof File)
-        .map((file) => ({ id: crypto.randomUUID(), name: file.name, size: file.size }));
+        .map((file) => ({
+          id: crypto.randomUUID(),
+          name: file.name,
+          size: file.size,
+          type,
+          addedAt: new Date().toISOString(),
+        }));
 
       attachmentsByNominationFile.set(nominationFileId, [...attachmentsOf(nominationFileId), ...uploaded]);
       return new HttpResponse(null, { status: 204 });
@@ -68,11 +89,13 @@ function AttachmentsStory(props: AttachmentsArgs) {
   return (
     <StoryQueryClient>
       <ConfirmationProvider>
-        <Attachments
-          isArchived={props.isArchived}
-          nominationFileId={nominationFileIdFor(props)}
-          sessionId={SESSION_ID}
-        />
+        <AddNominationFileAttachmentModalProvider>
+          <Attachments
+            isArchived={props.isArchived}
+            nominationFileId={nominationFileIdFor(props)}
+            sessionId={SESSION_ID}
+          />
+        </AddNominationFileAttachmentModalProvider>
       </ConfirmationProvider>
     </StoryQueryClient>
   );

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.test.tsx
@@ -1,22 +1,33 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
+import { frFormat } from '@/i18n/formats';
+
 import { Attachments } from './Attachments';
 
 const mocks = vi.hoisted(() => ({
-  add: vi.fn(),
-  attachments: [] as { id: string; name: string; size: number | null }[],
+  attachments: [] as {
+    id: string;
+    name: string;
+    size: number | null;
+    type: 'AUTRE' | 'FICHE_DE_JURIDICTION' | 'NOTE_INTENTION';
+    addedAt: string;
+  }[],
   createUrl: vi.fn(),
   download: vi.fn(),
   isSg: vi.fn(() => true),
   open: vi.fn(),
+  openAddAttachment: vi.fn(),
   remove: vi.fn(),
   waitForConfirmation: vi.fn(async () => ({ isConfirmed: true })),
 }));
 
+vi.mock('./context/AddNominationFileAttachmentModalContext', () => ({
+  useAddNominationFileAttachmentModal: () => ({ open: mocks.openAddAttachment }),
+}));
 vi.mock('@/shared/context/confirmation', () => ({
   useConfirmation: () => ({ buttonProps: {}, waitForConfirmation: mocks.waitForConfirmation }),
 }));
@@ -24,12 +35,6 @@ vi.mock('@/shared/hooks/useTab', () => ({ useTab: () => ({ open: mocks.open, dow
 vi.mock('@/features/auth/hooks/roles.hook', () => ({ useIsSgNavigation: () => mocks.isSg() }));
 vi.mock('@queries/nomination-sessions.queries', () => ({
   useListNominationFileAttachmentsQuery: () => ({ data: { items: mocks.attachments } }),
-  useAddNominationFileAttachmentsMutation: () => ({
-    mutate: mocks.add,
-    isPending: false,
-    isError: false,
-    reset: vi.fn(),
-  }),
   useCreateNominationFileAttachmentUrlMutation: () => ({
     mutate: mocks.createUrl,
     isPending: false,
@@ -48,7 +53,7 @@ const PROPS = { nominationFileId: 'nf-1', sessionId: 'session-1', isArchived: fa
 
 function renderAttachments(overrides: Partial<typeof PROPS> = {}) {
   return render(
-    <IntlProvider defaultLocale="fr" locale="fr">
+    <IntlProvider defaultLocale="fr" formats={frFormat} locale="fr">
       <Attachments {...PROPS} {...overrides} />
     </IntlProvider>,
   );
@@ -57,7 +62,15 @@ function renderAttachments(overrides: Partial<typeof PROPS> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.isSg.mockReturnValue(true);
-  mocks.attachments = [{ id: 'file-1', name: 'rapport.pdf', size: 2048 }];
+  mocks.attachments = [
+    {
+      id: 'file-1',
+      name: 'rapport.pdf',
+      size: 2048,
+      type: 'FICHE_DE_JURIDICTION',
+      addedAt: '2026-06-18T09:30:00.000Z',
+    },
+  ];
 });
 
 describe('Attachments listing', () => {
@@ -66,6 +79,14 @@ describe('Attachments listing', () => {
 
     expect(screen.getByRole('button', { name: 'rapport' })).toBeInTheDocument();
     expect(screen.getByText('PDF - 2 Ko')).toBeInTheDocument();
+  });
+
+  it('renders the type badge and the date the attachment was added', () => {
+    renderAttachments();
+    const list = within(screen.getByRole('list'));
+
+    expect(list.getByText('Fiche de juridiction')).toBeInTheDocument();
+    expect(list.getByText('Ajoutée le 18/06/2026')).toBeInTheDocument();
   });
 
   it('renders nothing for a member when there is no attachment', () => {
@@ -131,18 +152,16 @@ describe('Attachments actions', () => {
     expect(mocks.remove).not.toHaveBeenCalled();
   });
 
-  it('uploads the selected files', async () => {
+  it('opens the add modal on the displayed nomination file', async () => {
     const user = userEvent.setup();
-    const { container } = renderAttachments();
+    renderAttachments({ nominationFileId: 'nf-2' });
 
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    await user.upload(input, new File(['data'], 'new.pdf', { type: 'application/pdf' }));
+    await user.click(screen.getByRole('button', { name: 'Ajouter' }));
 
-    expect(mocks.add).toHaveBeenCalledWith(
-      expect.objectContaining({ nominationFileId: 'nf-1', sessionId: 'session-1' }),
-      expect.any(Object),
-    );
-    expect(mocks.add.mock.calls[0][0].files).toHaveLength(1);
+    expect(mocks.openAddAttachment).toHaveBeenCalledWith({
+      nominationFileId: 'nf-2',
+      sessionId: 'session-1',
+    });
   });
 });
 
@@ -152,14 +171,14 @@ describe('Attachments permissions', () => {
     renderAttachments();
 
     expect(screen.queryByRole('button', { name: /Supprimer/ })).not.toBeInTheDocument();
-    expect(screen.queryByText('Ajouter un fichier')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Ajouter' })).not.toBeInTheDocument();
   });
 
   it('hides delete and upload when the file is archived', () => {
     renderAttachments({ isArchived: true });
 
     expect(screen.queryByRole('button', { name: /Supprimer/ })).not.toBeInTheDocument();
-    expect(screen.queryByText('Ajouter un fichier')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Ajouter' })).not.toBeInTheDocument();
   });
 });
 

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.tsx
@@ -1,23 +1,27 @@
 import { Alert } from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
-import { Upload } from '@codegouvfr/react-dsfr/Upload';
-import { useCallback, useRef, type ChangeEvent } from 'react';
+import { useCallback } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useIsSgNavigation } from '@/features/auth/hooks/roles.hook';
 import { useConfirmation } from '@/shared/context/confirmation';
 import { useTab } from '@/shared/hooks/useTab';
+import type { NominationFileAttachmentTypeEnum } from '@/types/enums.types';
 import { formatFileSize, splitFileName } from '@/utils/file.utils';
 import {
-  useAddNominationFileAttachmentsMutation,
   useCreateNominationFileAttachmentUrlMutation,
   useListNominationFileAttachmentsQuery,
   useRemoveNominationFileAttachmentMutation,
 } from '@queries/nomination-sessions.queries';
 
+import { useAddNominationFileAttachmentModal } from './context/AddNominationFileAttachmentModalContext';
+import { NominationFileAttachmentTypeTag } from './NominationFileAttachmentTypeTag';
+
+export const ATTACHMENTS_SECTION_ID = 'magistrat-attachments-section';
+
 export function Attachments(props: { nominationFileId: string; sessionId: string; isArchived: boolean }) {
-  const { formatMessage } = useIntl();
   const isSg = useIsSgNavigation();
+  const { open: openAddAttachment } = useAddNominationFileAttachmentModal();
   const { data } = useListNominationFileAttachmentsQuery({
     nominationFileId: props.nominationFileId,
     sessionId: props.sessionId,
@@ -27,41 +31,32 @@ export function Attachments(props: { nominationFileId: string; sessionId: string
   const canManage = isSg && !props.isArchived;
   const labelId = `attachments-${props.nominationFileId}`;
 
-  const {
-    mutate: add,
-    isPending: isAddPending,
-    isError: isAddError,
-    reset: resetAdd,
-  } = useAddNominationFileAttachmentsMutation();
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
-  const onAdd = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const files = event.target.files;
-      if (!files || files.length === 0) return;
-
-      add(
-        { nominationFileId: props.nominationFileId, sessionId: props.sessionId, files: [...files] },
-        {
-          onSettled() {
-            if (inputRef.current) inputRef.current.value = '';
-          },
-        },
-      );
-    },
-    [add, props.sessionId, props.nominationFileId],
-  );
-
   if (attachments.length === 0 && !canManage) return null;
 
   return (
-    <div>
-      <p className="fr-mb-4v text-xl font-semibold" id={labelId}>
-        <FormattedMessage
-          defaultMessage="{count, plural, one {Pièce jointe} other {Pièces jointes ({count})}}"
-          values={{ count: attachments.length }}
-        />
-      </p>
+    <div id={ATTACHMENTS_SECTION_ID}>
+      <div className="fr-mb-4v flex items-center justify-between gap-4">
+        <p className="fr-mb-0 text-xl font-semibold" id={labelId}>
+          <FormattedMessage
+            defaultMessage="{count, plural, one {Pièce jointe} other {Pièces jointes ({count})}}"
+            values={{ count: attachments.length }}
+          />
+        </p>
+        {canManage && (
+          <Button
+            onClick={() =>
+              openAddAttachment({
+                nominationFileId: props.nominationFileId,
+                sessionId: props.sessionId,
+              })
+            }
+            priority="secondary"
+            size="small"
+          >
+            <FormattedMessage defaultMessage="Ajouter" />
+          </Button>
+        )}
+      </div>
 
       {attachments.length > 0 ? (
         <ul
@@ -71,12 +66,14 @@ export function Attachments(props: { nominationFileId: string; sessionId: string
           {attachments.map((file) => (
             <AttachmentItem
               key={file.id}
+              addedAt={file.addedAt}
               canDelete={canManage}
               fileId={file.id}
               name={file.name}
               nominationFileId={props.nominationFileId}
               sessionId={props.sessionId}
               size={file.size}
+              type={file.type}
             />
           ))}
         </ul>
@@ -87,41 +84,6 @@ export function Attachments(props: { nominationFileId: string; sessionId: string
           </div>
         )
       )}
-
-      {canManage && (
-        <div
-          className="fr-mt-3v fr-p-4v max-w-105 cursor-pointer bg-(--background-alt-grey) [&_.fr-hint-text]:text-sm [&_.fr-hint-text]:font-normal [&_.fr-hint-text]:text-(--text-mention-grey) [&_.fr-label]:cursor-pointer [&_.fr-label]:text-base [&_.fr-label]:font-medium [&_.fr-label]:text-(--text-label-grey) [&_.fr-upload]:cursor-pointer"
-          onClick={(event) => {
-            if ((event.target as HTMLElement).closest('.fr-upload, .fr-label')) return;
-            inputRef.current?.click();
-          }}
-        >
-          <Upload
-            disabled={isAddPending}
-            hint={formatMessage({ defaultMessage: 'Formats supportés : PNG, JPG et PDF' })}
-            label={formatMessage({ defaultMessage: 'Ajouter un fichier' })}
-            multiple
-            nativeInputProps={{
-              accept: 'image/png,image/jpeg,application/pdf',
-              onChange: onAdd,
-              ref: inputRef,
-            }}
-          />
-        </div>
-      )}
-
-      {isAddError && (
-        <Alert
-          className="fr-mt-2v"
-          closable
-          description={formatMessage({
-            defaultMessage: "L'ajout de la pièce jointe a échoué. Veuillez réessayer.",
-          })}
-          onClose={resetAdd}
-          severity="error"
-          small
-        />
-      )}
     </div>
   );
 }
@@ -130,9 +92,11 @@ function AttachmentItem(props: {
   fileId: string;
   nominationFileId: string;
   sessionId: string;
+  addedAt: string;
   canDelete: boolean;
   name: string;
   size: number | null;
+  type: NominationFileAttachmentTypeEnum;
 }) {
   const { formatMessage } = useIntl();
   const tab = useTab();
@@ -215,6 +179,16 @@ function AttachmentItem(props: {
 
   return (
     <li className="fr-py-3v">
+      <div className="fr-mb-2v flex items-center gap-2">
+        <NominationFileAttachmentTypeTag type={props.type} />
+        <span className="text-sm text-(--text-mention-grey)">
+          <FormattedMessage
+            defaultMessage="Ajoutée le {date, date, dateOnlyShort}"
+            values={{ date: new Date(props.addedAt) }}
+          />
+        </span>
+      </div>
+
       <div className="flex items-start justify-between gap-4">
         <div className="grid min-w-0 items-center gap-x-2" style={{ gridTemplateColumns: 'auto 1fr' }}>
           <span

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/NominationFileAttachmentTypeTag.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/NominationFileAttachmentTypeTag.tsx
@@ -1,0 +1,39 @@
+import { colors } from '@codegouvfr/react-dsfr';
+import Tag from '@codegouvfr/react-dsfr/Tag';
+
+import type { NominationFileAttachmentTypeEnum } from '@/types/enums.types';
+import { assertNever } from '@/utils/types.util';
+
+import { useNominationFileAttachmentTypeLabel } from './nomination-file-attachment-type';
+
+function tagColors(type: NominationFileAttachmentTypeEnum) {
+  switch (type) {
+    case 'FICHE_DE_JURIDICTION':
+      return {
+        background: colors.decisions.background.contrast.blueEcume.default,
+        color: colors.decisions.text.label.blueEcume.default,
+      };
+    case 'NOTE_INTENTION':
+      return {
+        background: colors.decisions.background.contrast.greenEmeraude.default,
+        color: colors.decisions.text.label.greenEmeraude.default,
+      };
+    case 'AUTRE':
+      return {
+        background: colors.decisions.background.contrast.grey.default,
+        color: colors.decisions.text.label.grey.default,
+      };
+    default:
+      return assertNever(type);
+  }
+}
+
+export function NominationFileAttachmentTypeTag(props: { type: NominationFileAttachmentTypeEnum }) {
+  const label = useNominationFileAttachmentTypeLabel();
+
+  return (
+    <Tag as="span" small style={tagColors(props.type)}>
+      {label(props.type)}
+    </Tag>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/context/AddNominationFileAttachmentModalContext.ts
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/context/AddNominationFileAttachmentModalContext.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react';
+
+export type AttachmentTarget = { nominationFileId: string; sessionId: string };
+
+type AddNominationFileAttachmentModalContextType = {
+  open: (target: AttachmentTarget) => void;
+};
+
+/** @internal */
+export const AddNominationFileAttachmentModalContext =
+  createContext<AddNominationFileAttachmentModalContextType | null>(null);
+
+export function useAddNominationFileAttachmentModal() {
+  const ctx = useContext(AddNominationFileAttachmentModalContext);
+  if (!ctx)
+    throw new Error(
+      'useAddNominationFileAttachmentModal must be used within AddNominationFileAttachmentModalProvider',
+    );
+
+  return ctx;
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/context/AddNominationFileAttachmentModalProvider.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/context/AddNominationFileAttachmentModalProvider.tsx
@@ -1,0 +1,30 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+
+import {
+  addNominationFileAttachmentModal,
+  AddNominationFileAttachmentModal,
+} from '../AddNominationFileAttachmentModal';
+
+import {
+  AddNominationFileAttachmentModalContext,
+  type AttachmentTarget,
+} from './AddNominationFileAttachmentModalContext';
+
+export function AddNominationFileAttachmentModalProvider(props: { children: ReactNode }) {
+  const [target, setTarget] = useState<AttachmentTarget | null>(null);
+
+  const open = useCallback((target: AttachmentTarget) => {
+    setTarget(target);
+    addNominationFileAttachmentModal.open();
+  }, []);
+
+  const value = useMemo(() => ({ open }), [open]);
+
+  return (
+    <AddNominationFileAttachmentModalContext value={value}>
+      <AddNominationFileAttachmentModal target={target} />
+
+      {props.children}
+    </AddNominationFileAttachmentModalContext>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/nomination-file-attachment-type.ts
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/nomination-file-attachment-type.ts
@@ -1,0 +1,27 @@
+import { useIntl } from 'react-intl';
+
+import type { NominationFileAttachmentTypeEnum } from '@/types/enums.types';
+import { assertNever } from '@/utils/types.util';
+
+export const NOMINATION_FILE_ATTACHMENT_TYPES = [
+  'FICHE_DE_JURIDICTION',
+  'NOTE_INTENTION',
+  'AUTRE',
+] as const satisfies readonly NominationFileAttachmentTypeEnum[];
+
+export function useNominationFileAttachmentTypeLabel() {
+  const { formatMessage } = useIntl();
+
+  return (type: NominationFileAttachmentTypeEnum): string => {
+    switch (type) {
+      case 'FICHE_DE_JURIDICTION':
+        return formatMessage({ defaultMessage: 'Fiche de juridiction' });
+      case 'NOTE_INTENTION':
+        return formatMessage({ defaultMessage: "Note d'intention" });
+      case 'AUTRE':
+        return formatMessage({ defaultMessage: 'Autre' });
+      default:
+        return assertNever(type);
+    }
+  };
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/observations/Observations.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/observations/Observations.test.tsx
@@ -95,6 +95,18 @@ describe('Observations', () => {
     expect(screen.queryByRole('button', { name: 'Ajouter' })).not.toBeInTheDocument();
   });
 
+  it('collapses back the observations expanded with the show more button', async () => {
+    const user = userEvent.setup();
+    observations = ['obs-1', 'obs-2', 'obs-3', 'obs-4'].map(makeObservation);
+    renderObservations();
+
+    await user.click(screen.getByRole('button', { name: 'Afficher plus (1)' }));
+    expect(screen.getAllByRole('listitem')).toHaveLength(4);
+
+    await user.click(screen.getByRole('button', { name: 'Afficher moins' }));
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+
   it('renders nothing for a member when there is neither observer nor observation', () => {
     isSg.mockReturnValue(false);
     renderObservations();

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/observations/Observations.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/observations/Observations.tsx
@@ -280,16 +280,20 @@ export function Observations({
         </ul>
       )}
 
-      {hiddenCount > 0 && (
+      {observations.length > VISIBLE_OBSERVATIONS && (
         <Button
           className="fr-mt-3v btn-compact"
-          iconId="fr-icon-arrow-down-s-line"
+          iconId={showAll ? 'fr-icon-arrow-up-s-line' : 'fr-icon-arrow-down-s-line'}
           iconPosition="right"
-          onClick={() => setShowAll(true)}
+          onClick={() => setShowAll(!showAll)}
           priority="tertiary"
           size="small"
         >
-          <FormattedMessage defaultMessage="Afficher plus ({count})" values={{ count: hiddenCount }} />
+          {showAll ? (
+            <FormattedMessage defaultMessage="Afficher moins" />
+          ) : (
+            <FormattedMessage defaultMessage="Afficher plus ({count})" values={{ count: hiddenCount }} />
+          )}
         </Button>
       )}
 

--- a/apps/client/src/generated/api/types.ts
+++ b/apps/client/src/generated/api/types.ts
@@ -520,6 +520,9 @@ export type DetailedNominationSessionAttachmentDto = {
 
 export type UploadNominationFileAttachmentsDto = {
     files?: Array<Blob | File>;
+    form: {
+        type: 'AUTRE' | 'FICHE_DE_JURIDICTION' | 'NOTE_INTENTION';
+    };
 };
 
 export type ListedNominationFileAttachmentDto = {
@@ -527,6 +530,8 @@ export type ListedNominationFileAttachmentDto = {
         id: string;
         name: string;
         size: number | null;
+        type: 'AUTRE' | 'FICHE_DE_JURIDICTION' | 'NOTE_INTENTION';
+        addedAt: string;
     }>;
 };
 

--- a/apps/client/src/queries/nomination-sessions.queries.ts
+++ b/apps/client/src/queries/nomination-sessions.queries.ts
@@ -22,6 +22,7 @@ import type {
   NoneAffectationVersion,
   PaginatedNominationFiles,
   SomeAffectationVersion,
+  UploadNominationFileAttachmentsDto,
 } from '@api/types';
 
 import { agendaKeys } from './agenda.queries';
@@ -385,10 +386,14 @@ export const useAddNominationFileAttachmentsMutation = () => {
       nominationFileId: string;
       sessionId: string;
       files: readonly File[] | FileList;
+      type: UploadNominationFileAttachmentsDto['form']['type'];
     }) => {
       await $api.sessions.uploadNominationFileAttachments({
         path: { nominationFileId: input.nominationFileId, sessionId: input.sessionId },
-        body: { files: [...input.files] },
+        body: {
+          files: [...input.files],
+          form: multipartJson({ type: input.type } satisfies UploadNominationFileAttachmentsDto['form']),
+        },
       });
     },
     onSuccess: async (_data, { nominationFileId, sessionId }) => {

--- a/apps/client/src/types/enums.types.ts
+++ b/apps/client/src/types/enums.types.ts
@@ -7,6 +7,7 @@ import type {
   FollowUpOnObservationDto,
   FoundDocsNominationFiles,
   PaginatedNominationFiles,
+  UploadNominationFileAttachmentsDto,
 } from '@api/types';
 
 export type RoleEnum = DetailedUserResponseDto['role'];
@@ -19,6 +20,7 @@ export const RoleEnumLabels: Record<RoleEnum, string> = {
 };
 
 export type GenderEnum = DetailedUserResponseDto['gender'];
+export type NominationFileAttachmentTypeEnum = UploadNominationFileAttachmentsDto['form']['type'];
 export type ReportStatusEnum = NonNullable<DetailedReportDto['state']>;
 export const REPORT_STATUSES = [
   'NEW',

--- a/apps/client/tests/e2e/nomination-file-attachment.spec.ts
+++ b/apps/client/tests/e2e/nomination-file-attachment.spec.ts
@@ -50,8 +50,9 @@ test.describe('Pièces jointes de dossier de nomination', () => {
     const attachment = new File(['preuve'], 'preuve.pdf', { type: 'application/pdf' });
     await modal.addAttachment(attachment);
 
-    // Alors la pièce jointe est visible
+    // Alors la pièce jointe est visible avec son type
     await modal.attachment(attachment.name).waitFor();
+    await modal.attachmentType('Fiche de juridiction').waitFor();
 
     // Quand je supprime la pièce jointe
     await modal.deleteAttachment(attachment.name);

--- a/apps/client/tests/pages/manage-single-session.page.ts
+++ b/apps/client/tests/pages/manage-single-session.page.ts
@@ -161,12 +161,20 @@ class MagistratSidePanel {
     return this.observationsSection.getByRole('button', { name: "Éditer l'observation" });
   }
 
-  private get fileInput(): Locator {
-    return this.dialog.locator('input[type="file"]');
+  private get attachmentsSection(): Locator {
+    return this.dialog.locator('#magistrat-attachments-section');
+  }
+
+  private get addAttachmentModal(): Locator {
+    return this.page.locator('#modal-add-nomination-file-attachment');
   }
 
   attachment(name: string): Locator {
     return this.dialog.getByTitle(`Ouvrir ${name} dans un nouvel onglet`, { exact: true });
+  }
+
+  attachmentType(label: string): Locator {
+    return this.attachmentsSection.getByText(label, { exact: true });
   }
 
   private deleteButton(name: string): Locator {
@@ -177,12 +185,17 @@ class MagistratSidePanel {
     return this.page.locator('#confirmation_modal').getByRole('button', { name: 'Supprimer', exact: true });
   }
 
-  async addAttachment(file: File): Promise<void> {
-    await this.fileInput.setInputFiles({
+  async addAttachment(file: File, type = 'Fiche de juridiction'): Promise<void> {
+    await this.attachmentsSection.getByRole('button', { name: 'Ajouter' }).click();
+
+    const modal = this.addAttachmentModal;
+    await modal.locator('input[type="file"]').setInputFiles({
       name: file.name,
       mimeType: file.type,
       buffer: Buffer.from(await file.arrayBuffer()),
     });
+    await modal.getByLabel('Type de document').selectOption({ label: type });
+    await modal.getByRole('button', { name: 'Ajouter à la proposition' }).click();
   }
 
   async deleteAttachment(name: string): Promise<void> {


### PR DESCRIPTION
- Attachments on a proposal are now typed: `FICHE_DE_JURIDICTION`, `NOTE_INTENTION` or `AUTRE`, picked in a new dedicated modal that replaces the inline drop zone
- Each attachment displays its type as a badge and the date it was added, backed by a new `created_at` column backfilled from the file creation date
- The type travels through the multipart `form` part and the `SessionTransparenceFileAttachmentAdded` event, down to the new `nomination_file_attachment_type_enum` column
- The modal is mounted at table level through a provider rather than inside the side panel, so it no longer fights with the panel's focus trap and Escape handling