### PR TITLE
feat(FON-530): prepare an agenda by selecting files in the table

### DIFF
--- a/apps/api-e2e/src/generated/api/types.ts
+++ b/apps/api-e2e/src/generated/api/types.ts
@@ -2274,6 +2274,7 @@ export type ListNominationFilesData = {
         outcomes?: string;
         priorities?: Array<'ETOILE' | 'OUTRE_MER' | 'PROFILE' | 'null'>;
         reporterIds?: Array<string | null>;
+        nominationFileIds?: Array<string>;
         search?: string;
         missingEvaluation?: string | boolean;
         /**

--- a/apps/api-e2e/src/specs/session.e2e-spec.ts
+++ b/apps/api-e2e/src/specs/session.e2e-spec.ts
@@ -272,6 +272,28 @@ test.describe('Session E2E', () => {
       expect(detailed.data).toEqual(listed);
     }, 10_000);
 
+    test('should list the nomination files it is asked for', async ({ agent, sessions, expect }) => {
+      const session = await sessions.createOne(TREVOUX_SESSION);
+      const files = await agent.sessions.listNominationFiles({ path: { sessionId: session.id } });
+      const [wanted] = files.data!.items;
+
+      const restricted = await agent.sessions.listNominationFiles({
+        path: { sessionId: session.id },
+        query: { nominationFileIds: [wanted!.id] },
+      });
+
+      expect(restricted.data!.items.map(({ id }) => id)).toEqual([wanted!.id]);
+      expect(restricted.data!.totalCount).toBe(1);
+
+      const none = await agent.sessions.listNominationFiles({
+        path: { sessionId: session.id },
+        query: { nominationFileIds: [randomUUID()] },
+      });
+
+      expect(none.data!.items).toEqual([]);
+      expect(none.data!.totalCount).toBe(0);
+    }, 10_000);
+
     test('should not detail a nomination file outside of the session', async ({ agent, sessions, expect }) => {
       const session = await sessions.createOne(TREVOUX_SESSION);
       const otherSession = await sessions.createOne(TREVOUX_SESSION);

--- a/apps/api/prisma/sql/listNominationFilesCountRawQuery.sql
+++ b/apps/api/prisma/sql/listNominationFilesCountRawQuery.sql
@@ -10,6 +10,7 @@
 
 -- @param {String} $9:sessionId
 -- @param {Boolean} $10:missingEvaluation?
+-- @param $11:nominationFileIds?
 
 SELECT COUNT(ddn.id)
 
@@ -78,6 +79,12 @@ WHERE (
   AND (
     /* missingEvaluation */$10::BOOLEAN IS NULL
     OR ddn.missing_evaluation = /* missingEvaluation */$10::BOOLEAN
+  )
+
+  /* -- NOMINATION FILES -- */
+  AND (
+    /* nominationFileIds */$11::UUID[] IS NULL
+    OR ddn.id = ANY(/* nominationFileIds */$11::UUID[])
   )
 )
 

--- a/apps/api/src/modules/session/transparence/infrastructure/dtos/nomination-file.dto.ts
+++ b/apps/api/src/modules/session/transparence/infrastructure/dtos/nomination-file.dto.ts
@@ -78,6 +78,8 @@ export class ListNominationFilesQueryDto extends createSortableDto(
       )
       .optional(),
 
+    nominationFileIds: z.preprocess(toNullableArray, z.array(z.uuid()).optional()).optional(),
+
     search: z
       .string()
       .trim()

