### PR TITLE
fix(FON-533): download the real attachment instead of the app page

### DIFF
--- a/apps/client/scalingo/nginx.conf.erb
+++ b/apps/client/scalingo/nginx.conf.erb
@@ -7,6 +7,10 @@ location / {
   try_files $uri /index.html;
 }
 
+location /api/ {
+  return 404;
+}
+
 location /assets/ {
   add_header Cache-Control "public, max-age=2592000, immutable"; # 30 days
   try_files $uri =404;

--- a/apps/client/src/features/auth/components/LoginProConnectButton.tsx
+++ b/apps/client/src/features/auth/components/LoginProConnectButton.tsx
@@ -12,9 +12,7 @@ export function LoginProConnectButton() {
   const onPrepare = () => {
     prepareLoginMutation.mutate(undefined, {
       onSuccess({ data }) {
-        const $a = document.createElement('a');
-        $a.href = data!.url;
-        $a.click();
+        if (data) window.location.href = data.url;
       },
     });
   };

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.test.tsx
@@ -10,15 +10,15 @@ import { Attachments } from './Attachments';
 
 const mocks = vi.hoisted(() => ({
   attachments: [] as {
+    addedAt: string;
     id: string;
     name: string;
     size: number | null;
     type: 'AUTRE' | 'FICHE_DE_JURIDICTION' | 'NOTE_INTENTION';
-    addedAt: string;
   }[],
   cancelTab: vi.fn(),
   createUrl: vi.fn(),
-  download: vi.fn(),
+  downloadFile: vi.fn(),
   isSg: vi.fn(() => true),
   open: vi.fn(),
   openAddAttachment: vi.fn(),
@@ -35,29 +35,36 @@ vi.mock('@/shared/context/confirm-modal', () => ({
 }));
 vi.mock('@/shared/hooks/useTab', () => ({
   useTab: () => ({
-    download: mocks.download,
     open: mocks.open,
     openDeferred: () => ({ cancel: mocks.cancelTab, settle: mocks.settleTab }),
   }),
 }));
 vi.mock('@/features/auth/hooks/roles.hook', () => ({ useIsSgNavigation: () => mocks.isSg() }));
-vi.mock('@queries/nomination-sessions.queries', () => ({
-  useListNominationFileAttachmentsQuery: () => ({ data: { items: mocks.attachments } }),
-  useCreateNominationFileAttachmentUrlMutation: () => ({
-    mutate: mocks.createUrl,
-    isPending: false,
+vi.mock('@queries/files.queries', () => ({
+  useDownloadFileMutation: () => ({
     isError: false,
+    isPending: false,
+    mutate: mocks.downloadFile,
     reset: vi.fn(),
   }),
-  useRemoveNominationFileAttachmentMutation: () => ({
-    mutate: mocks.remove,
-    isPending: false,
+}));
+vi.mock('@queries/nomination-sessions.queries', () => ({
+  useCreateNominationFileAttachmentUrlMutation: () => ({
     isError: false,
+    isPending: false,
+    mutate: mocks.createUrl,
+    reset: vi.fn(),
+  }),
+  useListNominationFileAttachmentsQuery: () => ({ data: { items: mocks.attachments } }),
+  useRemoveNominationFileAttachmentMutation: () => ({
+    isError: false,
+    isPending: false,
+    mutate: mocks.remove,
     reset: vi.fn(),
   }),
 }));
 
-const PROPS = { nominationFileId: 'nf-1', sessionId: 'session-1', isArchived: false };
+const PROPS = { isArchived: false, nominationFileId: 'nf-1', sessionId: 'session-1' };
 
 function renderAttachments(overrides: Partial<typeof PROPS> = {}) {
   return render(
@@ -72,11 +79,11 @@ beforeEach(() => {
   mocks.isSg.mockReturnValue(true);
   mocks.attachments = [
     {
+      addedAt: '2026-06-18T09:30:00.000Z',
       id: 'file-1',
       name: 'rapport.pdf',
       size: 2048,
       type: 'FICHE_DE_JURIDICTION',
-      addedAt: '2026-06-18T09:30:00.000Z',
     },
   ];
 });
@@ -134,16 +141,19 @@ describe('Attachments actions', () => {
     expect(mocks.settleTab).not.toHaveBeenCalled();
   });
 
-  it('downloads the file same-origin with the download flag', async () => {
+  it('downloads the file from the url the api returned', async () => {
     mocks.createUrl.mockImplementation((_vars, options) =>
-      options.onSuccess({ url: 'http://localhost:3000/api/files/v1/abc' }),
+      options.onSuccess({ url: 'https://api.example/api/files/v1/abc' }),
     );
     const user = userEvent.setup();
     renderAttachments();
 
     await user.click(screen.getByRole('button', { name: 'Télécharger rapport.pdf' }));
 
-    expect(mocks.download).toHaveBeenCalledWith('/api/files/v1/abc?download');
+    expect(mocks.downloadFile).toHaveBeenCalledWith({
+      name: 'rapport.pdf',
+      url: 'https://api.example/api/files/v1/abc',
+    });
   });
 
   it('removes the file once the deletion is confirmed', async () => {

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.tsx
@@ -8,6 +8,7 @@ import { useConfirmModal } from '@/shared/context/confirm-modal';
 import { useTab } from '@/shared/hooks/useTab';
 import type { NominationFileAttachmentTypeEnum } from '@/types/enums.types';
 import { formatFileSize, splitFileName } from '@/utils/file.utils';
+import { useDownloadFileMutation } from '@queries/files.queries';
 import {
   useCreateNominationFileAttachmentUrlMutation,
   useListNominationFileAttachmentsQuery,
@@ -19,7 +20,7 @@ import { NominationFileAttachmentTypeTag } from './NominationFileAttachmentTypeT
 
 export const ATTACHMENTS_SECTION_ID = 'magistrat-attachments-section';
 
-export function Attachments(props: { nominationFileId: string; sessionId: string; isArchived: boolean }) {
+export function Attachments(props: { isArchived: boolean; nominationFileId: string; sessionId: string }) {
   const isSg = useIsSgNavigation();
   const { open: openAddAttachment } = useAddNominationFileAttachmentModal();
   const { data } = useListNominationFileAttachmentsQuery({
@@ -89,12 +90,12 @@ export function Attachments(props: { nominationFileId: string; sessionId: string
 }
 
 function AttachmentItem(props: {
-  fileId: string;
-  nominationFileId: string;
-  sessionId: string;
   addedAt: string;
   canDelete: boolean;
+  fileId: string;
   name: string;
+  nominationFileId: string;
+  sessionId: string;
   size: number | null;
   type: NominationFileAttachmentTypeEnum;
 }) {
@@ -106,6 +107,12 @@ function AttachmentItem(props: {
     isError: isUrlError,
     reset: resetUrl,
   } = useCreateNominationFileAttachmentUrlMutation();
+  const {
+    mutate: download,
+    isPending: isDownloadPending,
+    isError: isDownloadError,
+    reset: resetDownload,
+  } = useDownloadFileMutation();
   const {
     mutate: remove,
     isPending: isRemovePending,
@@ -119,11 +126,12 @@ function AttachmentItem(props: {
     .filter(Boolean)
     .join(' - ');
 
-  const error = isUrlError
-    ? formatMessage({ defaultMessage: 'Le téléchargement du fichier a échoué. Veuillez réessayer.' })
-    : isRemoveError
-      ? formatMessage({ defaultMessage: 'La suppression du fichier a échoué. Veuillez réessayer.' })
-      : null;
+  const error =
+    isUrlError || isDownloadError
+      ? formatMessage({ defaultMessage: 'Le téléchargement du fichier a échoué. Veuillez réessayer.' })
+      : isRemoveError
+        ? formatMessage({ defaultMessage: 'La suppression du fichier a échoué. Veuillez réessayer.' })
+        : null;
 
   const onPreview = useCallback(() => {
     const attachmentTab = tab.openDeferred({
@@ -148,17 +156,14 @@ function AttachmentItem(props: {
       { fileId: props.fileId, nominationFileId: props.nominationFileId, sessionId: props.sessionId },
       {
         onSuccess: (response) => {
-          if (!response) return;
-          const { pathname } = new URL(response.url);
-          tab.download(`${pathname}?download`);
+          if (response) download({ name: props.name, url: response.url });
         },
       },
     );
-  }, [createUrl, tab, props.sessionId, props.nominationFileId, props.fileId]);
+  }, [createUrl, download, props.fileId, props.name, props.nominationFileId, props.sessionId]);
 
   const onDelete = useCallback(async () => {
     const { isConfirmed } = await waitForConfirmation({
-      title: formatMessage({ defaultMessage: 'Supprimer la pièce jointe' }),
       content: (
         <p>
           <FormattedMessage
@@ -171,17 +176,18 @@ function AttachmentItem(props: {
         cancel: formatMessage({ defaultMessage: 'Annuler' }),
         confirm: formatMessage({ defaultMessage: 'Supprimer' }),
       },
+      title: formatMessage({ defaultMessage: 'Supprimer la pièce jointe' }),
     });
     if (!isConfirmed) return;
     remove({ fileId: props.fileId, nominationFileId: props.nominationFileId, sessionId: props.sessionId });
   }, [
-    waitForConfirmation,
-    remove,
     formatMessage,
-    props.name,
-    props.sessionId,
-    props.nominationFileId,
     props.fileId,
+    props.name,
+    props.nominationFileId,
+    props.sessionId,
+    remove,
+    waitForConfirmation,
   ]);
 
   return (
@@ -205,7 +211,7 @@ function AttachmentItem(props: {
           />
           <button
             className="-mx-1 -my-0.5 truncate border-0 bg-transparent px-1 py-0.5 text-left text-(--text-action-high-blue-france) underline underline-offset-2 hover:bg-(--background-default-grey-hover) disabled:opacity-50"
-            disabled={isUrlPending || isRemovePending}
+            disabled={isUrlPending || isDownloadPending || isRemovePending}
             onClick={onPreview}
             title={formatMessage(
               { defaultMessage: 'Ouvrir {name} dans un nouvel onglet' },
@@ -220,7 +226,7 @@ function AttachmentItem(props: {
 
         <div className="flex shrink-0 items-center gap-1">
           <Button
-            disabled={isUrlPending || isRemovePending}
+            disabled={isUrlPending || isDownloadPending || isRemovePending}
             iconId="fr-icon-download-line"
             onClick={onDownload}
             priority="tertiary no outline"
@@ -247,6 +253,7 @@ function AttachmentItem(props: {
           description={error}
           onClose={() => {
             resetUrl();
+            resetDownload();
             resetRemove();
           }}
           severity="error"

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/summary/Summary.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/summary/Summary.tsx
@@ -6,12 +6,13 @@ import { FormattedMessage } from 'react-intl';
 import { useIsSg } from '@/features/auth/hooks/roles.hook';
 import { SummaryReaderSelector } from '@/features/summary/components/SummaryReaderSelector';
 import { SummaryContext } from '@/features/summary/context/SummaryContext';
+import { useOpenSummaryAttachment } from '@/features/summary/hooks/useOpenSummaryAttachment';
 import { useArchivedSession } from '@/shared/context/archived-session';
 import { ExpandableText } from '@/shared/ui/expandable-text';
 import { ROUTE_PATHS } from '@/utils/route-path.utils';
 import { useUser } from '@queries/auth.queries';
 import type { SessionNominationFile } from '@queries/nomination-sessions.queries';
-import { useGenerateSummaryAttachmentPublicUrlMutation, useSummaryQuery } from '@queries/summary.queries';
+import { useSummaryQuery } from '@queries/summary.queries';
 
 import { containsImage, toPlainText } from './summary-text';
 import { SummaryButton } from './SummaryButton';
@@ -199,7 +200,7 @@ function SummaryAttachments(props: {
   nominationFileId: string;
   sessionId: string;
 }) {
-  const { mutate: openAttachment, isPending } = useGenerateSummaryAttachmentPublicUrlMutation();
+  const { isPending, open: openAttachment } = useOpenSummaryAttachment();
   const { nominationFileId, sessionId } = props;
   const [expanded, setExpanded] = useState(false);
   const count = props.attachments.length;
@@ -230,7 +231,7 @@ function SummaryAttachments(props: {
                 className="px-0! underline underline-offset-3 before:no-underline [&::before]:mr-1!"
                 disabled={isPending}
                 iconId="ri-file-text-line"
-                onClick={() => openAttachment({ sessionId, nominationFileId, fileId: id })}
+                onClick={() => openAttachment({ fileId: id, name, nominationFileId, sessionId })}
                 priority="tertiary no outline"
                 size="small"
               >

--- a/apps/client/src/features/reports/components/AttachedFilesList.tsx
+++ b/apps/client/src/features/reports/components/AttachedFilesList.tsx
@@ -1,43 +1,55 @@
 import Button from '@codegouvfr/react-dsfr/Button';
-import { useMutation } from '@tanstack/react-query';
 import clsx from 'clsx';
+import { useCallback } from 'react';
+import { useIntl } from 'react-intl';
 
+import { useTab } from '@/shared/hooks/useTab';
 import { DeleteFileButton } from '@/shared/ui/DeleteFileButton';
-import { generateReportFilePublicUrl } from '@queries/reports.queries';
+import { useToasts } from '@/shared/ui/toast';
+import { useGenerateReportFilePublicUrlMutation } from '@queries/reports.queries';
 
 export function AttachedFilesList(props: {
-  reportId: string;
-  attachments: { name: string; fileId: string }[];
+  attachments: { fileId: string; name: string }[];
   onDelete: (fileName: string) => unknown;
+  reportId: string;
 }) {
-  const { mutate: createAttachmentLink } = useMutation({
-    mutationFn: async (fileName: string) => {
-      const result = await generateReportFilePublicUrl({
-        reportId: props.reportId,
-        fileNames: [fileName],
+  const { formatMessage } = useIntl();
+  const toasts = useToasts();
+  const tab = useTab();
+
+  const { isPending, mutateAsync: createAttachmentLink } = useGenerateReportFilePublicUrlMutation();
+
+  const onOpen = useCallback(
+    async (fileName: string) => {
+      const attachmentTab = tab.openDeferred({
+        message: formatMessage({ defaultMessage: 'Ouverture de la pièce jointe, merci de patienter...' }),
+        title: fileName,
       });
-      if (!result || !result.items.length) throw new Error();
 
-      const $a = document.createElement('a');
-      $a.href = result.items[0].url;
-      $a.target = '_blank';
-      $a.rel = 'noopener noreferrer';
-
-      document.body.appendChild($a);
-
-      $a.click();
-      $a.remove();
+      try {
+        attachmentTab.settle(await createAttachmentLink({ fileName, reportId: props.reportId }));
+      } catch {
+        attachmentTab.cancel();
+        toasts.error({
+          description: formatMessage({
+            defaultMessage: 'Réessayez et prévenez le support si cela persiste.',
+          }),
+          title: formatMessage({ defaultMessage: 'L\'ouverture de "{name}" a échoué' }, { name: fileName }),
+        });
+      }
     },
-  });
+    [createAttachmentLink, formatMessage, props.reportId, tab, toasts],
+  );
 
   return (
     <ul className={clsx('flex flex-col gap-2')}>
       {props.attachments.map((file) => (
         <li key={file.fileId} className="flex items-center gap-4">
           <Button
-            priority="tertiary no outline"
             className="text-ellipsis"
-            onClick={() => createAttachmentLink(file.name)}
+            disabled={isPending}
+            onClick={() => onOpen(file.name)}
+            priority="tertiary no outline"
           >
             {file.name}
           </Button>

--- a/apps/client/src/features/reports/components/ReportSummaryCard.tsx
+++ b/apps/client/src/features/reports/components/ReportSummaryCard.tsx
@@ -5,17 +5,17 @@ import React from 'react';
 import './ReportSummaryCard.css';
 
 import { reportHtmlIds } from '@/features/reports/constants/html-ids.constants';
+import { useOpenSummaryAttachment } from '@/features/summary/hooks/useOpenSummaryAttachment';
 import type { DetailedReportDto } from '@api/types';
-import { useGenerateSummaryAttachmentPublicUrlMutation } from '@queries/summary.queries';
 
 import { Card } from './Card';
 
 export function ReportSummaryCard(props: {
-  sessionId: string;
   nominationFileId: string;
+  sessionId: string;
   summary: DetailedReportDto['summary'];
 }) {
-  const { mutate } = useGenerateSummaryAttachmentPublicUrlMutation();
+  const { open: openAttachment } = useOpenSummaryAttachment();
   const html = React.useMemo(() => convertTitleNodes(props.summary?.content ?? ''), [props.summary]);
 
   if (!html) return null;
@@ -26,17 +26,8 @@ export function ReportSummaryCard(props: {
       <article className="report__summary" dangerouslySetInnerHTML={{ __html: html }} />
       {(props.summary?.attachments.length ?? 0) > 0 ? (
         <ButtonsGroup
-          inlineLayoutWhen="md and up"
           buttons={
             (props.summary?.attachments ?? []).map(({ fileId, name, type }) => ({
-              onClick: () =>
-                mutate({
-                  fileId,
-                  nominationFileId: props.nominationFileId,
-                  sessionId: props.sessionId,
-                }),
-              priority: 'tertiary no outline',
-              iconPosition: 'left',
               children: name,
               iconId:
                 type === 'application/pdf'
@@ -44,8 +35,18 @@ export function ReportSummaryCard(props: {
                   : type.startsWith('image/')
                     ? 'ri-file-image-fill'
                     : 'ri-file-fille',
+              iconPosition: 'left',
+              onClick: () =>
+                openAttachment({
+                  fileId,
+                  name,
+                  nominationFileId: props.nominationFileId,
+                  sessionId: props.sessionId,
+                }),
+              priority: 'tertiary no outline',
             })) as unknown as [ButtonProps, ...ButtonProps[]]
           }
+          inlineLayoutWhen="md and up"
         />
       ) : null}
     </Card>

--- a/apps/client/src/features/summary/components/SummarySectionAttachments.tsx
+++ b/apps/client/src/features/summary/components/SummarySectionAttachments.tsx
@@ -4,12 +4,9 @@ import { useCallback, useRef, type ChangeEvent } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useSummary } from '@/features/summary/context/SummaryContext';
+import { useOpenSummaryAttachment } from '@/features/summary/hooks/useOpenSummaryAttachment';
 import { useConfirmModal } from '@/shared/context/confirm-modal';
-import {
-  useAttachSummaryFilesMutation,
-  useDetachSummaryFilesMutation,
-  useGenerateSummaryAttachmentPublicUrlMutation,
-} from '@queries/summary.queries';
+import { useAttachSummaryFilesMutation, useDetachSummaryFilesMutation } from '@queries/summary.queries';
 
 import { SummarySectionCard } from './SummarySectionCard';
 
@@ -85,30 +82,32 @@ function SummaryAttachmentInput() {
 }
 
 function SummaryAttachment(props: { fileId: string; name: string }) {
-  const { canWriteSummary, sessionId, nominationFileId } = useSummary();
+  const { canWriteSummary, nominationFileId, sessionId } = useSummary();
   const { formatMessage } = useIntl();
 
-  const { mutate: openAttachment, isPending: isGenerating } = useGenerateSummaryAttachmentPublicUrlMutation();
+  const { isPending: isGenerating, open: openAttachment } = useOpenSummaryAttachment();
   const onOpenAttachment = useCallback(() => {
-    openAttachment({ sessionId, nominationFileId, fileId: props.fileId });
-  }, [openAttachment, sessionId, nominationFileId, props.fileId]);
+    openAttachment({ fileId: props.fileId, name: props.name, nominationFileId, sessionId });
+  }, [nominationFileId, openAttachment, props.fileId, props.name, sessionId]);
 
   const { mutate: detach, isPending: detachingIsPending } = useDetachSummaryFilesMutation();
   const { waitForConfirmation } = useConfirmModal();
   const onDeleteAttachment = useCallback(async () => {
     const { isConfirmed } = await waitForConfirmation({
-      title: formatMessage({ defaultMessage: 'Veuillez confirmer la suppression du fichier' }),
-      content: formatMessage({ defaultMessage: 'Une fois supprimé, il sera impossible de le récupérer.' }),
+      content: formatMessage({
+        defaultMessage: 'Une fois supprimé, il sera impossible de le récupérer.',
+      }),
       i18n: {
         cancel: formatMessage({ defaultMessage: 'Annuler' }),
         confirm: formatMessage({ defaultMessage: 'Supprimer le fichier' }),
       },
+      title: formatMessage({ defaultMessage: 'Veuillez confirmer la suppression du fichier' }),
     });
 
     if (!isConfirmed) return;
 
-    detach({ sessionId, nominationFileId, fileIds: [props.fileId] });
-  }, [sessionId, nominationFileId, detach, formatMessage, props.fileId, waitForConfirmation]);
+    detach({ fileIds: [props.fileId], nominationFileId, sessionId });
+  }, [detach, formatMessage, nominationFileId, props.fileId, sessionId, waitForConfirmation]);
 
   return (
     <li className="flex">

--- a/apps/client/src/features/summary/hooks/useOpenSummaryAttachment.ts
+++ b/apps/client/src/features/summary/hooks/useOpenSummaryAttachment.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+import { useIntl } from 'react-intl';
+
+import { useTab } from '@/shared/hooks/useTab';
+import { useToasts } from '@/shared/ui/toast';
+import { useGenerateSummaryAttachmentPublicUrlMutation } from '@queries/summary.queries';
+
+export function useOpenSummaryAttachment() {
+  const { formatMessage } = useIntl();
+  const toasts = useToasts();
+  const tab = useTab();
+  const { mutateAsync, isPending } = useGenerateSummaryAttachmentPublicUrlMutation();
+
+  const open = useCallback(
+    async (attachment: { fileId: string; name: string; nominationFileId: string; sessionId: string }) => {
+      const attachmentTab = tab.openDeferred({
+        message: formatMessage({ defaultMessage: 'Ouverture de la pièce jointe, merci de patienter...' }),
+        title: attachment.name,
+      });
+
+      try {
+        const url = await mutateAsync(attachment);
+        if (!url) throw new Error(`no public url for ${attachment.name}`);
+
+        attachmentTab.settle(url);
+      } catch {
+        attachmentTab.cancel();
+        toasts.error({
+          description: formatMessage({
+            defaultMessage: 'Réessayez et prévenez le support si cela persiste.',
+          }),
+          title: formatMessage(
+            { defaultMessage: 'L\'ouverture de "{name}" a échoué' },
+            { name: attachment.name },
+          ),
+        });
+      }
+    },
+    [formatMessage, mutateAsync, tab, toasts],
+  );
+
+  return { isPending, open };
+}

--- a/apps/client/src/features/transparence/components/attachments/NominationSessionAttachmentList.tsx
+++ b/apps/client/src/features/transparence/components/attachments/NominationSessionAttachmentList.tsx
@@ -1,11 +1,13 @@
 import Button from '@codegouvfr/react-dsfr/Button';
 import clsx from 'clsx';
 import { useCallback, type ReactNode } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useIsSg } from '@/features/auth/hooks/roles.hook';
 import { useArchivedSession } from '@/shared/context/archived-session';
+import { useTab } from '@/shared/hooks/useTab';
 import { DeleteFileButton } from '@/shared/ui/DeleteFileButton';
+import { useToasts } from '@/shared/ui/toast';
 import {
   useCreateNominationSessionAttachmentUrlMutation,
   useListNominationSessionAttachmentsQuery,
@@ -13,6 +15,9 @@ import {
 } from '@queries/nomination-sessions.queries';
 
 export function NominationSessionAttachmentList(props: { placeholder?: ReactNode; sessionId: string }) {
+  const { formatMessage } = useIntl();
+  const toasts = useToasts();
+  const tab = useTab();
   const { isArchived } = useArchivedSession();
   const isSg = useIsSg();
   const { data: attachments } = useListNominationSessionAttachmentsQuery({
@@ -21,28 +26,41 @@ export function NominationSessionAttachmentList(props: { placeholder?: ReactNode
 
   const { mutate: createUrl, isPending: isUrlPending } = useCreateNominationSessionAttachmentUrlMutation();
 
-  const onCreateUrl = useCallback(
-    (fileId: string) => {
+  const notifyOpeningFailure = useCallback(
+    (name: string) =>
+      toasts.error({
+        description: formatMessage({
+          defaultMessage: 'Réessayez et prévenez le support si cela persiste.',
+        }),
+        title: formatMessage({ defaultMessage: 'L\'ouverture de "{name}" a échoué' }, { name }),
+      }),
+    [formatMessage, toasts],
+  );
+
+  const onOpen = useCallback(
+    (file: { id: string; name: string }) => {
+      const attachmentTab = tab.openDeferred({
+        message: formatMessage({ defaultMessage: 'Ouverture de la pièce jointe, merci de patienter...' }),
+        title: file.name,
+      });
+
       createUrl(
-        { sessionId: props.sessionId, fileId },
+        { fileId: file.id, sessionId: props.sessionId },
         {
+          onError: () => {
+            attachmentTab.cancel();
+            notifyOpeningFailure(file.name);
+          },
           onSuccess: (response) => {
-            if (!response) throw new Error(`failed to download`);
+            if (response) return attachmentTab.settle(response.url);
 
-            const a = document.createElement('a');
-            a.href = response.url;
-            a.target = '_blank';
-            a.rel = 'noopener noreferrer';
-
-            document.body.appendChild(a);
-
-            a.click();
-            a.remove();
+            attachmentTab.cancel();
+            notifyOpeningFailure(file.name);
           },
         },
       );
     },
-    [createUrl, props.sessionId],
+    [createUrl, formatMessage, notifyOpeningFailure, props.sessionId, tab],
   );
 
   const { mutate: deleteAttachment, isPending: isDeletionPending } =
@@ -64,7 +82,7 @@ export function NominationSessionAttachmentList(props: { placeholder?: ReactNode
           <Button
             className={clsx('inline truncate', { grow: !isSg })}
             disabled={isUrlPending || isDeletionPending}
-            onClick={() => onCreateUrl(file.id)}
+            onClick={() => onOpen(file)}
             priority="tertiary no outline"
           >
             {file.name}

--- a/apps/client/src/pages/documents/agenda/AgendaUpdateFilesPage.tsx
+++ b/apps/client/src/pages/documents/agenda/AgendaUpdateFilesPage.tsx
@@ -26,22 +26,22 @@ export function AgendaUpdateFilesPage() {
       update.mutate(
         { nominationFileIds: [...nominationFileIds] },
         {
-          onSuccess: () => navigate(generatePath(ROUTE_PATHS.SG.AGENDA_PREVIEW, { sessionId, agendaId })),
           onError: async (err) => {
             const defaultError = formatMessage({
               defaultMessage: `Impossible de mettre à jour les propositions`,
             });
             if (err instanceof HttpException) {
-              const body = await err.response.json();
-              setError(body.validationError || defaultError);
+              const body = await err.response.json().catch(() => null);
+              setError(body?.validationError || defaultError);
             } else {
               setError(defaultError);
             }
           },
+          onSuccess: () => navigate(generatePath(ROUTE_PATHS.SG.AGENDA_PREVIEW, { agendaId, sessionId })),
         },
       );
     },
-    [update, navigate, sessionId, agendaId, formatMessage],
+    [agendaId, formatMessage, navigate, sessionId, update],
   );
 
   const onCancel = React.useCallback(
@@ -52,7 +52,7 @@ export function AgendaUpdateFilesPage() {
   return (
     <div className="fr-container fr-py-4v">
       <AgendaBreadCrumb />
-      {error && <Alert className="fr-mb-6v" title={error} as="h2" severity="error" closable />}
+      {error && <Alert as="h2" className="fr-mb-6v" closable severity="error" title={error} />}
       <h1>
         <FormattedMessage defaultMessage="Propositions de l'ordre du jour" />
       </h1>
@@ -60,21 +60,21 @@ export function AgendaUpdateFilesPage() {
         <span className="ri-loader-4-line animate-spin" />
       ) : (
         <AgendaFilesSelection
-          sessionId={sessionId}
-          formation={session?.formation ?? 'SIEGE'}
-          defaultSelectedFileIds={files?.items}
-          isSubmitting={update.isPending}
           cancelLabel={<FormattedMessage defaultMessage="Annuler" />}
+          defaultSelectedFileIds={files?.items}
+          formation={session?.formation ?? 'SIEGE'}
+          isSubmitting={update.isPending}
           onCancel={onCancel}
           onSubmit={onSubmit}
           renderSubmitLabel={(count) => (
             <FormattedMessage
-              values={{ count }}
               defaultMessage={`{count, plural,
                 =0 {En attente de sélection}
                 other {Enregistrer les propositions}}`}
+              values={{ count }}
             />
           )}
+          sessionId={sessionId}
         />
       )}
     </div>

--- a/apps/client/src/pages/documents/agenda/AgendaUpdateMetadataPage.tsx
+++ b/apps/client/src/pages/documents/agenda/AgendaUpdateMetadataPage.tsx
@@ -25,21 +25,21 @@ export function AgendaUpdateMetadataPage() {
   const onSubmit = React.useCallback(
     (values: AgendaMetadata) => {
       update.mutate(values, {
-        onSuccess: () => navigate(generatePath(ROUTE_PATHS.SG.AGENDA_PREVIEW, { sessionId, agendaId })),
         onError: async (err) => {
           const defaultError = formatMessage({
             defaultMessage: `Impossible de mettre à jour les métadonnées`,
           });
           if (err instanceof HttpException) {
-            const body = await err.response.json();
-            setError(body.validationError || defaultError);
+            const body = await err.response.json().catch(() => null);
+            setError(body?.validationError || defaultError);
           } else {
             setError(defaultError);
           }
         },
+        onSuccess: () => navigate(generatePath(ROUTE_PATHS.SG.AGENDA_PREVIEW, { agendaId, sessionId })),
       });
     },
-    [update, navigate, sessionId, agendaId, formatMessage],
+    [agendaId, formatMessage, navigate, sessionId, update],
   );
 
   const onCancel = React.useCallback(
@@ -50,7 +50,7 @@ export function AgendaUpdateMetadataPage() {
   return (
     <div className="fr-container fr-py-4v">
       <AgendaBreadCrumb />
-      {error && <Alert className="fr-mb-6v" title={error} as="h2" severity="error" closable />}
+      {error && <Alert as="h2" className="fr-mb-6v" closable severity="error" title={error} />}
       <h1>
         <FormattedMessage defaultMessage="Métadonnées de l'ordre du jour" />
       </h1>
@@ -58,14 +58,14 @@ export function AgendaUpdateMetadataPage() {
         <span className="ri-loader-4-line animate-spin" />
       ) : (
         <AgendaMetadataForm
-          formation={session?.formation ?? 'SIEGE'}
-          defaultValues={metadata}
-          isSubmitting={update.isPending}
-          submitLabel={<FormattedMessage defaultMessage="Enregistrer les métadonnées" />}
-          submitIconId="ri-save-line"
           cancelLabel={<FormattedMessage defaultMessage="Annuler" />}
+          defaultValues={metadata}
+          formation={session?.formation ?? 'SIEGE'}
+          isSubmitting={update.isPending}
           onCancel={onCancel}
           onSubmit={onSubmit}
+          submitIconId="ri-save-line"
+          submitLabel={<FormattedMessage defaultMessage="Enregistrer les métadonnées" />}
         />
       )}
     </div>

--- a/apps/client/src/pages/spaces/admin/IngestLolfiArchivePage.tsx
+++ b/apps/client/src/pages/spaces/admin/IngestLolfiArchivePage.tsx
@@ -55,18 +55,22 @@ export function IngestLolfiArchivePage() {
         { archive: dto.archive },
         {
           async onError(error) {
+            const defaultError = formatMessage({
+              defaultMessage: "L'ingestion de l'archive a échoué. Veuillez réessayer.",
+            });
+
             if (!(error instanceof HttpException)) {
-              setAsyncErrors([`Erreur: ${String(error)}`]);
+              setAsyncErrors([defaultError]);
               return;
             }
 
-            const { errors } = (await error.response.json()) as IngestedLolfiArchiveDto;
-            setAsyncErrors(errors ? errors.map(({ message }) => message) : null);
-          },
-          onSuccess: (data) => {
-            if (data?.id) {
-              return navigate(generatePath(ROUTE_PATHS.ADMIN.DETAILS_JOB, { jobId: String(data.id) }));
+            const body = (await error.response.json().catch(() => null)) as IngestedLolfiArchiveDto | null;
+            if (!body) {
+              setAsyncErrors([defaultError]);
+              return;
             }
+
+            setAsyncErrors(body.errors ? body.errors.map(({ message }) => message) : null);
           },
           onSettled() {
             if (inputRef.current) {
@@ -74,10 +78,15 @@ export function IngestLolfiArchivePage() {
               inputRef.current.files = null;
             }
           },
+          onSuccess: (data) => {
+            if (data?.id) {
+              return navigate(generatePath(ROUTE_PATHS.ADMIN.DETAILS_JOB, { jobId: String(data.id) }));
+            }
+          },
         },
       );
     },
-    [resetMutation, ingestArchive, navigate],
+    [formatMessage, ingestArchive, navigate, resetMutation],
   );
 
   return (
@@ -108,10 +117,14 @@ export function IngestLolfiArchivePage() {
           name="archive"
           render={({ field: { onChange } }) => (
             <Upload
+              hint={formatMessage({ defaultMessage: 'Format supporté : .zip' })}
               id="lolfi-archive-upload"
+              label={
+                <RequiredLabel>
+                  <FormattedMessage defaultMessage="Archive LOLFI" />
+                </RequiredLabel>
+              }
               nativeInputProps={{
-                type: 'file',
-                ref: inputRef,
                 onChange: (e) => {
                   const file = e.target.files?.[0];
                   if (file) {
@@ -119,13 +132,9 @@ export function IngestLolfiArchivePage() {
                     onChange(file);
                   }
                 },
+                ref: inputRef,
+                type: 'file',
               }}
-              hint={formatMessage({ defaultMessage: 'Format supporté : .zip' })}
-              label={
-                <RequiredLabel>
-                  <FormattedMessage defaultMessage="Archive LOLFI" />
-                </RequiredLabel>
-              }
               state={errors.archive || asyncErrors ? 'error' : 'default'}
               stateRelatedMessage={errors.archive?.message}
             />

--- a/apps/client/src/pages/transparence/TransparenceAttachmentsTab.tsx
+++ b/apps/client/src/pages/transparence/TransparenceAttachmentsTab.tsx
@@ -20,6 +20,7 @@ import { useToasts } from '@/shared/ui/toast';
 import { TotalBadge } from '@/shared/ui/total-badge';
 import { formatFileSize } from '@/utils/file.utils';
 import { unaccent } from '@/utils/string.utils';
+import { useDownloadFileMutation } from '@queries/files.queries';
 import {
   useCreateNominationSessionAttachmentUrlMutation,
   useListNominationSessionAttachmentsQuery,
@@ -51,6 +52,7 @@ export function TransparenceAttachmentsTab() {
     sessionId: transparence.id,
   });
   const { mutate: createUrl, isPending: isUrlPending } = useCreateNominationSessionAttachmentUrlMutation();
+  const { mutate: download, isPending: isDownloadPending } = useDownloadFileMutation();
   const { mutate: deleteAttachment } = useRemoveNominationSessionAttachmentMutation();
 
   const onOpen = useCallback(
@@ -71,22 +73,36 @@ export function TransparenceAttachmentsTab() {
         },
       );
     },
-    [createUrl, formatMessage, transparence.id, tab],
+    [createUrl, formatMessage, tab, transparence.id],
+  );
+
+  const notifyDownloadFailure = useCallback(
+    (name: string) =>
+      toasts.error({
+        description: formatMessage({
+          defaultMessage: 'Réessayez et prévenez le support si cela persiste.',
+        }),
+        title: formatMessage({ defaultMessage: 'Le téléchargement de "{name}" a échoué' }, { name }),
+      }),
+    [formatMessage, toasts],
   );
 
   const onDownload = useCallback(
-    (fileId: string) =>
+    (attachment: { id: string; name: string }) =>
       createUrl(
-        { fileId, sessionId: transparence.id },
+        { fileId: attachment.id, sessionId: transparence.id },
         {
+          onError: () => notifyDownloadFailure(attachment.name),
           onSuccess: (response) => {
             if (!response) return;
-            const { pathname } = new URL(response.url);
-            tab.download(`${pathname}?download`);
+            download(
+              { name: attachment.name, url: response.url },
+              { onError: () => notifyDownloadFailure(attachment.name) },
+            );
           },
         },
       ),
-    [createUrl, transparence.id, tab],
+    [createUrl, download, notifyDownloadFailure, transparence.id],
   );
 
   const allAttachments = attachments?.items ?? [];
@@ -178,10 +194,10 @@ export function TransparenceAttachmentsTab() {
         actions={(attachment) => (
           <div className="-ml-2 flex items-center gap-1">
             <IconButton
-              disabled={isUrlPending}
+              disabled={isUrlPending || isDownloadPending}
               iconId={ACTION_ICONS.download}
               label={formatMessage({ defaultMessage: 'Télécharger {name}' }, { name: attachment.name })}
-              onClick={() => onDownload(attachment.id)}
+              onClick={() => onDownload(attachment)}
             />
 
             {!isArchived && (

--- a/apps/client/src/queries/files.queries.ts
+++ b/apps/client/src/queries/files.queries.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { fileNameFromResponse, saveBlob } from '@/utils/file.utils';
+import * as $api from '@api/sdk';
+
+function fileUrlIdFrom(publicUrl: string): string {
+  return new URL(publicUrl).pathname.split('/').at(-1) ?? '';
+}
+
+export const useDownloadFileMutation = () =>
+  useMutation({
+    mutationFn: async (command: { name: string; url: string }): Promise<void> => {
+      const { data, response } = await $api.files.getFileByFileUrl({
+        parseAs: 'blob',
+        path: { fileUrlId: fileUrlIdFrom(command.url) },
+        query: { download: '' },
+      });
+
+      saveBlob(data as Blob, fileNameFromResponse(response, command.name));
+    },
+  });

--- a/apps/client/src/queries/nomination-sessions.queries.ts
+++ b/apps/client/src/queries/nomination-sessions.queries.ts
@@ -287,40 +287,14 @@ export const useCreateNominationSessionFromLodamMutation = () =>
         return data;
       } catch (err) {
         if (err instanceof HttpException && err.statusCode === 400) {
-          const { validationErrors } = await err.response.json();
-          throw Object.assign(new Error(), { validationErrors });
+          const body = await err.response.json().catch(() => null);
+          if (body) throw Object.assign(new Error(), { validationErrors: body.validationErrors });
         }
 
         throw err;
       }
     },
   });
-
-export function useUpdateNominationSessionObserversFromLodamMutation() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (input: { file: File; sessionId: string }) => {
-      try {
-        await $api.sessions.updateSessionObservers({
-          path: { sessionId: input.sessionId },
-          body: { file: input.file },
-        });
-      } catch (err) {
-        if (err instanceof HttpException && err.statusCode === 400) {
-          const { validationErrors } = await err.response.json();
-          throw Object.assign(new Error(), { validationErrors });
-        }
-
-        throw err;
-      }
-    },
-    onSuccess: (_data, { sessionId }) =>
-      queryClient.invalidateQueries({
-        queryKey: sessionKeys.listSessionNominationFiles({ sessionId }),
-      }),
-  });
-}
 
 export function useAddNominationSessionAttachmentMutation() {
   const queryClient = useQueryClient();
@@ -599,9 +573,6 @@ export const getListCurrentlyAffectedReportersQueryOptions = (options: { session
       return data ?? null;
     },
   }) as const;
-
-export const useListCurrentlyAffectedReportersQuery = (options: { sessionId: string }) =>
-  useQuery(getListCurrentlyAffectedReportersQueryOptions(options));
 
 export const useCountUnaffectedFilesQuery = (options: { enabled?: boolean; sessionId: string }) =>
   useQuery({

--- a/apps/client/src/queries/reports.queries.ts
+++ b/apps/client/src/queries/reports.queries.ts
@@ -35,14 +35,20 @@ export const useMyReportQuery = (props: {
     queryKey: reportKeys.myReport({ nominationFileId: props.nominationFileId }),
   });
 
-export function generateReportFilePublicUrl(props: { reportId: string; fileNames: readonly string[] }) {
-  return $api.reports
-    .getReportFilesUrl({
-      path: { reportId: props.reportId },
-      query: { fileNames: props.fileNames as string[] },
-    })
-    .then(({ data }) => data ?? null);
-}
+export const useGenerateReportFilePublicUrlMutation = () =>
+  useMutation({
+    mutationFn: async (mutation: { fileName: string; reportId: string }): Promise<string> => {
+      const { data } = await $api.reports.getReportFilesUrl({
+        path: { reportId: mutation.reportId },
+        query: { fileNames: [mutation.fileName] },
+      });
+
+      const [file] = data?.items ?? [];
+      if (!file) throw new Error(`no public url for ${mutation.fileName}`);
+
+      return file.url;
+    },
+  });
 
 function updateCommentScreenshots(
   html: string,

--- a/apps/client/src/queries/summary.queries.ts
+++ b/apps/client/src/queries/summary.queries.ts
@@ -99,23 +99,17 @@ export function useDetachSummaryFilesMutation() {
 
 export const useGenerateSummaryAttachmentPublicUrlMutation = () =>
   useMutation({
-    async mutationFn(mutation: { sessionId: string; nominationFileId: string; fileId: string }) {
-      const { sessionId, nominationFileId, fileId } = mutation;
+    async mutationFn(mutation: {
+      fileId: string;
+      nominationFileId: string;
+      sessionId: string;
+    }): Promise<string | null> {
+      const { fileId, nominationFileId, sessionId } = mutation;
       const { data } = await $api.summaries.generateAttachmentPublicUrl({
-        path: { sessionId, nominationFileId, fileId },
+        path: { fileId, nominationFileId, sessionId },
       });
 
-      if (!data) return;
-
-      const $a = document.createElement('a');
-      $a.href = data.url;
-      $a.target = '_blank';
-      $a.rel = 'noopener noreferrer';
-
-      document.body.appendChild($a);
-
-      $a.click();
-      $a.remove();
+      return data?.url ?? null;
     },
   });
 

--- a/apps/client/src/shared/hooks/useTab/useTab.test.ts
+++ b/apps/client/src/shared/hooks/useTab/useTab.test.ts
@@ -5,8 +5,8 @@ import { useTab } from './useTab';
 
 afterEach(() => vi.restoreAllMocks());
 
-describe('useTab.download', () => {
-  it('triggers a download through a transient anchor', () => {
+describe('useTab.open', () => {
+  it('opens the url through a transient anchor', () => {
     const appended: HTMLAnchorElement[] = [];
     vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
       appended.push(node as HTMLAnchorElement);
@@ -15,12 +15,12 @@ describe('useTab.download', () => {
     const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
 
     const { result } = renderHook(() => useTab());
-    act(() => result.current.download('https://files/report.pdf?download'));
+    act(() => result.current.open('https://files/report.pdf'));
 
     expect(click).toHaveBeenCalledOnce();
     const anchor = appended.find((node) => node.tagName === 'A')!;
-    expect(anchor.href).toBe('https://files/report.pdf?download');
-    expect(anchor.download).toBe('');
+    expect(anchor.href).toBe('https://files/report.pdf');
+    expect(anchor.target).toBe('_blank');
     expect(anchor.rel).toBe('noopener');
   });
 
@@ -29,7 +29,7 @@ describe('useTab.download', () => {
     const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
 
     const { result } = renderHook(() => useTab());
-    act(() => result.current.download(new URL('https://files/report.pdf')));
+    act(() => result.current.open(new URL('https://files/report.pdf')));
 
     expect(click).toHaveBeenCalledOnce();
   });

--- a/apps/client/src/shared/hooks/useTab/useTab.ts
+++ b/apps/client/src/shared/hooks/useTab/useTab.ts
@@ -25,8 +25,8 @@ export function useTab() {
     const $a = document.createElement('a');
     $a.href = url.toString();
     $a.rel = 'noopener';
-    $a.target = '_blank';
     $a.style.display = 'none';
+    $a.target = '_blank';
 
     document.body.appendChild($a);
     $a.click();
@@ -55,17 +55,5 @@ export function useTab() {
     [open],
   );
 
-  const download = useCallback((url: URL | string) => {
-    const $a = document.createElement('a');
-    $a.href = url.toString();
-    $a.rel = 'noopener';
-    $a.download = '';
-    $a.style.display = 'none';
-
-    document.body.appendChild($a);
-    $a.click();
-    $a.remove();
-  }, []);
-
-  return { open, openDeferred, download };
+  return { open, openDeferred };
 }

--- a/apps/client/src/utils/http.config.test.ts
+++ b/apps/client/src/utils/http.config.test.ts
@@ -18,6 +18,8 @@ describe('LONG_RUNNING_ROUTES', () => {
     ['/api/docs/v1/sessions/s1/new-official-reports/agendas', false],
     ['/api/docs/v1/agendas/a1', false],
     ['/api/docs/v1/presentation-plans/p1/html', false],
+    ['/api/files/v1/f1', true],
+    ['https://api.dev/api/files/v1/f1?download=', true],
     ['/api/sessions/v2/s1/files.xlsx', true],
     ['/api/sessions/v2/s1/files/missing-evaluations.xlsx', true],
     ['/api/sessions/v2/s1/files', false],

--- a/apps/client/src/utils/http.config.ts
+++ b/apps/client/src/utils/http.config.ts
@@ -14,6 +14,7 @@ export const LONG_RUNNING_ROUTES = [
   '/api/docs/v1/presentation-plans/{planId}/url',
   '/api/docs/v1/sessions/{sessionId}/agendas/{agendaId}',
   '/api/docs/v1/sessions/{sessionId}/official-reports/{officialReportId}',
+  '/api/files/v1/{fileUrlId}',
   '/api/sessions/v2/{sessionId}/files.xlsx',
   '/api/sessions/v2/{sessionId}/files/missing-evaluations.xlsx',
 ] as const;
@@ -34,7 +35,6 @@ export const createClientConfig: CreateClientConfig = (config) => ({
   ...config,
   baseUrl: getBaseUrl(),
   credentials: 'include',
-  throwOnError: true,
   fetch: async (init) => {
     const url = typeof init === 'string' ? init : init instanceof URL ? init.toString() : init.url;
     const isLongRunningUrl = LONG_RUNNING_PATTERNS.some((pattern) => pattern.test(url));
@@ -46,4 +46,5 @@ export const createClientConfig: CreateClientConfig = (config) => ({
     const response = await globalThis.fetch(init, { signal: AbortSignal.timeout(timeout) });
     return httpAssert(response);
   },
+  throwOnError: true,
 });


### PR DESCRIPTION
A Sentry `JSON.parse` error on staging turned out to be a false positive, but the investigation surfaced a real bug. The webapp domain answers `/api` routes with `index.html` and a 200, and attachment downloads relied on that without knowing it. Users got the app's HTML page instead of their file, in staging and production. It only worked locally, thanks to the Vite proxy.

- **Download attachments through the API client** and save from a `blob:` URL, like the xlsx exports. Added the route to `LONG_RUNNING_ROUTES` so large files are not cut off at 10s
- **Open files consistently across 5 call sites.** The blank tab is opened on click (`openDeferred`) instead of after the request, so the popup blocker cannot kill it, and failures now show a toast instead of nothing
- **nginx returns 404 on `/api`** instead of the SPA, so a misconfigured `VITE_API_URL` fails loudly instead of returning 200s everywhere
- **Guarded 4 `response.json()` calls** on error bodies, which turned into unhandled Sentry errors with no message for the user
- Housekeeping: 2 unused hooks removed, tab handling moved out of the `queries` layer, alphabetical sorting in the touched files

