### PR TITLE
refactor(FON-000): render the excluded jurisdictions the same way everywhere

### DIFF
--- a/apps/client/src/features/nomination-files-table/components/ExcludedJurisdictionLines.tsx
+++ b/apps/client/src/features/nomination-files-table/components/ExcludedJurisdictionLines.tsx
@@ -1,0 +1,34 @@
+import clsx from 'clsx';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import {
+  excludedJurisdictionLines,
+  type ExcludedJurisdictionConflict,
+} from '../context/member-excluded-jurisdictions';
+
+export function ExcludedJurisdictionLines(props: {
+  className?: string;
+  conflicts: readonly ExcludedJurisdictionConflict[];
+}) {
+  const { formatList } = useIntl();
+
+  const lines = excludedJurisdictionLines(props.conflicts);
+  if (lines.length === 0) return null;
+
+  return (
+    <ul className={clsx('fr-mb-0 flex flex-col gap-1', props.className)}>
+      {lines.map(({ jurisdictions, memberNames }) => (
+        <li key={JSON.stringify(jurisdictions)}>
+          <FormattedMessage
+            defaultMessage="{count, plural, one {Juridiction exclue} other {Juridictions exclues}} pour {memberNames} : {jurisdictions}"
+            values={{
+              count: jurisdictions.length,
+              jurisdictions: formatList(jurisdictions),
+              memberNames: formatList(memberNames),
+            }}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/ExcludedJurisdictionNotice.tsx
+++ b/apps/client/src/features/nomination-files-table/components/ExcludedJurisdictionNotice.tsx
@@ -1,38 +1,17 @@
-import { FormattedMessage, useIntl } from 'react-intl';
-
-import {
-  excludedJurisdictionLines,
-  type ExcludedJurisdictionConflict,
-} from '../context/member-excluded-jurisdictions';
+import type { ExcludedJurisdictionConflict } from '../context/member-excluded-jurisdictions';
 import { AlertBanner } from '@/shared/ui/alert-banner';
 
-export function ExcludedJurisdictionNotice(props: { conflicts: readonly ExcludedJurisdictionConflict[] }) {
-  const { formatList } = useIntl();
-  const lines = excludedJurisdictionLines(props.conflicts);
+import { ExcludedJurisdictionLines } from './ExcludedJurisdictionLines';
 
+export function ExcludedJurisdictionNotice(props: { conflicts: readonly ExcludedJurisdictionConflict[] }) {
   return (
     /** @warning the live region is always rendered: a screen reader ignores one that appears already filled */
     <div role="status">
-      {lines.length > 0 && (
+      {props.conflicts.length > 0 && (
         <AlertBanner
-          className="mt-2 px-4 py-2"
+          className="mt-2 px-4 py-4"
           icon="fr-icon-warning-fill"
-          message={
-            <ul className="fr-mb-0 flex flex-col gap-1">
-              {lines.map(({ jurisdictions, memberNames }) => (
-                <li key={JSON.stringify(jurisdictions)}>
-                  <FormattedMessage
-                    defaultMessage="{count, plural, one {Juridiction exclue} other {Juridictions exclues}} pour {memberNames} : {jurisdictions}"
-                    values={{
-                      count: jurisdictions.length,
-                      jurisdictions: formatList(jurisdictions),
-                      memberNames: formatList(memberNames),
-                    }}
-                  />
-                </li>
-              ))}
-            </ul>
-          }
+          message={<ExcludedJurisdictionLines conflicts={props.conflicts} />}
           tone="warning"
         />
       )}

--- a/apps/client/src/features/nomination-files-table/components/cells/reporters/ReportersCell.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/reporters/ReportersCell.test.tsx
@@ -16,7 +16,10 @@ const LYON = { id: 'CA  LYON', label: "Cour d'appel de Lyon" };
 const CAMILLE = { firstName: 'Camille', id: 'camille', lastName: 'Commun' };
 const PAUL = { firstName: 'Paul', id: 'paul', lastName: 'Parquet' };
 
-function renderCell(excludedJurisdictionsOfCamille: (typeof LYON)[]) {
+function renderCell(
+  excludedJurisdictionsOfCamille: (typeof LYON)[],
+  excludedJurisdictionsOfPaul: (typeof LYON)[] = [],
+) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   client.setQueryData(authKeys.introspectSession(), { ...PAUL, role: 'MEMBRE_DU_SIEGE' });
 
@@ -27,7 +30,7 @@ function renderCell(excludedJurisdictionsOfCamille: (typeof LYON)[]) {
 
   const model = MemberExcludedJurisdictions.fromMembers([
     { ...CAMILLE, excludedJurisdictions: excludedJurisdictionsOfCamille },
-    { ...PAUL, excludedJurisdictions: [] },
+    { ...PAUL, excludedJurisdictions: excludedJurisdictionsOfPaul },
   ]);
 
   return render(
@@ -53,6 +56,14 @@ describe('ReportersCell', () => {
 
     expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent(
       `Juridiction exclue pour Camille COMMUN : ${LYON.label}`,
+    );
+  });
+
+  it('gathers the reporters sharing a jurisdiction on a single line, as the notice does', () => {
+    renderCell([LYON], [LYON]);
+
+    expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent(
+      `Juridiction exclue pour Camille COMMUN et Paul PARQUET : ${LYON.label}`,
     );
   });
 

--- a/apps/client/src/features/nomination-files-table/components/cells/reporters/ReportersCell.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/reporters/ReportersCell.tsx
@@ -1,8 +1,6 @@
 import { ExcludedJurisdictionIcon } from '@/features/nomination-files-table/components/ExcludedJurisdictionIcon';
-import {
-  useExcludedJurisdictions,
-  useExcludedJurisdictionTitles,
-} from '@/features/nomination-files-table/context/excluded-jurisdictions.context';
+import { ExcludedJurisdictionLines } from '@/features/nomination-files-table/components/ExcludedJurisdictionLines';
+import { useExcludedJurisdictions } from '@/features/nomination-files-table/context/excluded-jurisdictions.context';
 import { ReporterTagList } from '@/shared/components/reporter-tag';
 import { useUser } from '@queries/auth.queries';
 import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
@@ -14,11 +12,11 @@ export function ReportersCell(props: { dossier: SessionNominationFile }) {
     props.dossier,
     props.dossier.reporters.map(({ id }) => id),
   );
-  const excludedTitleByReporterId = useExcludedJurisdictionTitles(conflicts);
+  const excludedReporterIds = new Set(conflicts.map(({ memberId }) => memberId));
 
   const reporters = props.dossier.reporters.map((reporter) => ({
     ...reporter,
-    icon: excludedTitleByReporterId.has(reporter.id) ? <ExcludedJurisdictionIcon /> : undefined,
+    icon: excludedReporterIds.has(reporter.id) ? <ExcludedJurisdictionIcon /> : undefined,
     isCurrentUser: reporter.id === user?.id,
   }));
 
@@ -27,15 +25,7 @@ export function ReportersCell(props: { dossier: SessionNominationFile }) {
   return (
     <div className="flex items-center">
       <ReporterTagList
-        details={
-          excludedTitleByReporterId.size > 0 ? (
-            <ul className="fr-mb-0 mt-1 flex flex-col gap-1">
-              {[...excludedTitleByReporterId].map(([reporterId, title]) => (
-                <li key={reporterId}>{title}</li>
-              ))}
-            </ul>
-          ) : undefined
-        }
+        details={<ExcludedJurisdictionLines className="mt-1" conflicts={conflicts} />}
         reporters={reporters}
       />
     </div>

--- a/apps/client/src/shared/components/reporter-tag/ReporterTagList.stories.tsx
+++ b/apps/client/src/shared/components/reporter-tag/ReporterTagList.stories.tsx
@@ -1,20 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { ExcludedJurisdictionIcon } from '@/features/nomination-files-table/components/ExcludedJurisdictionIcon';
+import { ExcludedJurisdictionLines } from '@/features/nomination-files-table/components/ExcludedJurisdictionLines';
+import type { ExcludedJurisdictionConflict } from '@/features/nomination-files-table/context/member-excluded-jurisdictions';
 
 import { ReporterTagList } from './ReporterTagList';
 
 const LYON = "Cour d'appel de Lyon";
 const RENNES = "Cour d'appel de Rennes";
 
-function excludedJurisdictionDetails(titles: readonly string[]) {
-  return (
-    <ul className="fr-mb-0 mt-1 flex flex-col gap-1">
-      {titles.map((title) => (
-        <li key={title}>{title}</li>
-      ))}
-    </ul>
-  );
+const CAMILLE = { firstName: 'Camille', id: 'camille', lastName: 'Commun' };
+const PAUL = { firstName: 'Paul', id: 'paul', lastName: 'Parquet' };
+const SOPHIE = { firstName: 'Sophie', id: 'sophie', lastName: 'Siège' };
+
+function conflict(memberName: string, jurisdiction: string): ExcludedJurisdictionConflict {
+  return { fileId: 'file-1', fileNumber: 12, jurisdiction, memberId: memberName, memberName };
 }
 
 const meta = {
@@ -36,9 +36,9 @@ const meta = {
       { firstName: 'Ada', id: 'ada', lastName: 'Lovelace' },
       { firstName: 'Jean-Pierre', id: 'jean-pierre', lastName: 'de la Tour' },
       { firstName: 'Marie', id: 'marie', lastName: 'Curie' },
-      { firstName: 'Sophie', id: 'sophie', lastName: 'Siège' },
-      { firstName: 'Camille', id: 'camille', lastName: 'Commun' },
-      { firstName: 'Paul', id: 'paul', lastName: 'Parquet' },
+      SOPHIE,
+      CAMILLE,
+      PAUL,
     ],
   },
 } satisfies Meta<typeof ReporterTagList>;
@@ -49,26 +49,38 @@ type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {};
 
-export const ExcludedJurisdictions: Story = {
+export const SharedExcludedJurisdiction: Story = {
   args: {
-    details: excludedJurisdictionDetails([
-      `Juridiction exclue pour Camille COMMUN : ${LYON}`,
-      `Juridiction exclue pour Sophie SIÈGE : ${LYON}`,
-    ]),
+    details: (
+      <ExcludedJurisdictionLines
+        className="mt-1"
+        conflicts={[conflict('Camille COMMUN', LYON), conflict('Sophie SIÈGE', LYON)]}
+      />
+    ),
     reporters: [
-      { firstName: 'Camille', icon: <ExcludedJurisdictionIcon />, id: 'camille', lastName: 'Commun' },
-      { firstName: 'Sophie', icon: <ExcludedJurisdictionIcon />, id: 'sophie', lastName: 'Siège' },
-      { firstName: 'Paul', id: 'paul', lastName: 'Parquet' },
+      { ...CAMILLE, icon: <ExcludedJurisdictionIcon /> },
+      { ...SOPHIE, icon: <ExcludedJurisdictionIcon /> },
+      PAUL,
     ],
   },
 };
 
-export const SeveralExcludedJurisdictions: Story = {
+export const ExcludedJurisdictions: Story = {
   args: {
-    details: excludedJurisdictionDetails([`Juridictions exclues pour Camille COMMUN : ${LYON} et ${RENNES}`]),
+    details: (
+      <ExcludedJurisdictionLines
+        className="mt-1"
+        conflicts={[
+          conflict('Camille COMMUN', LYON),
+          conflict('Camille COMMUN', RENNES),
+          conflict('Sophie SIÈGE', LYON),
+        ]}
+      />
+    ),
     reporters: [
-      { firstName: 'Camille', icon: <ExcludedJurisdictionIcon />, id: 'camille', lastName: 'Commun' },
-      { firstName: 'Paul', id: 'paul', lastName: 'Parquet' },
+      { ...CAMILLE, icon: <ExcludedJurisdictionIcon /> },
+      { ...SOPHIE, icon: <ExcludedJurisdictionIcon /> },
+      PAUL,
     ],
   },
 };

--- a/apps/client/src/shared/ui/alert-banner/AlertBanner.stories.tsx
+++ b/apps/client/src/shared/ui/alert-banner/AlertBanner.stories.tsx
@@ -1,25 +1,73 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComponentProps, PropsWithChildren } from 'react';
 
-import { AuditionScheduledBanner } from '@/shared/components/audition-banner';
+import { AuditionNotice } from '@/features/nomination-files-table/components/cells/magistrat-side-panel/components/audition-date/AuditionNotice';
+import { MissingSecondReporterNotice } from '@/features/nomination-files-table/components/cells/magistrat-side-panel/components/header/MissingSecondReporterNotice';
+import { MissingEvaluationNotice } from '@/features/nomination-files-table/components/cells/magistrat-side-panel/components/missing-evaluation/MissingEvaluation';
+import { ExcludedJurisdictionNotice } from '@/features/nomination-files-table/components/ExcludedJurisdictionNotice';
+import type { ExcludedJurisdictionConflict } from '@/features/nomination-files-table/context/member-excluded-jurisdictions';
 
 import { AlertBanner, AlertBannerAction } from './AlertBanner';
 
 const LAYOUT = 'rounded px-4 py-3';
 
+const NO_CONTROLS = { controls: { disable: true }, layout: 'padded' };
+
+const UPCOMING = {
+  auditionDate: { day: 15, month: 6, year: 2029 },
+  auditionTime: { hours: 14, minutes: 30, seconds: 0 },
+};
+const PAST = {
+  auditionDate: { day: 10, month: 1, year: 2020 },
+  auditionTime: { hours: 14, minutes: 30, seconds: 0 },
+};
+
 const LYON = "Cour d'appel de Lyon";
 const RENNES = "Cour d'appel de Rennes";
 
-const UPCOMING = { date: { day: 15, month: 6, year: 2029 }, time: { hours: 14, minutes: 30, seconds: 0 } };
-const PAST = { date: { day: 10, month: 1, year: 2020 }, time: { hours: 14, minutes: 30, seconds: 0 } };
+function conflict(memberName: string, jurisdiction: string): ExcludedJurisdictionConflict {
+  return { fileId: 'file-1', fileNumber: 12, jurisdiction, memberId: memberName, memberName };
+}
 
-const NO_CONTROLS = { controls: { disable: true }, layout: 'padded' };
+const EXCLUSIONS = [
+  [conflict('Camille COMMUN', LYON)],
+  [conflict('Camille COMMUN', LYON), conflict('Sophie SIÈGE', LYON)],
+  [conflict('Camille COMMUN', LYON), conflict('Camille COMMUN', RENNES), conflict('Sophie SIÈGE', LYON)],
+];
+
+const BLEEDS_TOP = 'px-8 pt-10';
+const BLEEDS_BOTTOM = 'px-8 pb-8';
+const STACK = 'flex flex-col gap-4';
+
+const ACTION_ONLY = {
+  className: { table: { disable: true } },
+  icon: { table: { disable: true } },
+  message: { table: { disable: true } },
+  tone: { table: { disable: true } },
+};
+
+function Notice(props: PropsWithChildren<{ className: string }>) {
+  return <div className={props.className}>{props.children}</div>;
+}
+
+function AlertBannerStory({
+  buttonAction,
+  ...props
+}: ComponentProps<typeof AlertBanner> & { buttonAction: boolean }) {
+  return (
+    <AlertBanner {...props}>
+      {buttonAction && <AlertBannerAction onClick={() => {}}>Modifier</AlertBannerAction>}
+    </AlertBanner>
+  );
+}
 
 const meta = {
   title: 'Shared/AlertBanner',
-  component: AlertBanner,
+  component: AlertBannerStory,
   parameters: { layout: 'padded' },
   tags: ['autodocs'],
   argTypes: {
+    buttonAction: { control: 'boolean' },
     children: { table: { disable: true } },
     className: { table: { disable: true } },
     icon: { control: 'text' },
@@ -27,12 +75,13 @@ const meta = {
     tone: { control: 'inline-radio', options: ['info', 'warning'] },
   },
   args: {
+    buttonAction: true,
     className: LAYOUT,
     icon: 'fr-icon-warning-fill',
     message: 'Une alerte sur ce dossier',
     tone: 'warning',
   },
-} satisfies Meta<typeof AlertBanner>;
+} satisfies Meta<typeof AlertBannerStory>;
 
 export default meta;
 
@@ -40,57 +89,48 @@ type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {};
 
-export const AuditionToSchedule: Story = {
-  args: {
-    children: <AlertBannerAction onClick={() => {}}>Planifier</AlertBannerAction>,
-    message: 'Une audition est à prévoir pour ce poste',
-  },
-  parameters: NO_CONTROLS,
-};
-
-export const AuditionScheduled: Story = {
-  parameters: NO_CONTROLS,
-  render: () => <AuditionScheduledBanner className={LAYOUT} {...UPCOMING} />,
-};
-
-export const AuditionPast: Story = {
-  parameters: NO_CONTROLS,
-  render: () => <AuditionScheduledBanner className={LAYOUT} {...PAST} />,
-};
-
-export const MissingEvaluation: Story = {
-  args: { icon: 'fr-icon-draft-line', message: 'Évaluation manquante dans le dossier administratif LOLFI' },
-  parameters: NO_CONTROLS,
-};
-
-export const MissingSecondReporter: Story = {
-  args: {
-    children: <AlertBannerAction onClick={() => {}}>Affecter</AlertBannerAction>,
-    message: '2 rapporteurs sont attendus pour ce poste',
-  },
-  parameters: NO_CONTROLS,
+export const Audition: Story = {
+  argTypes: ACTION_ONLY,
+  render: ({ buttonAction }) => (
+    <div className={STACK}>
+      <Notice className={BLEEDS_TOP}>
+        <AuditionNotice auditionDate={null} auditionMissing auditionTime={null} editable={buttonAction} />
+      </Notice>
+      <Notice className={BLEEDS_TOP}>
+        <AuditionNotice {...UPCOMING} auditionMissing={false} editable={buttonAction} />
+      </Notice>
+      <Notice className={BLEEDS_TOP}>
+        <AuditionNotice {...PAST} auditionMissing={false} editable={buttonAction} />
+      </Notice>
+    </div>
+  ),
 };
 
 export const ExcludedJurisdiction: Story = {
-  args: { message: `Juridiction exclue pour Marie LEFEVRE : ${LYON}` },
   parameters: NO_CONTROLS,
+  render: () => (
+    <div className={STACK}>
+      {EXCLUSIONS.map((conflicts) => (
+        <ExcludedJurisdictionNotice conflicts={conflicts} key={JSON.stringify(conflicts)} />
+      ))}
+    </div>
+  ),
 };
 
-export const SharedExcludedJurisdiction: Story = {
-  args: { message: `Juridiction exclue pour Marie LEFEVRE et Paul MOREAU : ${LYON}` },
-  parameters: NO_CONTROLS,
+export const MissingEvaluation: Story = {
+  argTypes: ACTION_ONLY,
+  render: ({ buttonAction }) => (
+    <Notice className={BLEEDS_TOP}>
+      <MissingEvaluationNotice editable={buttonAction} missingEvaluation />
+    </Notice>
+  ),
 };
 
-export const ExcludedJurisdictions: Story = {
-  args: {
-    message: (
-      <ul className="fr-mb-0 flex flex-col gap-1">
-        <li>
-          Juridictions exclues pour Marie LEFEVRE : {LYON} et {RENNES}
-        </li>
-        <li>Juridiction exclue pour Paul MOREAU : {LYON}</li>
-      </ul>
-    ),
-  },
-  parameters: NO_CONTROLS,
+export const MissingSecondReporter: Story = {
+  argTypes: ACTION_ONLY,
+  render: ({ buttonAction }) => (
+    <Notice className={BLEEDS_BOTTOM}>
+      <MissingSecondReporterNotice editable={buttonAction} onAffect={() => {}} />
+    </Notice>
+  ),
 };


### PR DESCRIPTION
- `ExcludedJurisdictionLines` now owns that rendering and both consumers use it
- The notice takes the same vertical padding as the audition and evaluation ones
- Storybook shows the cases through the real components: banner variants by subject in `Shared/AlertBanner`, grouped tooltip in `Shared/ReporterTagList`