### PR TITLE
fix(FON-529): report gotenberg generation failures

### DIFF
--- a/apps/api/src/modules/framework/files/mime-type.spec.ts
+++ b/apps/api/src/modules/framework/files/mime-type.spec.ts
@@ -1,0 +1,22 @@
+import { FILE_EXTENSIONS, filenameToMimeType } from './mime-type';
+
+describe('filenameToMimeType', () => {
+  it.each([
+    ['photo.jpg', 'image/jpeg'],
+    ['photo.jpeg', 'image/jpeg'],
+    ['PHOTO.JPEG', 'image/jpeg'],
+    ['rapport.PDF', 'application/pdf'],
+    ['note.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+    ['agenda.pdf-2026', 'application/pdf'],
+  ])('reads %s as %s', (filename, expected) => {
+    expect(filenameToMimeType(filename)).toBe(expected);
+  });
+
+  it.each(['archive.rar', 'README', ''])('does not guess a type for %s', (filename) => {
+    expect(filenameToMimeType(filename)).toBeUndefined();
+  });
+
+  it('keeps jpg as the extension used to name a stored jpeg', () => {
+    expect(FILE_EXTENSIONS['image/jpeg']).toBe('jpg');
+  });
+});

--- a/apps/api/src/modules/framework/files/mime-type.ts
+++ b/apps/api/src/modules/framework/files/mime-type.ts
@@ -35,12 +35,16 @@ export function isMimeType(value: unknown): value is FileMimeType {
   return MIME_TYPES.has(value as any);
 }
 
+const EXTENSION_ALIASES: Record<string, FileMimeType> = {
+  jpeg: FILE_MIME_TYPES.jpg,
+};
+
 /** @param filename a UNIX filename like {filename}.{extension}. It eventually supports format like {filename}.{extension}-{suffix} */
 export function filenameToMimeType(filename: string): FileMimeType | undefined {
-  const extension = filename.split('.').at(-1)?.split('-').at(0);
-  return isDefined(extension) && extension in FILE_MIME_TYPES
-    ? (FILE_MIME_TYPES as any)[extension]
-    : undefined;
+  const extension = filename.split('.').at(-1)?.split('-').at(0)?.toLowerCase();
+  if (!isDefined(extension)) return undefined;
+
+  return (FILE_MIME_TYPES as Record<string, FileMimeType>)[extension] ?? EXTENSION_ALIASES[extension];
 }
 
 /**

--- a/apps/api/src/modules/framework/http.ts
+++ b/apps/api/src/modules/framework/http.ts
@@ -191,7 +191,6 @@ class HttpModule {
             const instance = axios.create();
             retry(instance, {
               onRetry(count) {
-                console.log('retry', count);
                 Sentry.getActiveSpan()?.setAttribute('http.request.resend_count', count);
               },
             });

--- a/apps/api/src/modules/framework/pdf/gotenberg-http-client.service.spec.ts
+++ b/apps/api/src/modules/framework/pdf/gotenberg-http-client.service.spec.ts
@@ -1,5 +1,7 @@
 import { HttpService } from '@nestjs/axios';
-import { of } from 'rxjs';
+import { ServiceUnavailableException } from '@nestjs/common';
+import { AxiosError } from 'axios';
+import { of, throwError } from 'rxjs';
 import { mock } from 'vitest-mock-extended';
 
 import { GotenbergHttpClient } from './gotenberg-http-client.service';
@@ -29,6 +31,59 @@ describe('GotenbergHttpClient', () => {
 
       const [_, formData] = http.post.mock.lastCall! as [unknown, FormData | undefined];
       expect(formData?.get('printBackground')).toBe('false');
+    });
+
+    it('should keep the path prefix of the base url', async () => {
+      const http = mock<HttpService>();
+      http.post.mockReturnValue(of({ data: new ArrayBuffer(0) } as any));
+
+      const client = new GotenbergHttpClient(http, new URL('https://proxy.dev/gotenberg'));
+      await client.htmlToPdf({ 'index.html': '<html></html>' });
+
+      const [url] = http.post.mock.lastCall! as [string];
+      expect(url).toBe('https://proxy.dev/gotenberg/forms/chromium/convert/html');
+    });
+
+    it('should report the gotenberg failure as unavailable', async () => {
+      const http = mock<HttpService>();
+      http.post.mockReturnValue(
+        throwError(
+          () =>
+            new AxiosError('Request failed with status code 409', 'ERR_BAD_REQUEST', undefined, undefined, {
+              status: 409,
+              data: Buffer.from('waiting for expression timed out'),
+            } as any),
+        ),
+      );
+
+      const client = new GotenbergHttpClient(http, new URL('http://gotenberg.dev'));
+
+      await expect(client.htmlToPdf({ 'index.html': '<html></html>' })).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('should report a connection failure, which carries no response', async () => {
+      const http = mock<HttpService>();
+      http.post.mockReturnValue(
+        throwError(() => new AxiosError('connect ECONNREFUSED 10.240.0.2:80', 'ECONNREFUSED')),
+      );
+
+      const client = new GotenbergHttpClient(http, new URL('http://gotenberg.dev'));
+
+      await expect(client.htmlToPdf({ 'index.html': '<html></html>' })).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('should let a non-axios failure through untouched', async () => {
+      const http = mock<HttpService>();
+      const boom = new Error('boom');
+      http.post.mockReturnValue(throwError(() => boom));
+
+      const client = new GotenbergHttpClient(http, new URL('http://gotenberg.dev'));
+
+      await expect(client.htmlToPdf({ 'index.html': '<html></html>' })).rejects.toBe(boom);
     });
   });
 });

--- a/apps/api/src/modules/framework/pdf/gotenberg-http-client.service.ts
+++ b/apps/api/src/modules/framework/pdf/gotenberg-http-client.service.ts
@@ -1,7 +1,18 @@
 import { HttpService } from '@nestjs/axios';
+import { Logger, ServiceUnavailableException } from '@nestjs/common';
+import { isAxiosError } from 'axios';
 import { firstValueFrom } from 'rxjs';
 
+function readErrorBody(data: unknown): string {
+  if (data == null) return '';
+  if (Buffer.isBuffer(data)) return data.toString('utf8').trim().slice(0, 500);
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString('utf8').trim().slice(0, 500);
+
+  return (typeof data === 'string' ? data : JSON.stringify(data)).trim().slice(0, 500);
+}
+
 export class GotenbergHttpClient {
+  private readonly logger = new Logger(GotenbergHttpClient.name);
   private readonly urls = {
     htmlToPdf: `/forms/chromium/convert/html`,
   };
@@ -34,11 +45,23 @@ export class GotenbergHttpClient {
       form.append('files', file);
     }
 
-    const url = new URL(this.urls.htmlToPdf, this.baseUrl).toString();
+    const url = this.endpoint(this.urls.htmlToPdf);
     const response = await firstValueFrom(
       this.http.post<ArrayBuffer>(url, form, { timeout: request.timeout, responseType: 'arraybuffer' }),
-    );
+    ).catch((error: unknown) => this.rethrow(url, error));
 
     return Buffer.from(response.data);
+  }
+
+  private endpoint(path: string): string {
+    return new URL(this.baseUrl.pathname.replace(/\/$/, '') + path, this.baseUrl).toString();
+  }
+
+  private rethrow(url: string, error: unknown): never {
+    if (!isAxiosError(error)) throw error;
+
+    const { status, data } = error.response ?? {};
+    this.logger.error(`POST ${url} - ${status ?? error.code ?? error.message} ${readErrorBody(data)}`);
+    throw new ServiceUnavailableException('PDF_RENDERER_UNAVAILABLE', { cause: error });
   }
 }

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.test.tsx
@@ -16,12 +16,14 @@ const mocks = vi.hoisted(() => ({
     type: 'AUTRE' | 'FICHE_DE_JURIDICTION' | 'NOTE_INTENTION';
     addedAt: string;
   }[],
+  cancelTab: vi.fn(),
   createUrl: vi.fn(),
   download: vi.fn(),
   isSg: vi.fn(() => true),
   open: vi.fn(),
   openAddAttachment: vi.fn(),
   remove: vi.fn(),
+  settleTab: vi.fn(),
   waitForConfirmation: vi.fn(async () => ({ isConfirmed: true })),
 }));
 
@@ -31,7 +33,13 @@ vi.mock('./context/AddNominationFileAttachmentModalContext', () => ({
 vi.mock('@/shared/context/confirmation', () => ({
   useConfirmation: () => ({ buttonProps: {}, waitForConfirmation: mocks.waitForConfirmation }),
 }));
-vi.mock('@/shared/hooks/useTab', () => ({ useTab: () => ({ open: mocks.open, download: mocks.download }) }));
+vi.mock('@/shared/hooks/useTab', () => ({
+  useTab: () => ({
+    download: mocks.download,
+    open: mocks.open,
+    openDeferred: () => ({ cancel: mocks.cancelTab, settle: mocks.settleTab }),
+  }),
+}));
 vi.mock('@/features/auth/hooks/roles.hook', () => ({ useIsSgNavigation: () => mocks.isSg() }));
 vi.mock('@queries/nomination-sessions.queries', () => ({
   useListNominationFileAttachmentsQuery: () => ({ data: { items: mocks.attachments } }),
@@ -99,7 +107,7 @@ describe('Attachments listing', () => {
 });
 
 describe('Attachments actions', () => {
-  it('opens the file in a new tab when previewing', async () => {
+  it('settles the tab opened on click with the file url', async () => {
     mocks.createUrl.mockImplementation((_vars, options) =>
       options.onSuccess({ url: 'https://files/rapport.pdf' }),
     );
@@ -112,7 +120,18 @@ describe('Attachments actions', () => {
       { fileId: 'file-1', nominationFileId: 'nf-1', sessionId: 'session-1' },
       expect.any(Object),
     );
-    expect(mocks.open).toHaveBeenCalledWith('https://files/rapport.pdf');
+    expect(mocks.settleTab).toHaveBeenCalledWith('https://files/rapport.pdf');
+  });
+
+  it('closes the tab opened on click when the url cannot be created', async () => {
+    mocks.createUrl.mockImplementation((_vars, options) => options.onError());
+    const user = userEvent.setup();
+    renderAttachments();
+
+    await user.click(screen.getByRole('button', { name: 'rapport' }));
+
+    expect(mocks.cancelTab).toHaveBeenCalled();
+    expect(mocks.settleTab).not.toHaveBeenCalled();
   });
 
   it('downloads the file same-origin with the download flag', async () => {

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.tsx
@@ -126,15 +126,22 @@ function AttachmentItem(props: {
       : null;
 
   const onPreview = useCallback(() => {
+    const attachmentTab = tab.openDeferred({
+      message: formatMessage({ defaultMessage: 'Ouverture de la pièce jointe, merci de patienter...' }),
+      title: props.name,
+    });
+
     createUrl(
       { fileId: props.fileId, nominationFileId: props.nominationFileId, sessionId: props.sessionId },
       {
+        onError: () => attachmentTab.cancel(),
         onSuccess: (response) => {
-          if (response) tab.open(response.url);
+          if (response) attachmentTab.settle(response.url);
+          else attachmentTab.cancel();
         },
       },
     );
-  }, [createUrl, tab, props.sessionId, props.nominationFileId, props.fileId]);
+  }, [createUrl, formatMessage, props.fileId, props.name, props.nominationFileId, props.sessionId, tab]);
 
   const onDownload = useCallback(() => {
     createUrl(

--- a/apps/client/src/features/transparence/components/attachments/SessionAttachmentsTable.stories.tsx
+++ b/apps/client/src/features/transparence/components/attachments/SessionAttachmentsTable.stories.tsx
@@ -1,3 +1,4 @@
+import Button from '@codegouvfr/react-dsfr/Button';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
@@ -31,6 +32,21 @@ const ATTACHMENTS: SessionAttachment[] = [
 
 const onDownload = fn().mockName('onDownload');
 const onDelete = fn().mockName('onDelete');
+const onOpen = fn().mockName('onOpen');
+
+function AttachmentName(attachment: SessionAttachment) {
+  return (
+    <Button
+      className="fr-btn--align-on-content grow truncate text-left"
+      onClick={() => onOpen(attachment.name)}
+      priority="tertiary no outline"
+      size="small"
+      title={`Ouvrir ${attachment.name}`}
+    >
+      {attachment.name}
+    </Button>
+  );
+}
 
 function AttachmentActions(attachment: SessionAttachment) {
   return (
@@ -57,7 +73,7 @@ const meta = {
   ],
   parameters: { controls: { include: ['attachments'] }, layout: 'padded' },
   tags: ['autodocs'],
-  args: { actions: AttachmentActions, attachments: ATTACHMENTS },
+  args: { actions: AttachmentActions, attachments: ATTACHMENTS, renderName: AttachmentName },
 } satisfies Meta<typeof SessionAttachmentsTable>;
 
 export default meta;

--- a/apps/client/src/features/transparence/components/documents/DocActionDetails.tsx
+++ b/apps/client/src/features/transparence/components/documents/DocActionDetails.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import { useAlerts } from '@/shared/context/alerts';
+import { useDocumentFailure } from '@/shared/hooks/useDocumentFailure';
 import { useTab } from '@/shared/hooks/useTab';
 import type { FoundSessionDocsDto } from '@api/types';
 import {
@@ -20,6 +21,7 @@ export function DocActionDetails(props: {
 
   const { formatMessage } = useIntl();
   const alerts = useAlerts();
+  const describeFailure = useDocumentFailure();
   const tab = useTab();
   const { mutateAsync: openAgenda, isPending: isOpeningAgenda } = useDetailsSessionAgendaMutation();
   const { mutateAsync: openOfficialReport, isPending: isOpeningOfficialReport } =
@@ -27,21 +29,22 @@ export function DocActionDetails(props: {
 
   const onSettled = useCallback(() => setIsActing(false), [setIsActing]);
   const onFailure = useCallback(
-    () =>
+    (error: unknown) =>
       alerts.pushAlert({
         severity: 'error',
         title: formatMessage({
           defaultMessage: `Le document n'a pas pu être ouvert`,
         }),
-        description: formatMessage({
-          defaultMessage: 'Sa génération a échoué. Réessayez et prévenez le support si cela persiste.',
-        }),
+        description: describeFailure(error),
       }),
-    [alerts, formatMessage],
+    [alerts, describeFailure, formatMessage],
   );
 
   const onClick = useCallback(() => {
-    const documentTab = tab.openDeferred();
+    const documentTab = tab.openDeferred({
+      message: formatMessage({ defaultMessage: 'Préparation du document, merci de patienter...' }),
+      title: doc.name,
+    });
     setIsActing(true);
 
     const details =
@@ -51,12 +54,12 @@ export function DocActionDetails(props: {
 
     return details
       .then(({ url }) => documentTab.settle(url))
-      .catch(() => {
+      .catch((error: unknown) => {
         documentTab.cancel();
-        onFailure();
+        onFailure(error);
       })
       .finally(onSettled);
-  }, [sessionId, doc, setIsActing, onFailure, onSettled, openAgenda, openOfficialReport, tab]);
+  }, [sessionId, doc, formatMessage, setIsActing, onFailure, onSettled, openAgenda, openOfficialReport, tab]);
 
   return (
     <Button

--- a/apps/client/src/features/transparence/components/documents/SessionDocumentsTable.stories.tsx
+++ b/apps/client/src/features/transparence/components/documents/SessionDocumentsTable.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
 
 import { AlertsProvider } from '@/shared/context/alerts';
 import { ConfirmationProvider } from '@/shared/context/confirmation';
@@ -8,6 +9,7 @@ import { StoryQueryClient } from '@/shared/storybook/StoryQueryClient';
 import { DocActionAgendaFiles } from './DocActionAgendaFiles';
 import { DocActionAgendaMetadata } from './DocActionAgendaMetadata';
 import { DocActionDelete } from './DocActionDelete';
+import { DocActionDetails } from './DocActionDetails';
 import { DocActionUpdate } from './DocActionUpdate';
 import { SessionDocumentsTable, type SessionDocument } from './SessionDocumentsTable';
 
@@ -62,6 +64,12 @@ function DocActions(doc: SessionDocument) {
   );
 }
 
+const setIsActing = fn().mockName('setIsActing');
+
+function DocName(doc: SessionDocument) {
+  return <DocActionDetails disabled={false} doc={doc} sessionId={SESSION_ID} setIsActing={setIsActing} />;
+}
+
 const meta = {
   title: 'Session/Transparence/SessionDocumentsTable',
   component: SessionDocumentsTable,
@@ -81,7 +89,7 @@ const meta = {
   ],
   parameters: { controls: { include: ['docs'] }, layout: 'padded' },
   tags: ['autodocs'],
-  args: { actions: DocActions, docs: DOCS },
+  args: { actions: DocActions, docs: DOCS, renderName: DocName },
 } satisfies Meta<typeof SessionDocumentsTable>;
 
 export default meta;

--- a/apps/client/src/pages/documents/agenda/AgendaPreviewPage.tsx
+++ b/apps/client/src/pages/documents/agenda/AgendaPreviewPage.tsx
@@ -1,9 +1,11 @@
 import Button from '@codegouvfr/react-dsfr/Button';
+import clsx from 'clsx';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { generatePath, useNavigate, useParams } from 'react-router';
 
 import { AgendaDocumentEditor } from '@/features/agenda/components/agenda-editor';
+import { useDocumentFailure } from '@/shared/hooks/useDocumentFailure';
 import { Breadcrumb } from '@/shared/ui/Breadcrumb';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import { useAgendaDocumentBlocksQuery, useGenerateAgendaPdfMutation } from '@queries/agenda.queries';
@@ -11,6 +13,7 @@ import { useDetailedNominationSessionQuery } from '@queries/nomination-sessions.
 
 export function AgendaPreviewPage() {
   const navigate = useNavigate();
+  const describeFailure = useDocumentFailure();
 
   const { agendaId, sessionId } = useParams<{ agendaId: string; sessionId: string }>();
 
@@ -21,7 +24,7 @@ export function AgendaPreviewPage() {
     force: true,
     sessionId: sessionId!,
     agendaId: agendaId!,
-    onSuccess: () => navigate(generatePath(ROUTE_PATHS.SG.SESSION_ID, { sessionId: sessionId! })),
+    onSuccess: () => navigate(generatePath(ROUTE_PATHS.SG.SESSION_ID_DOCUMENTS, { sessionId: sessionId! })),
   });
 
   const [hasPendingRevalidation, setHasPendingRevalidation] = useState(false);
@@ -101,13 +104,23 @@ export function AgendaPreviewPage() {
               <FormattedMessage defaultMessage="Certains dossiers ont changé et doivent être validés" />
             </p>
           )}
+          {generatePdf.isError && (
+            <p className="fr-mb-0 text-(--text-default-error)" role="alert">
+              {describeFailure(generatePdf.error)}
+            </p>
+          )}
           <Button
+            className={clsx({ 'after:animate-spin': generatePdf.isPending })}
             disabled={generatePdf.isPending || hasPendingRevalidation}
             iconId={generatePdf.isPending ? 'ri-loader-4-line' : 'fr-icon-success-fill'}
             iconPosition="right"
             onClick={() => generatePdf.mutate()}
           >
-            <FormattedMessage defaultMessage="Valider le document" />
+            {generatePdf.isPending ? (
+              <FormattedMessage defaultMessage="Génération en cours..." />
+            ) : (
+              <FormattedMessage defaultMessage="Valider le document" />
+            )}
           </Button>
         </div>
       </div>

--- a/apps/client/src/pages/documents/official-report/OfficialReportPreviewPage.tsx
+++ b/apps/client/src/pages/documents/official-report/OfficialReportPreviewPage.tsx
@@ -1,9 +1,11 @@
 import Button from '@codegouvfr/react-dsfr/Button';
+import clsx from 'clsx';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { generatePath, useNavigate, useParams } from 'react-router';
 
 import { OfficialReportDocumentEditor } from '@/features/official-report/components/official-report-editor/OfficialReportDocumentEditor';
+import { useDocumentFailure } from '@/shared/hooks/useDocumentFailure';
 import { Breadcrumb } from '@/shared/ui/Breadcrumb';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import {
@@ -14,6 +16,7 @@ import { useDetailedNominationSessionQuery } from '@queries/nomination-sessions.
 
 export function OfficialReportPreviewPage() {
   const navigate = useNavigate();
+  const describeFailure = useDocumentFailure();
 
   const { officialReportId, sessionId } = useParams<{
     officialReportId: string;
@@ -29,7 +32,7 @@ export function OfficialReportPreviewPage() {
     force: true,
     sessionId: sessionId!,
     officialReportId: officialReportId!,
-    onSuccess: () => navigate(generatePath(ROUTE_PATHS.SG.SESSION_ID, { sessionId: sessionId! })),
+    onSuccess: () => navigate(generatePath(ROUTE_PATHS.SG.SESSION_ID_DOCUMENTS, { sessionId: sessionId! })),
   });
 
   const [hasPendingRevalidation, setHasPendingRevalidation] = useState(false);
@@ -94,13 +97,23 @@ export function OfficialReportPreviewPage() {
               <FormattedMessage defaultMessage="Certains dossiers ont changé d'issue ou de rapporteurs, et doivent être validés" />
             </p>
           )}
+          {generatePdf.isError && (
+            <p className="fr-mb-0 text-(--text-default-error)" role="alert">
+              {describeFailure(generatePdf.error)}
+            </p>
+          )}
           <Button
+            className={clsx({ 'after:animate-spin': generatePdf.isPending })}
             disabled={generatePdf.isPending || hasPendingRevalidation}
             iconId={generatePdf.isPending ? 'ri-loader-4-line' : 'fr-icon-success-fill'}
             iconPosition="right"
             onClick={() => generatePdf.mutate()}
           >
-            <FormattedMessage defaultMessage="Valider le document" />
+            {generatePdf.isPending ? (
+              <FormattedMessage defaultMessage="Génération en cours..." />
+            ) : (
+              <FormattedMessage defaultMessage="Valider le document" />
+            )}
           </Button>
         </div>
       </div>

--- a/apps/client/src/pages/transparence/TransparenceAttachmentsTab.tsx
+++ b/apps/client/src/pages/transparence/TransparenceAttachmentsTab.tsx
@@ -52,7 +52,10 @@ export function TransparenceAttachmentsTab() {
 
   const onOpen = useCallback(
     (fileId: string) => {
-      const attachmentTab = tab.openDeferred();
+      const attachmentTab = tab.openDeferred({
+        message: formatMessage({ defaultMessage: 'Ouverture de la pièce jointe, merci de patienter...' }),
+        title: formatMessage({ defaultMessage: 'Pièce jointe' }),
+      });
 
       createUrl(
         { fileId, sessionId: transparence.id },
@@ -65,7 +68,7 @@ export function TransparenceAttachmentsTab() {
         },
       );
     },
-    [createUrl, transparence.id, tab],
+    [createUrl, formatMessage, transparence.id, tab],
   );
 
   const onDownload = useCallback(

--- a/apps/client/src/shared/hooks/useDocumentFailure/index.ts
+++ b/apps/client/src/shared/hooks/useDocumentFailure/index.ts
@@ -1,0 +1,1 @@
+export { useDocumentFailure } from './useDocumentFailure';

--- a/apps/client/src/shared/hooks/useDocumentFailure/useDocumentFailure.ts
+++ b/apps/client/src/shared/hooks/useDocumentFailure/useDocumentFailure.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+
+import { HttpException } from '@/utils/http-exception';
+
+const REASONS = defineMessages({
+  forbidden: { defaultMessage: `Vous n'avez pas les droits nécessaires pour le générer.` },
+  missing: { defaultMessage: 'Le document est introuvable.' },
+  renderer: { defaultMessage: 'Le service de génération PDF est indisponible.' },
+  timeout: { defaultMessage: 'La génération a pris trop de temps.' },
+  unknown: { defaultMessage: 'Sa génération a échoué.' },
+});
+
+const REASON_BY_STATUS: Record<number, keyof typeof REASONS> = {
+  403: 'forbidden',
+  404: 'missing',
+  503: 'renderer',
+};
+
+function failureOf(error: unknown): { code: string | null; reason: keyof typeof REASONS } {
+  if (error instanceof DOMException && error.name === 'TimeoutError') {
+    return { code: null, reason: 'timeout' };
+  }
+  if (!(error instanceof HttpException)) return { code: null, reason: 'unknown' };
+
+  return {
+    code: String(error.statusCode),
+    reason: REASON_BY_STATUS[error.statusCode] ?? 'unknown',
+  };
+}
+
+export function useDocumentFailure() {
+  const { formatMessage } = useIntl();
+
+  return useCallback(
+    (error: unknown) => {
+      const { code, reason } = failureOf(error);
+      const explanation = formatMessage(REASONS[reason]);
+
+      if (!code) {
+        return formatMessage(
+          { defaultMessage: '{reason} Réessayez et prévenez le support si cela persiste.' },
+          { reason: explanation },
+        );
+      }
+
+      return formatMessage(
+        { defaultMessage: '{reason} Réessayez et prévenez le support si cela persiste (code {code}).' },
+        { code, reason: explanation },
+      );
+    },
+    [formatMessage],
+  );
+}

--- a/apps/client/src/shared/hooks/useTab/useTab.test.ts
+++ b/apps/client/src/shared/hooks/useTab/useTab.test.ts
@@ -34,3 +34,34 @@ describe('useTab.download', () => {
     expect(click).toHaveBeenCalledOnce();
   });
 });
+
+describe('useTab.openDeferred', () => {
+  it('shows a pending message in the blank tab until the url settles', () => {
+    const tabDocument = document.implementation.createHTMLDocument();
+    const handle = { close: vi.fn(), document: tabDocument, location: { replace: vi.fn() } };
+    vi.spyOn(window, 'open').mockReturnValue(handle as unknown as Window);
+
+    const { result } = renderHook(() => useTab());
+    const deferred = result.current.openDeferred({
+      message: 'Préparation...',
+      title: 'Ordre du jour',
+    });
+
+    expect(tabDocument.title).toBe('Ordre du jour');
+    expect(tabDocument.body.textContent).toBe('Préparation...');
+
+    deferred.settle('https://files/agenda.pdf');
+    expect(handle.location.replace).toHaveBeenCalledWith('https://files/agenda.pdf');
+  });
+
+  it('opens a bare blank tab when no pending message is given', () => {
+    const tabDocument = document.implementation.createHTMLDocument();
+    const handle = { close: vi.fn(), document: tabDocument, location: { replace: vi.fn() } };
+    vi.spyOn(window, 'open').mockReturnValue(handle as unknown as Window);
+
+    const { result } = renderHook(() => useTab());
+    result.current.openDeferred();
+
+    expect(tabDocument.body.textContent).toBe('');
+  });
+});

--- a/apps/client/src/shared/hooks/useTab/useTab.ts
+++ b/apps/client/src/shared/hooks/useTab/useTab.ts
@@ -1,5 +1,21 @@
 import { useCallback } from 'react';
 
+function fillPendingTab(handle: Window, pending: { message: string; title: string }) {
+  try {
+    const { document: tab } = handle;
+    tab.documentElement.lang = 'fr';
+    tab.title = pending.title;
+
+    const paragraph = tab.createElement('p');
+    paragraph.textContent = pending.message;
+    paragraph.style.cssText = 'font-family: system-ui, sans-serif; margin: 2rem';
+
+    tab.body?.appendChild(paragraph);
+  } catch {
+    // an unwritable blank tab is not worth failing the navigation for
+  }
+}
+
 export function useTab() {
   const open = useCallback((url: URL | string) => {
     const $a = document.createElement('a');
@@ -13,23 +29,27 @@ export function useTab() {
     $a.remove();
   }, []);
 
-  const openDeferred = useCallback(() => {
-    const handle = window.open('about:blank', '_blank');
+  const openDeferred = useCallback(
+    (pending?: { message: string; title: string }) => {
+      const handle = window.open('about:blank', '_blank');
+      if (handle && pending) fillPendingTab(handle, pending);
 
-    return {
-      cancel: () => handle?.close(),
-      settle: (url: URL | string) => {
-        if (!handle) return open(url);
+      return {
+        cancel: () => handle?.close(),
+        settle: (url: URL | string) => {
+          if (!handle) return open(url);
 
-        try {
-          handle.location.replace(url.toString());
-        } catch {
-          handle.close();
-          open(url);
-        }
-      },
-    };
-  }, [open]);
+          try {
+            handle.location.replace(url.toString());
+          } catch {
+            handle.close();
+            open(url);
+          }
+        },
+      };
+    },
+    [open],
+  );
 
   const download = useCallback((url: URL | string) => {
     const $a = document.createElement('a');

--- a/apps/client/src/shared/storybook/msw.handlers.ts
+++ b/apps/client/src/shared/storybook/msw.handlers.ts
@@ -3,6 +3,8 @@ import { http, HttpResponse } from 'msw';
 import type {
   CreatedSummaryDto,
   DetailedNominationFileAttachmentDto,
+  DetailedSessionAgenda,
+  DetailedSessionOfficialReportDto,
   DetailedUserResponseDto,
   GeneratedSummaryAttachmentPublicUrlDto,
   GetObservationFileUrlResponseDto,
@@ -44,6 +46,19 @@ export const sgAuthHandlers = [
 export const sessionDocsHandlers = [
   http.delete('*/api/docs/v1/agendas/:agendaId', noContent),
   http.delete('*/api/docs/v1/official-reports/:officialReportId', noContent),
+
+  http.get('*/api/docs/v1/sessions/:sessionId/agendas/:agendaId', ({ params }) =>
+    HttpResponse.json<DetailedSessionAgenda>({
+      id: String(params.agendaId),
+      url: FILE_URL,
+    }),
+  ),
+  http.get('*/api/docs/v1/sessions/:sessionId/official-reports/:officialReportId', ({ params }) =>
+    HttpResponse.json<DetailedSessionOfficialReportDto>({
+      id: String(params.officialReportId),
+      url: FILE_URL,
+    }),
+  ),
 ];
 
 export const sidePanelHandlers = [

--- a/apps/client/src/utils/http.config.test.ts
+++ b/apps/client/src/utils/http.config.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import sdk from '../generated/api/sdk.ts?raw';
+
+import { PDF_GENERATION_ROUTES, routeToPattern } from './http.config';
+
+describe('PDF_GENERATION_ROUTES', () => {
+  it.each(PDF_GENERATION_ROUTES)('%s still exists in the generated sdk', (route) => {
+    expect(sdk).toContain(`url: '${route}'`);
+  });
+
+  it.each([
+    ['/api/docs/v1/agendas/abc.pdf', true],
+    ['/api/docs/v1/agendas/abc.pdf?force=true', true],
+    ['https://api.dev/api/docs/v1/sessions/s1/official-reports/o1', true],
+    ['/api/docs/v1/presentation-plans/p1/url', true],
+    ['/api/docs/v1/sessions/s1/agendas/a1/blocks', false],
+    ['/api/docs/v1/sessions/s1/new-official-reports/agendas', false],
+    ['/api/docs/v1/agendas/a1', false],
+    ['/api/docs/v1/presentation-plans/p1/html', false],
+  ])('matches %s: %s', (url, expected) => {
+    const patterns = PDF_GENERATION_ROUTES.map(routeToPattern);
+    expect(patterns.some((pattern) => pattern.test(url))).toBe(expected);
+  });
+});

--- a/apps/client/src/utils/http.config.ts
+++ b/apps/client/src/utils/http.config.ts
@@ -7,6 +7,26 @@ export function getBaseUrl() {
   return import.meta.env.VITE_API_URL;
 }
 
+export const PDF_GENERATION_ROUTES = [
+  '/api/docs/v1/agendas/{agendaId}.pdf',
+  '/api/docs/v1/official-reports/{officialReportId}.pdf',
+  '/api/docs/v1/presentation-plans/{planId}.pdf',
+  '/api/docs/v1/presentation-plans/{planId}/url',
+  '/api/docs/v1/sessions/{sessionId}/agendas/{agendaId}',
+  '/api/docs/v1/sessions/{sessionId}/official-reports/{officialReportId}',
+] as const;
+
+export function routeToPattern(route: string): RegExp {
+  const source = route
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\\\{[^}]+\\\}/g, '[^/?#]+')
+    .replace(/\{[^}]+\}/g, '[^/?#]+');
+
+  return new RegExp(`${source}(\\?|#|$)`);
+}
+
+const PDF_GENERATION_PATTERNS = PDF_GENERATION_ROUTES.map(routeToPattern);
+
 /** @see https://heyapi.dev/openapi-ts/clients/fetch#runtime-api */
 export const createClientConfig: CreateClientConfig = (config) => ({
   ...config,
@@ -15,7 +35,7 @@ export const createClientConfig: CreateClientConfig = (config) => ({
   throwOnError: true,
   fetch: async (init) => {
     const url = typeof init === 'string' ? init : init instanceof URL ? init.toString() : init.url;
-    const isPdfGenerationUrl = /\/api\/docs\/v1\/.+\.pdf/.test(url);
+    const isPdfGenerationUrl = PDF_GENERATION_PATTERNS.some((pattern) => pattern.test(url));
 
     const isQuery =
       init instanceof URL || (typeof init !== 'string' && [undefined, 'GET'].includes(init.method));


### PR DESCRIPTION
### Making the failure visible

- the screen now says why the generation failed (forbidden, missing document, renderer unavailable, timed out), with the HTTP status when there is one
- gotenberg answers with a raw byte body, which reached the logs undecoded and therefore unreadable in Sentry
- both validation pages never read `isError`, so a failure rendered nothing at all

### Making the wait visible

- the button reads "Génération en cours..." with a spinning icon, it was static
- the tab opened before the document is ready shows a message instead of staying blank
- validating now lands on the Documents tab rather than Propositions, where the result of the action was invisible

### Related fixes found along the way

- a path prefix in `GOTENBERG_API_URL` was silently dropped when building the URL
- client timeouts did not cover the routes that render a PDF on read, cutting them at 10s, a test now pins those routes against the generated SDK so the list cannot drift silently
- `.jpeg` attachments were downloaded instead of displayed: the extension was missing from the MIME table and NestJS falls back to `application/octet-stream`. Extension matching is now case insensitive too