--- a/apps/api/src/modules/session/transparence/infrastructure/queries/list-nomination-files.query.ts
+++ b/apps/api/src/modules/session/transparence/infrastructure/queries/list-nomination-files.query.ts
@@ -57,12 +57,15 @@ export class ListNominationFilesQuery {
     sorting: Sortable<ListNominationFilesQueryDto>;
     filters: {
       missingEvaluation: boolean | undefined;
+      nominationFileIds: readonly string[] | undefined;
       outcomes: readonly (NominationFileOutcomeEnum | null)[];
       priorities: readonly (PriorityEnum | null)[];
       reporterIds: readonly (string | null)[];
       search: string | null;
     };
   }): Promise<PaginatedNominationFiles> {
+    const nominationFileIds = query.filters.nominationFileIds ? [...query.filters.nominationFileIds] : null;
+
     const [totalCount, items] = await this.db.withTransaction(async () => {
       const session = await this.findVisibleSession(query);
       if (!session) return [0, [] as NominationFileAffectationItem[]] as const;
@@ -84,13 +87,14 @@ export class ListNominationFilesQuery {
           where.search,
           query.sessionId,
           where.missingEvaluation,
+          nominationFileIds,
         ),
       );
 
       return [
         Number(txCount ?? 0n),
         await this.loadFiles({
-          nominationFileIds: null,
+          nominationFileIds,
           pagination: query.pagination,
           session,
           sessionId: query.sessionId,

--- a/apps/api/src/modules/session/transparence/infrastructure/transparence.service.ts
+++ b/apps/api/src/modules/session/transparence/infrastructure/transparence.service.ts
@@ -193,6 +193,7 @@ export class TransparenceService {
     user: { role: RoleEnum; id: string };
     filters: {
       missingEvaluation: boolean | undefined;
+      nominationFileIds: readonly string[] | undefined;
       outcomes: readonly (NominationFileOutcomeEnum | null)[];
       priorities: readonly (PriorityEnum | null)[];
       reporterIds: readonly (string | null)[];

--- a/apps/api/src/modules/session/transparence/transparence.controller.ts
+++ b/apps/api/src/modules/session/transparence/transparence.controller.ts
@@ -221,6 +221,7 @@ export class SessionController {
       sorting: { sortBy: query.sortBy, sortDesc: query.sortDesc },
       filters: {
         missingEvaluation: query.missingEvaluation,
+        nominationFileIds: query.nominationFileIds,
         outcomes: query.outcomes,
         priorities: query.priorities ?? [],
         reporterIds: query.reporterIds ?? [],

--- a/apps/client/src/features/agenda/components/AgendaFilesSelection.tsx
+++ b/apps/client/src/features/agenda/components/AgendaFilesSelection.tsx
@@ -38,7 +38,11 @@ export function AgendaFilesSelection(props: {
   const nominationFiles = React.useMemo(() => data?.items ?? [], [data]);
 
   const initialSelection = React.useMemo(() => {
-    if (props.defaultSelectedFileIds) return props.defaultSelectedFileIds;
+    if (props.defaultSelectedFileIds) {
+      const availableIds = new Set(nominationFiles.map(({ id }) => id));
+      return props.defaultSelectedFileIds.filter((id) => availableIds.has(id));
+    }
+
     return nominationFiles.flatMap((f) =>
       f.outcome?.value !== 'SUSPENDED' && f.reporters.length > 0 ? [f.id] : [],
     );

--- a/apps/client/src/features/agenda/components/AgendaNominationFilesStep.tsx
+++ b/apps/client/src/features/agenda/components/AgendaNominationFilesStep.tsx
@@ -15,7 +15,6 @@ export function AgendaNominationFilesStep(props: { className?: string }) {
       sessionId={session.id}
       formation={session.formation}
       defaultSelectedFileIds={basket.fileIds.length > 0 ? basket.fileIds : null}
-      onSelectionChange={basket.set}
       onCancel={cancel}
       onSubmit={goToMetadata}
       renderSubmitLabel={(count) => (

--- a/apps/client/src/features/agenda/context/AgendaProvider.tsx
+++ b/apps/client/src/features/agenda/context/AgendaProvider.tsx
@@ -48,9 +48,8 @@ export function AgendaProvider(props: PropsWithChildren) {
   }, []);
 
   const cancel = useCallback(() => {
-    basket.clear();
     navigate(generatePath(ROUTE_PATHS.SG.SESSION_ID, { sessionId }));
-  }, [navigate, sessionId, basket]);
+  }, [navigate, sessionId]);
 
   const submit = useCallback(
     async (metadata: AgendaMetadata) => {

--- a/apps/client/src/features/agenda/hooks/useAgendaBasket.hook.ts
+++ b/apps/client/src/features/agenda/hooks/useAgendaBasket.hook.ts
@@ -33,7 +33,7 @@ export function useAgendaBasket(sessionId: string): AgendaBasket {
         setState({ fileIds: fileIds.filter((id) => !removed.has(id)) });
       },
       set: (next) => setState({ fileIds: Array.from(new Set(next)) }),
-      clear: () => clear(),
+      clear,
     };
   }, [fileIds, setState, clear]);
 }

--- a/apps/client/src/features/agenda/hooks/useAgendaBasket.test.ts
+++ b/apps/client/src/features/agenda/hooks/useAgendaBasket.test.ts
@@ -1,0 +1,30 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useAgendaBasket } from './useAgendaBasket.hook';
+
+describe('useAgendaBasket', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should accumulate files without duplicating them', () => {
+    const { result } = renderHook(() => useAgendaBasket('session-1'));
+
+    act(() => result.current.add(['dossier-1', 'dossier-2']));
+    act(() => result.current.add(['dossier-2', 'dossier-3']));
+
+    expect(result.current.fileIds).toEqual(['dossier-1', 'dossier-2', 'dossier-3']);
+    expect(result.current.size).toBe(3);
+  });
+
+  it('should empty the basket both in memory and in the storage', () => {
+    const { result } = renderHook(() => useAgendaBasket('session-1'));
+
+    act(() => result.current.add(['dossier-1']));
+    act(() => result.current.clear());
+
+    expect(result.current.isEmpty).toBe(true);
+    expect(localStorage.getItem('fondation.agenda-basket.session-1')).toBeNull();
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/NominationFilesAgendaBasket.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/NominationFilesAgendaBasket.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgendaBasket } from '@/features/agenda/hooks/useAgendaBasket.hook';
+
+import { NominationFilesAgendaBasket } from './NominationFilesAgendaBasket';
+
+function renderBasket(options: { isFiltering?: boolean; size?: number } = {}) {
+  const size = options.size ?? 2;
+  const onToggleFilter = vi.fn();
+  const basket = { isEmpty: size === 0, size } as unknown as AgendaBasket;
+
+  render(
+    <IntlProvider defaultLocale="fr" locale="fr">
+      <NominationFilesAgendaBasket
+        basket={basket}
+        isFiltering={options.isFiltering ?? false}
+        onToggleFilter={onToggleFilter}
+      />
+    </IntlProvider>,
+  );
+
+  return { onToggleFilter };
+}
+
+describe('NominationFilesAgendaBasket', () => {
+  it('should stay out of the way while the agenda is empty', () => {
+    renderBasket({ size: 0 });
+
+    expect(screen.queryByRole('button', { name: /ODJ en préparation/ })).toBeNull();
+  });
+
+  it('should ask for the agenda files only', async () => {
+    const { onToggleFilter } = renderBasket();
+
+    const toggle = screen.getByRole('button', { name: /ODJ en préparation/ });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(toggle);
+
+    expect(onToggleFilter).toHaveBeenCalled();
+  });
+
+  it('should tell the filter is on', () => {
+    renderBasket({ isFiltering: true });
+
+    expect(screen.getByRole('button', { name: /ODJ en préparation/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('should count the files waiting in the agenda', () => {
+    renderBasket({ size: 3 });
+
+    expect(screen.getByRole('button', { name: /ODJ en préparation/ })).toHaveTextContent('(3)');
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/NominationFilesAgendaBasket.tsx
+++ b/apps/client/src/features/nomination-files-table/components/NominationFilesAgendaBasket.tsx
@@ -1,0 +1,38 @@
+import Button from '@codegouvfr/react-dsfr/Button';
+import clsx from 'clsx';
+import { FormattedMessage } from 'react-intl';
+
+import type { AgendaBasket } from '@/features/agenda/hooks/useAgendaBasket.hook';
+
+export function NominationFilesAgendaBasket(props: {
+  basket: AgendaBasket;
+  isFiltering: boolean;
+  onToggleFilter: () => void;
+}) {
+  if (props.basket.isEmpty) return null;
+
+  return (
+    <div
+      className={clsx(
+        'flex w-fit items-center rounded-full transition-colors duration-200',
+        props.isFiltering
+          ? 'bg-(--background-action-low-blue-france-active)'
+          : 'bg-(--background-action-low-blue-france)',
+      )}
+    >
+      <Button
+        className="rounded-full text-(--text-action-high-blue-france) hover:bg-transparent"
+        nativeButtonProps={{ 'aria-pressed': props.isFiltering }}
+        onClick={props.onToggleFilter}
+        priority="tertiary no outline"
+        size="small"
+        type="button"
+      >
+        <span>
+          <FormattedMessage defaultMessage="ODJ en préparation" />
+          <span className="fr-ml-1v text-xs">({props.basket.size})</span>
+        </span>
+      </Button>
+    </div>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/NominationFilesAutoAffectationButton.tsx
+++ b/apps/client/src/features/nomination-files-table/components/NominationFilesAutoAffectationButton.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 import { useNominationFilesTable } from '../context/files-table.context';
 import { useAlerts } from '@/shared/context/alerts';
 import { useConfirmModal } from '@/shared/context/confirm-modal';
+import { Tooltip } from '@/shared/ui/tooltip';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import {
   useAutoAffectationMutation,
@@ -109,23 +110,29 @@ export function NominationFilesAutoAffectationButton() {
 
   if (!canManage) return null;
 
-  return (
+  const isBusy = isAutoAffecting || isFetching;
+  const nothingToAffect =
+    !isBusy && !unaffectedFilesCount
+      ? formatMessage({ defaultMessage: 'Tous les dossiers ont des rapporteurs attribués' })
+      : null;
+
+  const button = (
     <Button
-      className="py-2!"
-      disabled={isAutoAffecting || isFetching || !unaffectedFilesCount}
+      className="py-2! aria-disabled:cursor-not-allowed aria-disabled:text-(--text-disabled-grey) aria-disabled:shadow-[inset_0_0_0_1px_var(--border-disabled-grey)]"
+      disabled={isBusy}
       iconId={isAutoAffecting ? undefined : 'fr-icon-sparkling-2-line'}
-      onClick={onAutoAffectation}
+      nativeButtonProps={nothingToAffect ? { 'aria-disabled': true } : undefined}
+      onClick={nothingToAffect ? undefined : onAutoAffectation}
       priority="secondary"
       size="small"
-      title={
-        unaffectedFilesCount
-          ? undefined
-          : formatMessage({ defaultMessage: 'Tous les dossiers ont des rapporteurs attribués' })
-      }
     >
       {isAutoAffecting
         ? formatMessage({ defaultMessage: 'En cours...' })
         : formatMessage({ defaultMessage: 'Attribuer les rapports' })}
     </Button>
   );
+
+  if (!nothingToAffect) return button;
+
+  return <Tooltip label={nothingToAffect}>{button}</Tooltip>;
 }

--- a/apps/client/src/features/nomination-files-table/components/NominationFilesSelectionBar.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/NominationFilesSelectionBar.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgendaBasket } from '@/features/agenda/hooks/useAgendaBasket.hook';
+
+import { NominationFilesSelectionBar } from './NominationFilesSelectionBar';
+
+const readiness = { canCreateAgenda: true };
+
+vi.mock('../context/files-table.context', () => ({
+  useNominationFilesTable: () => ({ sessionId: 'session-1' }),
+}));
+
+vi.mock('@queries/agenda.queries', () => ({
+  useIsSessionReadyForDocGenerationQuery: () => ({ data: readiness }),
+}));
+
+function renderBar(
+  selectedFileIds = ['dossier-1', 'dossier-2'],
+  options: { isFilteringBasket?: boolean } = {},
+) {
+  const add = vi.fn();
+  const remove = vi.fn();
+  const onClear = vi.fn();
+  const onExit = vi.fn();
+  const basket = { add, remove } as unknown as AgendaBasket;
+
+  render(
+    <IntlProvider defaultLocale="fr" locale="fr">
+      <NominationFilesSelectionBar
+        basket={basket}
+        isFilteringBasket={options.isFilteringBasket ?? false}
+        onClear={onClear}
+        onExit={onExit}
+        selectedFileIds={selectedFileIds}
+      />
+    </IntlProvider>,
+  );
+
+  return { add, onClear, onExit, remove };
+}
+
+describe('NominationFilesSelectionBar', () => {
+  beforeEach(() => {
+    readiness.canCreateAgenda = true;
+  });
+
+  it('should add the selected files to the agenda basket and leave the selection mode', async () => {
+    const { add, onExit } = renderBar();
+
+    expect(screen.getByText('2 propositions sélectionnées')).toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', { name: /Ajouter à l'ODJ/ }));
+
+    expect(add).toHaveBeenCalledWith(['dossier-1', 'dossier-2']);
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  it('should drop the selection without touching the basket', async () => {
+    const { add, onClear } = renderBar();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tout désélectionner' }));
+
+    expect(onClear).toHaveBeenCalled();
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('should leave the selection mode', async () => {
+    const { onExit } = renderBar();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quitter la sélection' }));
+
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  it('should wait for a selection before offering the agenda action', () => {
+    renderBar([]);
+
+    expect(screen.getByText('Aucune proposition sélectionnée')).toBeVisible();
+    expect(screen.getByRole('button', { name: /Ajouter à l'ODJ/ })).toBeDisabled();
+  });
+
+  it('should take the selected files out of the agenda while the table is filtered on it', async () => {
+    const { onExit, remove } = renderBar(['dossier-1'], { isFilteringBasket: true });
+
+    expect(screen.queryByRole('button', { name: /Ajouter à l'ODJ/ })).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: /Retirer de l'ODJ/ }));
+
+    expect(remove).toHaveBeenCalledWith(['dossier-1']);
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  it('should wait for a selection before taking files out of the agenda', () => {
+    renderBar([], { isFilteringBasket: true });
+
+    expect(screen.getByRole('button', { name: /Retirer de l'ODJ/ })).toBeDisabled();
+  });
+
+  it('should keep the agenda action reachable but inert when the session cannot host a new one', async () => {
+    readiness.canCreateAgenda = false;
+    const { add } = renderBar();
+
+    const button = screen.getByRole('button', { name: /Ajouter à l'ODJ/ });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(button).not.toBeDisabled();
+
+    await userEvent.click(button);
+
+    expect(add).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/NominationFilesSelectionBar.tsx
+++ b/apps/client/src/features/nomination-files-table/components/NominationFilesSelectionBar.tsx
@@ -1,0 +1,103 @@
+import Button from '@codegouvfr/react-dsfr/Button';
+import { useCallback } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { useNominationFilesTable } from '../context/files-table.context';
+import type { AgendaBasket } from '@/features/agenda/hooks/useAgendaBasket.hook';
+import { Tooltip } from '@/shared/ui/tooltip';
+import { useIsSessionReadyForDocGenerationQuery } from '@queries/agenda.queries';
+
+import { NominationFilesSelectionModeButton } from './NominationFilesSelectionModeButton';
+
+function AddToAgendaButton(props: {
+  disabled: boolean;
+  onClick: () => void;
+  unavailableReason: string | null;
+}) {
+  const button = (
+    <Button
+      className="py-2! aria-disabled:cursor-not-allowed aria-disabled:bg-(--background-disabled-grey) aria-disabled:text-(--text-disabled-grey)"
+      disabled={props.disabled}
+      iconId="fr-icon-file-add-line"
+      nativeButtonProps={props.unavailableReason ? { 'aria-disabled': true } : undefined}
+      onClick={props.unavailableReason ? undefined : props.onClick}
+      priority="primary"
+      size="small"
+    >
+      <FormattedMessage defaultMessage="Ajouter à l'ODJ" />
+    </Button>
+  );
+
+  if (!props.unavailableReason) return button;
+
+  return <Tooltip label={props.unavailableReason}>{button}</Tooltip>;
+}
+
+export function NominationFilesSelectionBar(props: {
+  basket: AgendaBasket;
+  isFilteringBasket: boolean;
+  onClear: () => void;
+  onExit: () => void;
+  selectedFileIds: readonly string[];
+}) {
+  const { basket, isFilteringBasket, onClear, onExit, selectedFileIds } = props;
+  const { formatMessage } = useIntl();
+  const { sessionId } = useNominationFilesTable();
+  const { data: readiness } = useIsSessionReadyForDocGenerationQuery({ sessionId });
+
+  const count = selectedFileIds.length;
+  const cannotAddReason = readiness?.canCreateAgenda
+    ? null
+    : formatMessage({ defaultMessage: "Aucun dossier n'est disponible pour un ordre du jour" });
+
+  const onAddToAgenda = useCallback(() => {
+    basket.add(selectedFileIds);
+    onExit();
+  }, [basket, onExit, selectedFileIds]);
+
+  const onRemoveFromAgenda = useCallback(() => {
+    basket.remove(selectedFileIds);
+    onExit();
+  }, [basket, onExit, selectedFileIds]);
+
+  return (
+    <div className="fr-pl-4v flex min-h-10 items-center justify-between gap-4 bg-(--background-alt-blue-france)">
+      <p aria-live="polite" className="fr-m-0 text-sm font-medium">
+        <FormattedMessage
+          defaultMessage={`{count, plural,
+            =0 {Aucune proposition sélectionnée}
+            one {1 proposition sélectionnée}
+            other {{count, number} propositions sélectionnées}}`}
+          values={{ count }}
+        />
+      </p>
+
+      <div className="flex items-center gap-2">
+        {count > 0 && (
+          <Button className="py-2!" onClick={onClear} priority="tertiary no outline" size="small">
+            <FormattedMessage defaultMessage="Tout désélectionner" />
+          </Button>
+        )}
+        {isFilteringBasket ? (
+          <Button
+            className="py-2!"
+            disabled={count === 0}
+            iconId="ri-file-reduce-line"
+            onClick={onRemoveFromAgenda}
+            priority="primary"
+            size="small"
+          >
+            <FormattedMessage defaultMessage="Retirer de l'ODJ" />
+          </Button>
+        ) : (
+          <AddToAgendaButton
+            disabled={count === 0}
+            onClick={onAddToAgenda}
+            unavailableReason={cannotAddReason}
+          />
+        )}
+        <NominationFilesSelectionModeButton isSelecting onToggle={onExit} />
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/NominationFilesSelectionModeButton.tsx
+++ b/apps/client/src/features/nomination-files-table/components/NominationFilesSelectionModeButton.tsx
@@ -1,0 +1,27 @@
+import { cx } from '@codegouvfr/react-dsfr/fr/cx';
+import clsx from 'clsx';
+import { useIntl } from 'react-intl';
+
+import { Tooltip } from '@/shared/ui/tooltip';
+
+export function NominationFilesSelectionModeButton(props: { isSelecting: boolean; onToggle: () => void }) {
+  const { formatMessage } = useIntl();
+  const label = props.isSelecting
+    ? formatMessage({ defaultMessage: 'Quitter la sélection' })
+    : formatMessage({ defaultMessage: 'Sélectionner des propositions' });
+
+  return (
+    <Tooltip label={label}>
+      <button
+        aria-label={label}
+        className={clsx(
+          cx('fr-btn', 'fr-btn--tertiary', 'fr-btn--sm'),
+          props.isSelecting ? 'fr-icon-close-line' : 'fr-icon-edit-fill',
+          'h-10! max-h-10! w-10! max-w-10! justify-center before:mr-0! before:[--icon-size:1.25rem]!',
+        )}
+        onClick={props.onToggle}
+        type="button"
+      />
+    </Tooltip>
+  );
+}

--- a/apps/client/src/features/nomination-files-table/components/SessionFilesTable.tsx
+++ b/apps/client/src/features/nomination-files-table/components/SessionFilesTable.tsx
@@ -2,6 +2,9 @@ import {
   getCoreRowModel,
   useReactTable,
   type ColumnFiltersState,
+  type OnChangeFn,
+  type Row,
+  type RowSelectionState,
   type SortingState,
   type Table,
   type TableOptions,
@@ -61,11 +64,14 @@ function SessionFilesNewTable(props: {
 
 export function SessionFilesTable(
   props: PropsWithChildren<{
+    canSelectRow?: (row: Row<SessionNominationFile>) => boolean;
     columns: TableOptions<SessionNominationFile>['columns'];
     emptyLabel?: string;
     filtersEnd?: ReactNode;
     filtersSlot?: Element | null;
+    onRowSelectionChange?: OnChangeFn<RowSelectionState>;
     restrictTo?: SessionNominationFilesFilters;
+    rowSelection?: RowSelectionState;
     summary?: (session: { totalCount: number }) => ReactNode;
   }>,
 ) {
@@ -139,18 +145,24 @@ export function SessionFilesTable(
   const table = useReactTable({
     columns: props.columns,
     data: nominationFiles,
+    enableRowSelection: props.canSelectRow ?? !!props.onRowSelectionChange,
     getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.id,
     manualFiltering: true,
     manualSorting: true,
     onColumnFiltersChange,
+    onRowSelectionChange: props.onRowSelectionChange,
     onSortingChange,
-    state: { columnFilters: tableState.columnFilters, sorting: tableState.sorting },
+    state: {
+      columnFilters: tableState.columnFilters,
+      rowSelection: props.rowSelection ?? {},
+      sorting: tableState.sorting,
+    },
   });
 
   const filters = (
     <div className="flex items-center justify-between gap-4">
-      <div className="flex items-center gap-6">
+      <div className="flex items-center gap-4">
         <ReactTableFilterColumn table={table} />
         {props.filtersEnd}
       </div>

--- a/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.stories.tsx
@@ -28,6 +28,10 @@ const sessions: Record<string, SessionDataset> = {
   empty: { files: [] },
 };
 
+function prepareAgenda(fileIds: readonly string[], sessionId = 'draft') {
+  localStorage.setItem(`fondation.agenda-basket.${sessionId}`, JSON.stringify({ fileIds }));
+}
+
 function SgSessionFilesTableStory(props: {
   canManage: boolean;
   formation: FormationEnum;
@@ -56,6 +60,7 @@ const meta = {
   component: SgSessionFilesTableStory,
   beforeEach: ({ msw }) => {
     msw.use(...sgAuthHandlers, ...makeSessionHandlers(sessions));
+    prepareAgenda([]);
   },
   parameters: {
     layout: 'fullscreen',
@@ -78,6 +83,13 @@ export const Playground: Story = {};
 
 export const PublishedAffectations: Story = {
   args: { sessionId: 'published' },
+};
+
+export const WithOdj: Story = {
+  beforeEach: ({ msw }) => {
+    msw.use(...sgAuthHandlers, ...makeSessionHandlers(sessions));
+    prepareAgenda(['dossier-1', 'dossier-2', 'dossier-3']);
+  },
 };
 
 export const Archived: Story = {

--- a/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.tsx
+++ b/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.tsx
@@ -1,12 +1,13 @@
-import { createColumnHelper } from '@tanstack/react-table';
-import { useMemo, type PropsWithChildren } from 'react';
+import { createColumnHelper, type Row, type RowSelectionState } from '@tanstack/react-table';
+import { useCallback, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
 import { useIntl } from 'react-intl';
 
 import { useNominationFilesTable, type SessionOutcome } from '../context/files-table.context';
 import { NominationFilesTableProvider } from '../context/NominationFilesTableProvider';
 import { useSessionFilesFilters } from '../hooks/useSessionFilesFilters';
+import { useAgendaBasket } from '@/features/agenda/hooks/useAgendaBasket.hook';
 import { PriorityBadgeList } from '@/shared/components/priority-badge';
-import { rowCell } from '@/shared/ui/new-table';
+import { rowCell, useSelectionColumn } from '@/shared/ui/new-table';
 import type { FormationEnum } from '@/types/enums.types';
 import {
   useListNominationFilesAsExcelMutation,
@@ -20,9 +21,12 @@ import { NominationFileStatusCell } from './cells/NominationFileStatusCell';
 import { ObservantsCell } from './cells/observations/ObservantsCell';
 import { ReportersCell } from './cells/reporters/ReportersCell';
 import { NominationFileTargetPositionCell } from './cells/targeted-position/NominationFileTargetPositionCell';
+import { NominationFilesAgendaBasket } from './NominationFilesAgendaBasket';
 import { NominationFilesAutoAffectationButton } from './NominationFilesAutoAffectationButton';
 import { NominationFilesExportButton } from './NominationFilesExportButton';
 import { NominationFilesPublishButton } from './NominationFilesPublishButton';
+import { NominationFilesSelectionBar } from './NominationFilesSelectionBar';
+import { NominationFilesSelectionModeButton } from './NominationFilesSelectionModeButton';
 import { NominationFilesStatusBadges } from './NominationFilesStatusBadges';
 import { SessionFilesTable } from './SessionFilesTable';
 
@@ -120,27 +124,95 @@ function useSgSessionFilesColumns() {
 }
 
 function SgSessionFilesTableInner(props: PropsWithChildren<{ filtersSlot?: Element | null }>) {
-  const { sessionId } = useNominationFilesTable();
-  const columns = useSgSessionFilesColumns();
+  const { formatMessage } = useIntl();
+  const { canManage, sessionId } = useNominationFilesTable();
+  const basket = useAgendaBasket(sessionId);
+  const fileColumns = useSgSessionFilesColumns();
+  const selectionColumn = useSelectionColumn<SessionNominationFile>({
+    lockedLabel: formatMessage({ defaultMessage: "déjà dans l'ODJ en préparation" }),
+  });
   const exportAsExcel = useListNominationFilesAsExcelMutation();
 
-  return (
-    <SessionFilesTable columns={columns} filtersSlot={props.filtersSlot}>
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-6">
-          <AffectationVersionStatusBadge sessionId={sessionId} />
-          <NominationFilesStatusBadges />
-        </div>
+  const [isSelecting, setSelecting] = useState(false);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [isFilteringBasket, setFilteringBasket] = useState(false);
+  const clearSelection = useCallback(() => setRowSelection({}), []);
+  const enterSelection = useCallback(() => setSelecting(true), []);
+  const exitSelection = useCallback(() => {
+    setSelecting(false);
+    setRowSelection({});
+  }, []);
 
-        <div className="flex items-center gap-2">
-          <NominationFilesExportButton
-            disabled={exportAsExcel.isPending}
-            onExport={() => exportAsExcel.mutate({ sessionId })}
-          />
-          <NominationFilesAutoAffectationButton />
-          <NominationFilesPublishButton />
+  const toggleBasketFilter = useCallback(() => {
+    setFilteringBasket((filtering) => !filtering);
+    setRowSelection({});
+  }, []);
+
+  useEffect(() => {
+    if (basket.isEmpty) setFilteringBasket(false);
+  }, [basket.isEmpty]);
+
+  const isSelectable = canManage && isSelecting;
+  const isFilteringBasketFiles = isFilteringBasket && !basket.isEmpty;
+
+  const canSelectRow = useCallback(
+    (row: Row<SessionNominationFile>) => isFilteringBasketFiles || !basket.has(row.original.id),
+    [basket, isFilteringBasketFiles],
+  );
+
+  const columns = useMemo(
+    () => (isSelectable ? [selectionColumn, ...fileColumns] : fileColumns),
+    [fileColumns, isSelectable, selectionColumn],
+  );
+  const selectedFileIds = useMemo(
+    () => Object.entries(rowSelection).flatMap(([id, isSelected]) => (isSelected ? [id] : [])),
+    [rowSelection],
+  );
+
+  return (
+    <SessionFilesTable
+      canSelectRow={isSelectable ? canSelectRow : undefined}
+      columns={columns}
+      filtersEnd={
+        <NominationFilesAgendaBasket
+          basket={basket}
+          isFiltering={isFilteringBasketFiles}
+          onToggleFilter={toggleBasketFilter}
+        />
+      }
+      filtersSlot={props.filtersSlot}
+      onRowSelectionChange={isSelectable ? setRowSelection : undefined}
+      restrictTo={isFilteringBasketFiles ? { nominationFileIds: basket.fileIds } : undefined}
+      rowSelection={rowSelection}
+    >
+      {isSelectable ? (
+        <NominationFilesSelectionBar
+          basket={basket}
+          isFilteringBasket={isFilteringBasketFiles}
+          onClear={clearSelection}
+          onExit={exitSelection}
+          selectedFileIds={selectedFileIds}
+        />
+      ) : (
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-6">
+            <AffectationVersionStatusBadge sessionId={sessionId} />
+            <NominationFilesStatusBadges />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <NominationFilesExportButton
+              disabled={exportAsExcel.isPending}
+              onExport={() => exportAsExcel.mutate({ sessionId })}
+            />
+            <NominationFilesAutoAffectationButton />
+            <NominationFilesPublishButton />
+            {canManage && (
+              <NominationFilesSelectionModeButton isSelecting={false} onToggle={enterSelection} />
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {props.children}
     </SessionFilesTable>

--- a/apps/client/src/features/transparence/components/documents/DocGenerationMenu.tsx
+++ b/apps/client/src/features/transparence/components/documents/DocGenerationMenu.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { generatePath } from 'react-router';
 
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from '@/shared/ui/menu';
@@ -7,7 +7,6 @@ import { getNewAgendaPath, ROUTE_PATHS } from '@/utils/route-path.utils';
 import { useIsSessionReadyForDocGenerationQuery } from '@queries/agenda.queries';
 
 export function DocGenerationMenu(props: { sessionId: string }) {
-  const { formatMessage } = useIntl();
   const { data: readiness } = useIsSessionReadyForDocGenerationQuery({
     sessionId: props.sessionId,
   });
@@ -36,14 +35,13 @@ export function DocGenerationMenu(props: { sessionId: string }) {
             <FormattedMessage defaultMessage="Ordre du jour" />
           </MenuItem>
         ) : (
-          <MenuItem
-            disabled
-            iconId="ri-calendar-line"
-            title={formatMessage({
-              defaultMessage: "Aucun dossier n'est disponible pour un ordre du jour",
-            })}
-          >
-            <FormattedMessage defaultMessage="Ordre du jour" />
+          <MenuItem disabled iconId="ri-calendar-line">
+            <span className="flex flex-col items-start text-left">
+              <FormattedMessage defaultMessage="Ordre du jour" />
+              <span className="text-xs font-normal text-(--text-mention-grey)">
+                <FormattedMessage defaultMessage="Aucun dossier n'est disponible" />
+              </span>
+            </span>
           </MenuItem>
         )}
 
@@ -52,15 +50,13 @@ export function DocGenerationMenu(props: { sessionId: string }) {
             <FormattedMessage defaultMessage="Procès verbal" />
           </MenuItem>
         ) : (
-          <MenuItem
-            disabled
-            iconId="ri-file-text-line"
-            title={formatMessage({
-              defaultMessage:
-                "Chaque dossier d'un ordre du jour doit avoir une issue et un rapporteur publié pour générer le procès verbal",
-            })}
-          >
-            <FormattedMessage defaultMessage="Procès verbal" />
+          <MenuItem disabled iconId="ri-file-text-line">
+            <span className="flex flex-col items-start text-left">
+              <FormattedMessage defaultMessage="Procès verbal" />
+              <span className="text-xs font-normal text-(--text-mention-grey)">
+                <FormattedMessage defaultMessage="Chaque dossier de l'ODJ doit avoir une issue et un rapporteur publié" />
+              </span>
+            </span>
           </MenuItem>
         )}
       </MenuContent>

--- a/apps/client/src/generated/api/types.ts
+++ b/apps/client/src/generated/api/types.ts
@@ -2277,6 +2277,7 @@ export type ListNominationFilesData = {
         outcomes?: string;
         priorities?: Array<'ETOILE' | 'OUTRE_MER' | 'PROFILE' | 'null'>;
         reporterIds?: Array<string | null>;
+        nominationFileIds?: Array<string>;
         search?: string;
         missingEvaluation?: string | boolean;
         /**

--- a/apps/client/src/queries/nomination-sessions.queries.ts
+++ b/apps/client/src/queries/nomination-sessions.queries.ts
@@ -122,6 +122,7 @@ function selectSessionNominationFiles(data: InfiniteData<PaginatedNominationFile
 
 export type SessionNominationFilesFilters = {
   missingEvaluation?: boolean;
+  nominationFileIds?: readonly string[];
   reporterIds?: string[];
   priorities?: (PrioriteEnum | 'null')[];
   outcomes?: (NominationFileOutcomeEnum | null)[];
@@ -147,6 +148,9 @@ export const useInfiniteSessionNominationFilesQuery = (options: {
             limit: SESSION_NOMINATION_FILES_PAGE_SIZE,
             page: pageParam,
             missingEvaluation: options.filters?.missingEvaluation,
+            nominationFileIds: options.filters?.nominationFileIds
+              ? [...options.filters.nominationFileIds]
+              : undefined,
             sortBy: options.sorting?.[0]?.id,
             sortDesc: options.sorting?.[0]?.desc ? 'true' : undefined,
             priorities: options.filters?.priorities,

--- a/apps/client/src/shared/hooks/useLocallyStoredState/useLocallyStoredState.hook.ts
+++ b/apps/client/src/shared/hooks/useLocallyStoredState/useLocallyStoredState.hook.ts
@@ -7,40 +7,101 @@ type Jsonifiable =
   | null
   | { [id: string]: string | number | boolean | null | (string | number | boolean | null)[] };
 
+const NAMESPACE = 'fondation';
+
+const listenersByKey = new Map<string, Set<() => void>>();
+const snapshots = new Map<string, { raw: string | null; value: unknown }>();
+
+function storageKey(key: string): string {
+  return `${NAMESPACE}.${key}`;
+}
+
+function emit(key: string): void {
+  listenersByKey.get(key)?.forEach((listener) => listener());
+}
+
+function onStorageEvent(event: StorageEvent): void {
+  if (!event.key?.startsWith(`${NAMESPACE}.`)) return;
+  emit(event.key.slice(NAMESPACE.length + 1));
+}
+
+function subscribe(key: string, listener: () => void): () => void {
+  const listeners = listenersByKey.get(key) ?? new Set<() => void>();
+  listeners.add(listener);
+  listenersByKey.set(key, listeners);
+  if (listenersByKey.size === 1 && listeners.size === 1) {
+    window.addEventListener('storage', onStorageEvent);
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) listenersByKey.delete(key);
+    if (listenersByKey.size === 0) window.removeEventListener('storage', onStorageEvent);
+  };
+}
+
+function read<T>(key: string, fallback: T): T {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(storageKey(key));
+  } catch {
+    return fallback;
+  }
+
+  const snapshot = snapshots.get(key);
+  if (snapshot && snapshot.raw === raw) return snapshot.value as T;
+
+  let value = fallback;
+  try {
+    if (raw) value = JSON.parse(raw) as T;
+  } catch {
+    value = fallback;
+  }
+
+  snapshots.set(key, { raw, value });
+  return value;
+}
+
+function write(key: string, value: Jsonifiable): void {
+  try {
+    localStorage.setItem(storageKey(key), JSON.stringify(value));
+  } catch {
+    /* empty */
+  }
+  emit(key);
+}
+
+function erase(key: string): void {
+  try {
+    localStorage.removeItem(storageKey(key));
+  } catch {
+    /* empty */
+  }
+  emit(key);
+}
+
 /** synchronizes react state with local storage */
 export function useLocallyStoredState<T extends Jsonifiable>(options: {
   state: T;
   key: string;
 }): [state: T, stateUpdater: React.Dispatch<React.SetStateAction<T>>, clear: () => void] {
-  const [state, setReactState] = React.useState<T>(readLocalStorage(options.key) ?? options.state);
+  const { key } = options;
+  const fallbackRef = React.useRef(options.state);
+
+  const state = React.useSyncExternalStore(
+    React.useCallback((listener) => subscribe(key, listener), [key]),
+    React.useCallback(() => read(key, fallbackRef.current), [key]),
+  );
 
   const update = React.useCallback(
     (updater: T | ((currentState: T) => T)) => {
-      const next = typeof updater === 'function' ? updater(state) : updater;
-      writeLocalStorage(options.key, next);
-      setReactState(next);
+      const next = typeof updater === 'function' ? updater(read(key, fallbackRef.current)) : (updater as T);
+      write(key, next);
     },
-    [state, options.key, setReactState],
+    [key],
   );
 
-  const clear = React.useCallback(() => {
-    clearLocalStorage(options.key);
-  }, [options.key]);
+  const clear = React.useCallback(() => erase(key), [key]);
 
   return [state, update, clear];
-}
-
-const NAMESPACE = 'fondation';
-
-function readLocalStorage<T>(key: string): T | undefined {
-  const value = localStorage.getItem(`${NAMESPACE}.${key}`);
-  return value ? JSON.parse(value) : undefined;
-}
-
-function writeLocalStorage(key: string, value: Jsonifiable): undefined {
-  localStorage.setItem(`${NAMESPACE}.${key}`, JSON.stringify(value));
-}
-
-function clearLocalStorage(key: string): void {
-  localStorage.removeItem(`${NAMESPACE}.${key}`);
 }

--- a/apps/client/src/shared/hooks/useLocallyStoredState/useLocallyStoredState.test.ts
+++ b/apps/client/src/shared/hooks/useLocallyStoredState/useLocallyStoredState.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useLocallyStoredState } from './useLocallyStoredState.hook';
+
+describe('useLocallyStoredState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should start from what the storage already holds', () => {
+    localStorage.setItem('fondation.basket', JSON.stringify({ ids: ['a'] }));
+
+    const { result } = renderHook(() =>
+      useLocallyStoredState<{ ids: string[] }>({ key: 'basket', state: { ids: [] } }),
+    );
+
+    expect(result.current[0]).toEqual({ ids: ['a'] });
+  });
+
+  it('should keep every reader of the same key in sync', () => {
+    const writer = renderHook(() =>
+      useLocallyStoredState<{ ids: string[] }>({ key: 'basket', state: { ids: [] } }),
+    );
+    const reader = renderHook(() =>
+      useLocallyStoredState<{ ids: string[] }>({ key: 'basket', state: { ids: [] } }),
+    );
+
+    act(() => writer.result.current[1]({ ids: ['a'] }));
+    expect(reader.result.current[0]).toEqual({ ids: ['a'] });
+
+    act(() => writer.result.current[2]());
+    expect(reader.result.current[0]).toEqual({ ids: [] });
+  });
+
+  it('should fall back to the given state when the storage holds nonsense', () => {
+    localStorage.setItem('fondation.basket', '{ not json');
+
+    const { result } = renderHook(() =>
+      useLocallyStoredState<{ ids: string[] }>({ key: 'basket', state: { ids: [] } }),
+    );
+
+    expect(result.current[0]).toEqual({ ids: [] });
+  });
+});

--- a/apps/client/src/shared/storybook/session.handlers.ts
+++ b/apps/client/src/shared/storybook/session.handlers.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { GradeEnum } from '@/types/enums.types';
 import type {
   CountedUnaffectedFilesDto,
+  DocGenerationSessionReadinessDto,
   ListedCurrentlyAffectedReportersDto,
   ListedMemberSessionReportsDto,
   NominationFilesStatusCountDto,
@@ -68,8 +69,10 @@ function matchesFilters(file: SessionNominationFile, query: URLSearchParams) {
   const priorities = query.getAll('priorities');
   const reporterIds = query.getAll('reporterIds');
   const outcomes = query.get('outcomes')?.split(',').filter(Boolean) ?? [];
+  const nominationFileIds = query.getAll('nominationFileIds');
   const fileReporterIds = file.reporters.map(({ id }) => id);
 
+  if (nominationFileIds.length && !nominationFileIds.includes(file.id)) return false;
   if (search && !matchesSearch(file, search)) return false;
   if (priorities.length && !matchesAny(file.priorities, priorities)) return false;
   if (reporterIds.length && !matchesAny(fileReporterIds, reporterIds)) return false;
@@ -177,6 +180,14 @@ export function makeSessionHandlers(sessions: Record<string, SessionDataset>) {
         HttpResponse.json<ListedMemberSessionReportsDto>({
           items: datasetOf(params.sessionId).memberReports ?? [],
         }),
+    ),
+
+    http.get('*/api/docs/v1/sessions/:sessionId/readiness', ({ params }) =>
+      HttpResponse.json<DocGenerationSessionReadinessDto>({
+        canCreateAgenda: datasetOf(params.sessionId).files.length > 0,
+        canCreateOfficialReport: false,
+        isReady: datasetOf(params.sessionId).files.length > 0,
+      }),
     ),
 
     http.get('*/api/members/v1', () =>

--- a/apps/client/src/shared/ui/new-table/Checkbox.tsx
+++ b/apps/client/src/shared/ui/new-table/Checkbox.tsx
@@ -18,7 +18,7 @@ export function Checkbox(props: {
       <input
         aria-label={props.label}
         checked={props.checked}
-        className="peer size-4 cursor-pointer appearance-none rounded-sm border border-(--border-action-high-blue-france) bg-(--background-default-grey) checked:bg-(--background-action-high-blue-france) indeterminate:bg-(--background-action-high-blue-france) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--border-action-high-blue-france) disabled:cursor-not-allowed disabled:opacity-50"
+        className="peer size-4 cursor-pointer appearance-none rounded-sm border border-(--border-action-high-blue-france) bg-(--background-default-grey) checked:bg-(--background-action-high-blue-france) indeterminate:bg-(--background-action-high-blue-france) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--border-action-high-blue-france) disabled:cursor-not-allowed disabled:border-(--border-default-grey) disabled:bg-(--background-disabled-grey)"
         disabled={props.disabled}
         onChange={props.onChange}
         ref={ref}

--- a/apps/client/src/shared/ui/new-table/NewTable.fixtures.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.fixtures.tsx
@@ -48,12 +48,14 @@ const ROW_TINTS = {
 export function DemoTable(props: {
   enableSorting?: boolean;
   height?: number;
+  lockedRowIds?: readonly string[];
   rowCount?: number;
   rowTint?: keyof typeof ROW_TINTS;
+  unvirtualized?: boolean;
   withSelection?: boolean;
 }) {
   const data = useMemo(() => makePeople(props.rowCount ?? 100), [props.rowCount]);
-  const selectionColumn = useSelectionColumn<Person>();
+  const selectionColumn = useSelectionColumn<Person>({ lockedLabel: 'déjà traitée' });
 
   const columns = useMemo(
     () => (props.withSelection ? [selectionColumn, ...peopleColumns] : peopleColumns),
@@ -63,7 +65,9 @@ export function DemoTable(props: {
   const table = useReactTable({
     columns,
     data,
-    enableRowSelection: props.withSelection ?? false,
+    enableRowSelection: props.lockedRowIds
+      ? (row) => !props.lockedRowIds?.includes(row.id)
+      : (props.withSelection ?? false),
     enableSorting: props.enableSorting ?? false,
     getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.id,
@@ -76,6 +80,7 @@ export function DemoTable(props: {
         emptyLabel="Aucune donnée"
         rowTint={props.rowTint ? () => ROW_TINTS[props.rowTint!] : undefined}
         table={table}
+        unvirtualized={props.unvirtualized}
       />
     </div>
   );

--- a/apps/client/src/shared/ui/new-table/NewTable.stories.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.stories.tsx
@@ -19,6 +19,11 @@ const meta = {
       control: 'boolean',
       description: 'Active la colonne de sélection (checkbox + select-all + shift-click).',
     },
+    lockedRowIds: {
+      control: 'object',
+      description:
+        'Lignes non sélectionnables (`person-0`, `person-1`...) : case désactivée, cellule grisée et tooltip expliquant pourquoi. Demande withSelection pour que la colonne soit affichée.',
+    },
     rowTint: {
       control: 'inline-radio',
       options: [undefined, 'blue', 'yellow'],
@@ -46,6 +51,10 @@ export const Playground: Story = {};
 
 export const WithSelection: Story = {
   args: { withSelection: true },
+};
+
+export const LockedRows: Story = {
+  args: { lockedRowIds: ['person-1', 'person-3'], rowCount: 8, withSelection: true },
 };
 
 export const Sorting: Story = {

--- a/apps/client/src/shared/ui/new-table/NewTable.test.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.test.tsx
@@ -28,6 +28,27 @@ describe('NewTable', () => {
     expect(screen.getByLabelText('Désélectionner toutes les lignes')).toBeInTheDocument();
   });
 
+  it('leaves the locked rows out of a shift range', async () => {
+    const user = userEvent.setup();
+    render(<DemoTable lockedRowIds={['person-1']} rowCount={5} unvirtualized withSelection />);
+
+    await user.click(screen.getByLabelText('Sélectionner la ligne 1'));
+    await user.keyboard('{Shift>}');
+    await user.click(screen.getByLabelText('Sélectionner la ligne 3'));
+    await user.keyboard('{/Shift}');
+
+    expect(screen.getByLabelText('Sélectionner la ligne 1')).toBeChecked();
+    expect(screen.getByLabelText('Sélectionner la ligne 3')).toBeChecked();
+    expect(screen.getByLabelText('Ligne 2 : déjà traitée')).not.toBeChecked();
+  });
+
+  it('locks out the rows the table refuses to select, and says why', () => {
+    render(<DemoTable lockedRowIds={['person-0']} rowCount={5} unvirtualized withSelection />);
+
+    expect(screen.getByLabelText('Ligne 1 : déjà traitée')).toBeDisabled();
+    expect(screen.getByLabelText('Sélectionner la ligne 2')).toBeEnabled();
+  });
+
   it('toggles the sort state of a column when its header is clicked', async () => {
     const user = userEvent.setup();
     render(<DemoTable enableSorting rowCount={50} />);

--- a/apps/client/src/shared/ui/new-table/NewTable.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.tsx
@@ -197,11 +197,14 @@ export function NewTable<Data extends RowData>(props: {
                 >
                   {row.getVisibleCells().map((cell) => {
                     const sticky = cell.column.columnDef.meta?.sticky;
+                    const cellClassName = cell.column.columnDef.meta?.cellClassName?.(row);
                     return (
                       <div
                         className={clsx(
                           'flex items-center overflow-hidden px-4 py-3 wrap-break-word',
-                          sticky && 'sticky left-0 z-1 border-r border-(--border-default-grey) bg-inherit',
+                          sticky && 'sticky left-0 z-1 border-r border-(--border-default-grey)',
+                          sticky && !cellClassName && 'bg-inherit',
+                          cellClassName,
                         )}
                         key={cell.id}
                         role="cell"

--- a/apps/client/src/shared/ui/new-table/hooks/useSelectionColumn.tsx
+++ b/apps/client/src/shared/ui/new-table/hooks/useSelectionColumn.tsx
@@ -2,11 +2,15 @@ import { type ColumnDef, type RowData } from '@tanstack/react-table';
 import { useMemo, useRef } from 'react';
 
 import { Checkbox } from '../Checkbox';
+import { Tooltip } from '@/shared/ui/tooltip';
 
 const SELECTION_COLUMN_SIZE = 48;
 
-export function useSelectionColumn<Data extends RowData>(): ColumnDef<Data> {
+export function useSelectionColumn<Data extends RowData>(options?: {
+  lockedLabel?: string;
+}): ColumnDef<Data> {
   const lastSelectedRef = useRef<string | null>(null);
+  const lockedLabel = options?.lockedLabel;
 
   return useMemo(
     () => ({
@@ -23,36 +27,59 @@ export function useSelectionColumn<Data extends RowData>(): ColumnDef<Data> {
           onChange={table.getToggleAllRowsSelectedHandler()}
         />
       ),
-      cell: ({ row, table }) => (
-        <Checkbox
-          checked={row.getIsSelected()}
-          disabled={!row.getCanSelect()}
-          label={`Sélectionner la ligne ${row.index + 1}`}
-          onChange={(event) => {
-            const shouldSelect = event.currentTarget.checked;
-            const hasShift = (event.nativeEvent as MouseEvent).shiftKey;
-            const last = lastSelectedRef.current;
-
-            if (hasShift && last) {
-              const rows = table.getRowModel().rows;
-              const lastIndex = table.getRow(last).index;
-              const [from, to] = [lastIndex, row.index].sort((a, b) => a - b);
-              table.setRowSelection((selection) => ({
-                ...selection,
-                ...Object.fromEntries(rows.slice(from, to + 1).map((r) => [r.id, shouldSelect])),
-              }));
-            } else {
-              row.toggleSelected(shouldSelect);
+      cell: ({ row, table }) => {
+        const checkbox = (
+          <Checkbox
+            checked={row.getIsSelected()}
+            disabled={!row.getCanSelect()}
+            label={
+              row.getCanSelect() || !lockedLabel
+                ? `Sélectionner la ligne ${row.index + 1}`
+                : `Ligne ${row.index + 1} : ${lockedLabel}`
             }
+            onChange={(event) => {
+              const shouldSelect = event.currentTarget.checked;
+              const hasShift = (event.nativeEvent as MouseEvent).shiftKey;
+              const last = lastSelectedRef.current;
 
-            lastSelectedRef.current = row.id;
-          }}
-        />
-      ),
+              if (hasShift && last) {
+                const rows = table.getRowModel().rows;
+                const lastIndex = table.getRow(last).index;
+                const [from, to] = [lastIndex, row.index].sort((a, b) => a - b);
+                table.setRowSelection((selection) => ({
+                  ...selection,
+                  ...Object.fromEntries(
+                    rows
+                      .slice(from, to + 1)
+                      .filter((r) => r.getCanSelect())
+                      .map((r) => [r.id, shouldSelect]),
+                  ),
+                }));
+              } else {
+                row.toggleSelected(shouldSelect);
+              }
+
+              lastSelectedRef.current = row.id;
+            }}
+          />
+        );
+
+        if (row.getCanSelect() || !lockedLabel) return checkbox;
+
+        return (
+          <Tooltip className="w-full items-center self-stretch" label={lockedLabel}>
+            {checkbox}
+          </Tooltip>
+        );
+      },
       id: 'select',
-      meta: { sticky: true },
+      meta: {
+        cellClassName: (row) =>
+          !row.getCanSelect() && lockedLabel ? 'bg-(--background-contrast-grey)' : undefined,
+        sticky: true,
+      },
       size: SELECTION_COLUMN_SIZE,
     }),
-    [],
+    [lockedLabel],
   );
 }

--- a/apps/client/src/shared/ui/new-table/new-table.types.d.ts
+++ b/apps/client/src/shared/ui/new-table/new-table.types.d.ts
@@ -1,7 +1,9 @@
 import '@tanstack/react-table';
+import type { Row, RowData } from '@tanstack/react-table';
 
 declare module '@tanstack/react-table' {
   interface ColumnMeta {
+    cellClassName?: (row: Row<RowData>) => string | undefined;
     sticky?: boolean;
   }
 }

--- a/apps/client/tests/e2e/generate-docs.spec.ts
+++ b/apps/client/tests/e2e/generate-docs.spec.ts
@@ -176,4 +176,36 @@ test.describe('Générer un ordre du jour', () => {
 
     await officialReportPage.submit();
   });
+
+  test('prépare un ordre du jour à partir des propositions cochées dans le tableau', async ({ app }) => {
+    const page = app.pages.session;
+
+    // Quand je coche 2 propositions dans le tableau
+    await page.selectFiles({ name: 'BOURDIEU PIERRE' }, { name: 'HARENDT ANNA' });
+
+    // Et que je les ajoute à l'ordre du jour
+    await page.addSelectionToAgendaButton.click();
+
+    // Alors l'ordre du jour en préparation contient ces 2 propositions
+    await test.expect(page.agendaBasket).toContainText('2');
+
+    // Et quand je filtre le tableau sur l'ordre du jour en préparation
+    await page.agendaBasket.click();
+
+    // Alors seules ces 2 propositions restent affichées
+    await test.expect(page.sessionRow({ name: 'BOURDIEU PIERRE' })).toBeVisible();
+    await test.expect(page.sessionRow({ name: 'GRAMSCI ANTONIO' })).toBeHidden();
+
+    // Et quand j'en retire une depuis ce tableau filtré
+    await page.selectFiles({ name: 'HARENDT ANNA' });
+    await page.removeSelectionFromAgendaButton.click();
+
+    // Alors elle quitte l'ordre du jour en préparation
+    await test.expect(page.agendaBasket).toContainText('1');
+    await test.expect(page.sessionRow({ name: 'HARENDT ANNA' })).toBeHidden();
+
+    // Et la génération d'un ordre du jour démarre avec la proposition restante
+    const agendaPage = await page.startAgendaGeneration();
+    await test.expect(agendaPage.selectAllFilesCheckbox).toHaveAccessibleName(/1 proposition sélectionnée/);
+  });
 });

--- a/apps/client/tests/pages/manage-single-session.page.ts
+++ b/apps/client/tests/pages/manage-single-session.page.ts
@@ -231,6 +231,26 @@ export class ManageSingleSessionPage {
       .first();
   }
 
+  async selectFiles(...selectors: readonly ({ number: number } | { name: string })[]): Promise<void> {
+    await this.app.page.getByRole('button', { name: 'Sélectionner des propositions' }).click();
+
+    for (const selector of selectors) {
+      await this.sessionRow(selector).getByRole('checkbox').click();
+    }
+  }
+
+  get addSelectionToAgendaButton(): Locator {
+    return this.app.page.getByRole('button', { name: "Ajouter à l'ODJ" });
+  }
+
+  get removeSelectionFromAgendaButton(): Locator {
+    return this.app.page.getByRole('button', { name: "Retirer de l'ODJ" });
+  }
+
+  get agendaBasket(): Locator {
+    return this.app.page.getByRole('button', { name: /ODJ en préparation/ });
+  }
+
   async editAffectation(
     magistrat: MagistratTarget,
     selection: { priorities?: readonly (string | RegExp)[]; reporters?: readonly (string | RegExp)[] },


### PR DESCRIPTION
Prepare an agenda straight from the files table, instead of rebuilding the selection in the generation wizard.

- A pencil button reveals checkboxes and a contextual action bar
- "Ajouter à l'ODJ" puts the selection in an agenda being prepared, kept per session
- An "ODJ en préparation (n)" chip sits among the filters and restricts the table to those files
- Under that filter, the action becomes "Retirer de l'ODJ"
- Files already prepared are locked out of the selection, with a tooltip saying why