### PR TITLE
fix(FON-532): lock the files an agenda cannot hold

### DIFF
--- a/apps/client/src/features/agenda/components/AgendaFilesSelection.tsx
+++ b/apps/client/src/features/agenda/components/AgendaFilesSelection.tsx
@@ -49,6 +49,9 @@ export function AgendaFilesSelection(props: {
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [props.defaultSelectedFileIds, nominationFiles]);
 
+  const droppedCount =
+    data && props.defaultSelectedFileIds ? props.defaultSelectedFileIds.length - initialSelection.length : 0;
+
   const selection = useSelection({
     items: nominationFiles,
     toString: ({ id }) => id,
@@ -119,6 +122,18 @@ export function AgendaFilesSelection(props: {
           />
         )}
       </div>
+
+      {droppedCount > 0 && (
+        <p className="fr-pl-2v fr-mt-1v fr-mb-0 text-sm text-(--text-mention-grey)">
+          <FormattedMessage
+            values={{ count: droppedCount }}
+            defaultMessage={`{count, plural,
+              one {1 proposition préparée ne peut pas figurer dans un ordre du jour : elle a été écartée}
+              other {{count, number} propositions préparées ne peuvent pas figurer dans un ordre du jour : elles ont été écartées}}`}
+          />
+        </p>
+      )}
+
       <div ref={scrollRef} className="fr-mt-2v h-[42vh] min-h-64 overflow-y-scroll">
         {filtered.length === 0 && (
           <p className="fr-pt-4v text-center text-(--text-mention-grey)">

--- a/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.stories.tsx
+++ b/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.stories.tsx
@@ -12,7 +12,13 @@ import { FormationEnum } from '@/types/enums.types';
 import { SgSessionFilesTable } from './SgSessionFilesTable';
 
 const sessions: Record<string, SessionDataset> = {
-  draft: { files: sessionFiles, members: sessionMembers },
+  draft: {
+    agendaEligibleFileIds: sessionFiles
+      .filter(({ content }) => content.status.value !== 'DSJ_REPORTED')
+      .map(({ id }) => id),
+    files: sessionFiles,
+    members: sessionMembers,
+  },
   published: {
     affectationsVersion: {
       '@type': 'fr.csm.fondation.affectations.version.some',

--- a/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.tsx
+++ b/apps/client/src/features/nomination-files-table/components/SgSessionFilesTable.tsx
@@ -9,6 +9,7 @@ import { useAgendaBasket } from '@/features/agenda/hooks/useAgendaBasket.hook';
 import { PriorityBadgeList } from '@/shared/components/priority-badge';
 import { rowCell, useSelectionColumn } from '@/shared/ui/new-table';
 import type { FormationEnum } from '@/types/enums.types';
+import { useFindAgendaNominationFilesQuery } from '@queries/agenda.queries';
 import {
   useListNominationFilesAsExcelMutation,
   type SessionNominationFile,
@@ -128,10 +129,8 @@ function SgSessionFilesTableInner(props: PropsWithChildren<{ filtersSlot?: Eleme
   const { canManage, sessionId } = useNominationFilesTable();
   const basket = useAgendaBasket(sessionId);
   const fileColumns = useSgSessionFilesColumns();
-  const selectionColumn = useSelectionColumn<SessionNominationFile>({
-    lockedLabel: formatMessage({ defaultMessage: "déjà dans l'ODJ en préparation" }),
-  });
   const exportAsExcel = useListNominationFilesAsExcelMutation();
+  const { data: agendaFiles } = useFindAgendaNominationFilesQuery({ enabled: canManage, sessionId });
 
   const [isSelecting, setSelecting] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -155,10 +154,52 @@ function SgSessionFilesTableInner(props: PropsWithChildren<{ filtersSlot?: Eleme
   const isSelectable = canManage && isSelecting;
   const isFilteringBasketFiles = isFilteringBasket && !basket.isEmpty;
 
-  const canSelectRow = useCallback(
-    (row: Row<SessionNominationFile>) => isFilteringBasketFiles || !basket.has(row.original.id),
-    [basket, isFilteringBasketFiles],
+  const agendaFileIds = useMemo(
+    () => (agendaFiles ? new Set(agendaFiles.items.map(({ id }) => id)) : null),
+    [agendaFiles],
   );
+
+  useEffect(() => {
+    if (!agendaFileIds || isFilteringBasketFiles) return;
+
+    setRowSelection((selection) =>
+      Object.keys(selection).every((id) => agendaFileIds.has(id))
+        ? selection
+        : Object.fromEntries(Object.entries(selection).filter(([id]) => agendaFileIds.has(id))),
+    );
+  }, [agendaFileIds, isFilteringBasketFiles]);
+
+  const canSelectRow = useCallback(
+    (row: Row<SessionNominationFile>) => {
+      if (isFilteringBasketFiles) return true;
+      if (basket.has(row.original.id)) return false;
+
+      return !agendaFileIds || agendaFileIds.has(row.original.id);
+    },
+    [agendaFileIds, basket, isFilteringBasketFiles],
+  );
+
+  const lockedLabel = useCallback(
+    (row: Row<SessionNominationFile>) => {
+      const { content, id } = row.original;
+      if (basket.has(id)) {
+        return formatMessage({ defaultMessage: "Déjà dans l'ODJ en préparation" });
+      }
+
+      if (content.status.value === 'DSJ_REPORTED') {
+        return formatMessage({ defaultMessage: 'Déjà acté en PV de restitution' });
+      }
+
+      if (!content.detectedMagistratId || !content.jurisdictions.targeted) {
+        return formatMessage({ defaultMessage: 'Magistrat ou poste cible non identifié' });
+      }
+
+      return formatMessage({ defaultMessage: 'Ne peut pas figurer dans un ordre du jour' });
+    },
+    [basket, formatMessage],
+  );
+
+  const selectionColumn = useSelectionColumn<SessionNominationFile>({ lockedLabel });
 
   const columns = useMemo(
     () => (isSelectable ? [selectionColumn, ...fileColumns] : fileColumns),

--- a/apps/client/src/queries/agenda.queries.ts
+++ b/apps/client/src/queries/agenda.queries.ts
@@ -179,8 +179,9 @@ export const useAgendaDocumentBlocksQuery = (query: { id: string | undefined | n
         .then(({ data = null }) => data),
   });
 
-export const useFindAgendaNominationFilesQuery = (query: { sessionId: string }) =>
+export const useFindAgendaNominationFilesQuery = (query: { enabled?: boolean; sessionId: string }) =>
   useQuery({
+    enabled: query.enabled ?? true,
     queryKey: agendaKeys.findAgendaNominationFiles({ sessionId: query.sessionId }),
     queryFn: () =>
       $api.docs

--- a/apps/client/src/shared/storybook/session.handlers.ts
+++ b/apps/client/src/shared/storybook/session.handlers.ts
@@ -17,6 +17,7 @@ type ListedMember = PaginatedMemberListItemDto['items'][number];
 
 export type SessionDataset = {
   affectationsVersion?: SomeAffectationVersion;
+  agendaEligibleFileIds?: readonly string[];
   files: readonly SessionNominationFile[];
   memberReports?: ListedMemberSessionReportsDto['items'];
   members?: readonly ListedMember[];
@@ -181,6 +182,22 @@ export function makeSessionHandlers(sessions: Record<string, SessionDataset>) {
           items: datasetOf(params.sessionId).memberReports ?? [],
         }),
     ),
+
+    http.get('*/api/docs/v1/sessions/:sessionId/files', ({ params }) => {
+      const { agendaEligibleFileIds, files } = datasetOf(params.sessionId);
+      const eligible = agendaEligibleFileIds
+        ? files.filter(({ id }) => agendaEligibleFileIds.includes(id))
+        : files;
+
+      return HttpResponse.json({
+        items: eligible.map((file) => ({
+          id: file.id,
+          number: file.content.numeroDeDossier,
+          outcome: file.content.outcome,
+          reporters: file.reporters,
+        })),
+      });
+    }),
 
     http.get('*/api/docs/v1/sessions/:sessionId/readiness', ({ params }) =>
       HttpResponse.json<DocGenerationSessionReadinessDto>({

--- a/apps/client/src/shared/ui/new-table/NewTable.fixtures.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.fixtures.tsx
@@ -55,7 +55,9 @@ export function DemoTable(props: {
   withSelection?: boolean;
 }) {
   const data = useMemo(() => makePeople(props.rowCount ?? 100), [props.rowCount]);
-  const selectionColumn = useSelectionColumn<Person>({ lockedLabel: 'déjà traitée' });
+  const selectionColumn = useSelectionColumn<Person>({
+    lockedLabel: (row) => (row.index % 2 === 0 ? 'déjà traitée' : 'hors périmètre'),
+  });
 
   const columns = useMemo(
     () => (props.withSelection ? [selectionColumn, ...peopleColumns] : peopleColumns),

--- a/apps/client/src/shared/ui/new-table/NewTable.test.tsx
+++ b/apps/client/src/shared/ui/new-table/NewTable.test.tsx
@@ -39,14 +39,15 @@ describe('NewTable', () => {
 
     expect(screen.getByLabelText('Sélectionner la ligne 1')).toBeChecked();
     expect(screen.getByLabelText('Sélectionner la ligne 3')).toBeChecked();
-    expect(screen.getByLabelText('Ligne 2 : déjà traitée')).not.toBeChecked();
+    expect(screen.getByLabelText('Ligne 2 : hors périmètre')).not.toBeChecked();
   });
 
-  it('locks out the rows the table refuses to select, and says why', () => {
-    render(<DemoTable lockedRowIds={['person-0']} rowCount={5} unvirtualized withSelection />);
+  it('locks out the rows the table refuses to select, and says why for each of them', () => {
+    render(<DemoTable lockedRowIds={['person-0', 'person-1']} rowCount={5} unvirtualized withSelection />);
 
     expect(screen.getByLabelText('Ligne 1 : déjà traitée')).toBeDisabled();
-    expect(screen.getByLabelText('Sélectionner la ligne 2')).toBeEnabled();
+    expect(screen.getByLabelText('Ligne 2 : hors périmètre')).toBeDisabled();
+    expect(screen.getByLabelText('Sélectionner la ligne 3')).toBeEnabled();
   });
 
   it('toggles the sort state of a column when its header is clicked', async () => {

--- a/apps/client/src/shared/ui/new-table/hooks/useSelectionColumn.tsx
+++ b/apps/client/src/shared/ui/new-table/hooks/useSelectionColumn.tsx
@@ -1,4 +1,4 @@
-import { type ColumnDef, type RowData } from '@tanstack/react-table';
+import { type ColumnDef, type Row, type RowData } from '@tanstack/react-table';
 import { useMemo, useRef } from 'react';
 
 import { Checkbox } from '../Checkbox';
@@ -7,7 +7,7 @@ import { Tooltip } from '@/shared/ui/tooltip';
 const SELECTION_COLUMN_SIZE = 48;
 
 export function useSelectionColumn<Data extends RowData>(options?: {
-  lockedLabel?: string;
+  lockedLabel?: (row: Row<Data>) => string;
 }): ColumnDef<Data> {
   const lastSelectedRef = useRef<string | null>(null);
   const lockedLabel = options?.lockedLabel;
@@ -28,15 +28,12 @@ export function useSelectionColumn<Data extends RowData>(options?: {
         />
       ),
       cell: ({ row, table }) => {
+        const locked = row.getCanSelect() ? undefined : lockedLabel?.(row);
         const checkbox = (
           <Checkbox
             checked={row.getIsSelected()}
             disabled={!row.getCanSelect()}
-            label={
-              row.getCanSelect() || !lockedLabel
-                ? `Sélectionner la ligne ${row.index + 1}`
-                : `Ligne ${row.index + 1} : ${lockedLabel}`
-            }
+            label={locked ? `Ligne ${row.index + 1} : ${locked}` : `Sélectionner la ligne ${row.index + 1}`}
             onChange={(event) => {
               const shouldSelect = event.currentTarget.checked;
               const hasShift = (event.nativeEvent as MouseEvent).shiftKey;
@@ -64,10 +61,10 @@ export function useSelectionColumn<Data extends RowData>(options?: {
           />
         );
 
-        if (row.getCanSelect() || !lockedLabel) return checkbox;
+        if (!locked) return checkbox;
 
         return (
-          <Tooltip className="w-full items-center self-stretch" label={lockedLabel}>
+          <Tooltip className="w-full items-center self-stretch" label={locked}>
             {checkbox}
           </Tooltip>
         );


### PR DESCRIPTION
Stop the files table from offering an agenda a file it cannot hold

- Files already acted in an official report, or whose magistrate or target position is unresolved, can no longer be ticked
- Their cell is greyed and a tooltip gives the reason: already in the prepared agenda, already acted in a PV or unidentified magistrate or target position
- If a prepared file is dropped anyway, the generation wizard now says how many and why, instead of silently shortening the selection


