### PR TITLE
fix(FON-528): keep the storybook build out of the icon scan

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           # In Scalingo dashboard, we set the PROJECT_DIR environment variable to storybook
           mkdir -p scalingo/storybook
-          cp -r apps/client/storybook-static "$_"
+          cp -r apps/client/build/storybook "$_"
           cp -r apps/client/.storybook/scalingo/* "$_"
           cp apps/client/.storybook/scalingo/.buildpacks "$_"
           tar -czf storybook-scalingo.tar.gz scalingo

--- a/apps/client/.gitignore
+++ b/apps/client/.gitignore
@@ -30,7 +30,7 @@ dist-ssr
 /playwright/.auth/
 
 # Storybook
-storybook-static/
+/build/
 
 # Sentry Config File
 .env.sentry-build-plugin

--- a/apps/client/.storybook/scalingo/nginx.conf.erb
+++ b/apps/client/.storybook/scalingo/nginx.conf.erb
@@ -1,4 +1,4 @@
-root /app/storybook-static;
+root /app/storybook;
 
 location / {
   add_header X-Content-Type-Options "nosniff";

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -19,7 +19,7 @@
     "predev": "pnpm run update-icons && rm -rf node_modules/.vite-app",
     "prebuild": "pnpm run update-icons",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "storybook build --output-dir build/storybook",
     "msw:init": "msw init .storybook/public --save",
     "prestorybook": "pnpm run update-icons",
     "prebuild-storybook": "pnpm run update-icons",


### PR DESCRIPTION
Build Storybook into `build/storybook`, a directory the crawler already skips

- `build-storybook` gets `--output-dir build/storybook`
- `.gitignore`: `storybook-static/` becomes `/build/`, anchored on purpose. The crawler only skips `build` at the root, so a nested one must stay visible rather than be hidden by git alone
- the deploy workflow copies `build/storybook` and nginx serves it from `/app/storybook`

Not `dist/storybook`: it would escape the crawler too, but Vite builds into `dist/` with `emptyOutDir` on, so `pnpm build` silently wipes the Storybook build

### Note

`storybook-static/` leaves the `.gitignore`, so a stale build now shows up as untracked and keeps polluting the scan until removed:

```sh
rm -rf apps/client/storybook-static
```