### PR TITLE
fix(FON-539): attach the jurisdiction sheet to the magistrat instead of the session

### DIFF
--- a/apps/api-e2e/src/generated/api/types.ts
+++ b/apps/api-e2e/src/generated/api/types.ts
@@ -422,6 +422,7 @@ export type PaginatedNominationFiles = {
             canWrite: boolean;
         } | null;
         hasAttachment: boolean;
+        hasJurisdictionSheet: boolean;
     }>;
     totalCount: number;
     currentPageIndex: number;
@@ -543,7 +544,11 @@ export type ListedNominationFileAttachmentDto = {
         name: string;
         size: number | null;
         type: 'AUTRE' | 'FICHE_DE_JURIDICTION' | 'NOTE_INTENTION';
-        addedAt: string;
+        addedAt: {
+            year: number;
+            month: number;
+            day: number;
+        };
     }>;
 };
 
@@ -664,6 +669,7 @@ export type DetailedNominationFileDto = {
         canWrite: boolean;
     } | null;
     hasAttachment: boolean;
+    hasJurisdictionSheet: boolean;
 };
 
 export type DetailedNominationSessionDto = {

--- a/apps/api-e2e/src/specs/session.e2e-spec.ts
+++ b/apps/api-e2e/src/specs/session.e2e-spec.ts
@@ -164,6 +164,7 @@ test.describe('Session E2E', () => {
           }),
         ],
         hasAttachment: false,
+        hasJurisdictionSheet: false,
       } satisfies NominationFile);
 
       expect(nominationFiles.data!.items).toContainEqual({
@@ -221,6 +222,7 @@ test.describe('Session E2E', () => {
           }),
         ]),
         hasAttachment: false,
+        hasJurisdictionSheet: false,
       } satisfies NominationFile);
     });
 
@@ -257,6 +259,31 @@ test.describe('Session E2E', () => {
       const filesAfter = await agent.sessions.listNominationFiles({ path: { sessionId } });
       const updatedFile = filesAfter.data!.items.find((file) => file.id === nominationFileId);
       expect(updatedFile?.hasAttachment).toBe(true);
+      expect(updatedFile?.hasJurisdictionSheet).toBe(true);
+    });
+
+    test('should only flag a jurisdiction sheet for that very type', async ({ agent, expect }) => {
+      const importResponse = await agent.sessions.createSessionFromLodam({
+        body: { file: await lodamFile(), form: lodamForm() },
+      });
+      const sessionId = importResponse.data!.id;
+
+      const filesBefore = await agent.sessions.listNominationFiles({ path: { sessionId } });
+      const nominationFileId = filesBefore.data!.items[0]!.id;
+
+      const uploadRes = await agent.sessions.uploadNominationFileAttachments({
+        path: { sessionId, nominationFileId },
+        body: {
+          files: [makeFile({ type: 'application/pdf', name: 'intention.pdf' })],
+          form: attachmentForm({ type: 'NOTE_INTENTION' }),
+        },
+      });
+      expect(uploadRes.response?.status).toBe(204);
+
+      const filesAfter = await agent.sessions.listNominationFiles({ path: { sessionId } });
+      const updatedFile = filesAfter.data!.items.find((file) => file.id === nominationFileId);
+      expect(updatedFile?.hasAttachment).toBe(true);
+      expect(updatedFile?.hasJurisdictionSheet).toBe(false);
     });
 
     test('should detail a nomination file exactly as the list serves it', async ({ agent, sessions, expect }) => {

--- a/apps/api/prisma/migrations/20260827150000_reset_alert_hidden_on_attached_jurisdiction_sheet/migration.sql
+++ b/apps/api/prisma/migrations/20260827150000_reset_alert_hidden_on_attached_jurisdiction_sheet/migration.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- the alert is now derived from the attached jurisdiction sheets: `alert_hidden` only
+-- records the explicit "Ignorer cette alerte" gesture
+UPDATE "nominations_context"."dossier_de_nomination" AS ddn
+SET alert_hidden = FALSE
+WHERE ddn.alert_hidden AND EXISTS (
+  SELECT 1
+  FROM "nominations_context"."nomination_file_attachment" AS nfa
+  WHERE nfa.nomination_file_id = ddn.id AND nfa."type" = 'FICHE_DE_JURIDICTION'
+);
+
+COMMIT;

--- a/apps/api/prisma/sql/listNominationFilesRawQuery.sql
+++ b/apps/api/prisma/sql/listNominationFilesRawQuery.sql
@@ -51,6 +51,12 @@ SELECT
     WHERE nfa.nomination_file_id = ddn.id
   ) AS "hasAttachment",
 
+  EXISTS (
+    SELECT 1
+    FROM nominations_context.nomination_file_attachment AS nfa
+    WHERE nfa.nomination_file_id = ddn.id AND nfa."type" = 'FICHE_DE_JURIDICTION'
+  ) AS "hasJurisdictionSheet",
+
   TS_RANK(ddn."search", query) AS "queryRank",
 
   summaries."summary" AS summary,

--- a/apps/api/src/modules/session/transparence/infrastructure/queries/list-nomination-files.query.ts
+++ b/apps/api/src/modules/session/transparence/infrastructure/queries/list-nomination-files.query.ts
@@ -295,6 +295,7 @@ export class ListNominationFilesQuery {
             }
           : null,
         hasAttachment: x.hasAttachment,
+        hasJurisdictionSheet: x.hasJurisdictionSheet,
       };
     });
   }
@@ -407,6 +408,7 @@ const RawListedNominationFiles = z.array(
     detectedTargetedFunctionId: z.string().nullable(),
     detectedMagistratId: z.string().nullable(),
     hasAttachment: z.boolean(),
+    hasJurisdictionSheet: z.boolean(),
     queryRank: z.number().nullable(),
 
     memberMemo: z.string().nullable(),
@@ -501,6 +503,7 @@ const NominationFileAffectationItemSchema = z.object({
   memo: z.string().nullable(),
   summary: z.object({ id: z.string(), canRead: z.boolean(), canWrite: z.boolean() }).nullable(),
   hasAttachment: z.boolean(),
+  hasJurisdictionSheet: z.boolean(),
 });
 
 export type NominationFileAffectationItem = z.infer<typeof NominationFileAffectationItemSchema>;

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/Attachments.tsx
@@ -16,10 +16,9 @@ import {
   useRemoveNominationFileAttachmentMutation,
 } from '@queries/nomination-sessions.queries';
 
+import { attachmentsSectionId } from './attachments-section';
 import { useAddNominationFileAttachmentModal } from './context/AddNominationFileAttachmentModalContext';
 import { NominationFileAttachmentTypeTag } from './NominationFileAttachmentTypeTag';
-
-export const ATTACHMENTS_SECTION_ID = 'magistrat-attachments-section';
 
 export function Attachments(props: { isArchived: boolean; nominationFileId: string; sessionId: string }) {
   const isSg = useIsSgNavigation();
@@ -36,7 +35,7 @@ export function Attachments(props: { isArchived: boolean; nominationFileId: stri
   if (attachments.length === 0 && !canManage) return null;
 
   return (
-    <div id={ATTACHMENTS_SECTION_ID}>
+    <div id={attachmentsSectionId(props.nominationFileId)}>
       <div className="fr-mb-4v flex items-center justify-between gap-4">
         <p className="fr-mb-0 text-xl font-semibold" id={labelId}>
           <FormattedMessage

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/attachments-section.test.ts
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/attachments-section.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { attachmentsSectionId, revealAttachments } from './attachments-section';
+
+function mountSection(nominationFileId: string) {
+  const section = document.createElement('div');
+  section.id = attachmentsSectionId(nominationFileId);
+  section.scrollIntoView = vi.fn();
+  document.body.append(section);
+
+  return section;
+}
+
+const nextFrames = (count: number) =>
+  new Promise<void>((resolve) => {
+    const tick = (remaining: number) =>
+      remaining === 0 ? resolve() : requestAnimationFrame(() => tick(remaining - 1));
+    tick(count);
+  });
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('revealAttachments', () => {
+  it('scrolls to the section of that magistrat', () => {
+    const section = mountSection('nomination-file-1');
+    mountSection('nomination-file-2');
+
+    revealAttachments('nomination-file-1');
+
+    expect(section.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('waits for the side panel to render the section', async () => {
+    revealAttachments('nomination-file-1');
+    await nextFrames(2);
+
+    const section = mountSection('nomination-file-1');
+    await nextFrames(2);
+
+    expect(section.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up rather than polling forever', async () => {
+    revealAttachments('nomination-file-1', 1);
+    await nextFrames(4);
+
+    const section = mountSection('nomination-file-1');
+    await nextFrames(4);
+
+    expect(section.scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/attachments-section.ts
+++ b/apps/client/src/features/nomination-files-table/components/cells/magistrat-side-panel/components/attachments/attachments-section.ts
@@ -1,0 +1,15 @@
+const REVEAL_ATTEMPTS = 60;
+
+export function attachmentsSectionId(nominationFileId: string): string {
+  return `magistrat-attachments-${nominationFileId}`;
+}
+
+export function revealAttachments(nominationFileId: string, attempts = REVEAL_ATTEMPTS): void {
+  const section = document.getElementById(attachmentsSectionId(nominationFileId));
+  if (section) {
+    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return;
+  }
+
+  if (attempts > 0) requestAnimationFrame(() => revealAttachments(nominationFileId, attempts - 1));
+}

--- a/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionCell.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionCell.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  makeSessionNominationFile,
+  type NominationFileOverrides,
+} from '@/test-utils/factories/session-nomination-file.factory';
+
+import { NominationFileTargetPositionCell } from './NominationFileTargetPositionCell';
+
+const isSg = vi.fn();
+const open = vi.fn();
+
+vi.mock('@/features/auth/hooks/roles.hook', () => ({ useIsSg: () => isSg() }));
+
+vi.mock('./NominationFileTargetPositionContext', () => ({
+  useNominationFileTargetPositionModal: () => ({ open }),
+}));
+
+const ALERTED_POSITION = { content: { posteCible: 'Procureur de la République TJ GRASSE' } };
+
+function renderCell(overrides: NominationFileOverrides) {
+  return render(
+    <IntlProvider defaultLocale="fr" locale="fr">
+      <NominationFileTargetPositionCell nominationFile={makeSessionNominationFile(overrides)} />
+    </IntlProvider>,
+  );
+}
+
+/** only the alerted cell turns the position into a button, the plain one stays text */
+const positionButton = () => screen.queryByRole('button', { name: /Procureur de la République TJ GRASSE/ });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isSg.mockReturnValue(true);
+});
+
+describe('NominationFileTargetPositionCell', () => {
+  it('asks for a jurisdiction sheet on the positions that need one', () => {
+    renderCell(ALERTED_POSITION);
+
+    expect(positionButton()).toBeInTheDocument();
+  });
+
+  it('stops asking once a jurisdiction sheet is attached', () => {
+    renderCell({ ...ALERTED_POSITION, hasJurisdictionSheet: true });
+
+    expect(positionButton()).not.toBeInTheDocument();
+  });
+
+  it('keeps asking when the attached files are of another kind', () => {
+    renderCell({ ...ALERTED_POSITION, hasAttachment: true });
+
+    expect(positionButton()).toBeInTheDocument();
+  });
+
+  it('stops asking once the alert has been explicitly ignored', () => {
+    renderCell({ content: { ...ALERTED_POSITION.content, isAlertHidden: true } });
+
+    expect(positionButton()).not.toBeInTheDocument();
+  });
+
+  it('never asks outside of the secretariat général', () => {
+    isSg.mockReturnValue(false);
+    renderCell(ALERTED_POSITION);
+
+    expect(positionButton()).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionCell.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionCell.tsx
@@ -27,7 +27,7 @@ function useHearingAlert(nominationFile: SessionNominationFile): boolean {
   const isSg = useIsSg();
   const { isAlertHidden, posteCible } = nominationFile.content;
 
-  if (!isSg || isAlertHidden || !posteCible) return false;
+  if (!isSg || isAlertHidden || nominationFile.hasJurisdictionSheet || !posteCible) return false;
 
   return HEARING_ALERT_POSITIONS.some((x) => x.test(normalizePosition(posteCible)));
 }

--- a/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionModal.test.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionModal.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeSessionNominationFile } from '@/test-utils/factories/session-nomination-file.factory';
+
+import { NominationFileTargetPositionModal } from './NominationFileTargetPositionModal';
+
+const addAttachment = vi.fn();
+const hideAlert = vi.fn();
+const openSidePanel = vi.fn();
+const success = vi.fn();
+
+vi.mock('@queries/nomination-sessions.queries', () => ({
+  useAddNominationFileAttachmentsMutation: () => ({ mutateAsync: addAttachment, isPending: false }),
+  useNominationFilesAlertMutation: () => ({ mutateAsync: hideAlert, isPending: false }),
+}));
+
+vi.mock('@/shared/ui/toast', () => ({ useToasts: () => ({ success }) }));
+
+vi.mock('../magistrat-side-panel/context/side-panel.context', () => ({
+  useSidePanel: () => ({ open: openSidePanel }),
+}));
+
+const nominationFile = makeSessionNominationFile({ id: 'nomination-file-1' });
+
+function renderModal() {
+  const onClose = vi.fn();
+  const view = render(
+    <IntlProvider defaultLocale="fr" locale="fr">
+      <NominationFileTargetPositionModal
+        nominationFile={nominationFile}
+        onClose={onClose}
+        onClosed={vi.fn()}
+        open
+        sessionId="session-1"
+      />
+    </IntlProvider>,
+  );
+
+  return { ...view, onClose };
+}
+
+async function importFile(container: HTMLElement, user: ReturnType<typeof userEvent.setup>) {
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+  await user.upload(input, new File(['data'], 'fiche.pdf', { type: 'application/pdf' }));
+  await user.click(screen.getByRole('button', { name: 'Sauvegarder' }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  addAttachment.mockResolvedValue(undefined);
+  hideAlert.mockResolvedValue(undefined);
+});
+
+describe('NominationFileTargetPositionModal', () => {
+  it('attaches the imported file to the nomination file as a jurisdiction sheet', async () => {
+    const user = userEvent.setup();
+    const { container } = renderModal();
+
+    await importFile(container, user);
+
+    await waitFor(() =>
+      expect(addAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nominationFileId: 'nomination-file-1',
+          sessionId: 'session-1',
+          type: 'FICHE_DE_JURIDICTION',
+        }),
+      ),
+    );
+  });
+
+  it('tells where the imported file landed and opens the magistrat panel on demand', async () => {
+    const user = userEvent.setup();
+    const { container } = renderModal();
+
+    await importFile(container, user);
+
+    await waitFor(() => expect(success).toHaveBeenCalledTimes(1));
+    expect(success.mock.calls[0][0]).toMatchObject({
+      description: 'À retrouver dans les pièces jointes du magistrat.',
+      title: 'Fiche de juridiction importée',
+    });
+
+    success.mock.calls[0][0].action.onClick();
+    expect(openSidePanel).toHaveBeenCalledWith('nomination-file-1');
+  });
+
+  it('leaves the alert alone on import, since the attached sheet is what silences it', async () => {
+    const user = userEvent.setup();
+    const { container, onClose } = renderModal();
+
+    await importFile(container, user);
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(hideAlert).not.toHaveBeenCalled();
+  });
+
+  it('hides the alert for good when it is explicitly ignored', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+
+    await user.click(screen.getByRole('button', { name: 'Ignorer cette alerte' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(hideAlert).toHaveBeenCalledWith({ nominationFileId: 'nomination-file-1' });
+  });
+
+  it('keeps the alert when the import fails', async () => {
+    const user = userEvent.setup();
+    addAttachment.mockRejectedValue(new Error('upload failed'));
+    const { container } = renderModal();
+
+    await importFile(container, user);
+
+    expect(await screen.findByText('Erreur pendant le téléchargement')).toBeInTheDocument();
+    expect(success).not.toHaveBeenCalled();
+    expect(hideAlert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionModal.tsx
+++ b/apps/client/src/features/nomination-files-table/components/cells/targeted-position/NominationFileTargetPositionModal.tsx
@@ -1,13 +1,16 @@
 import Alert from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
 import { useCallback, useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
+import { revealAttachments } from '../magistrat-side-panel/components/attachments/attachments-section';
+import { useSidePanel } from '../magistrat-side-panel/context/side-panel.context';
 import { DOCUMENT_FILE_TYPES } from '@/constants/files.constants';
 import { Modal } from '@/shared/ui/modal';
+import { useToasts } from '@/shared/ui/toast';
 import { Upload } from '@/shared/ui/upload';
 import {
-  useAddNominationSessionAttachmentMutation,
+  useAddNominationFileAttachmentsMutation,
   useNominationFilesAlertMutation,
   type SessionNominationFile,
 } from '@queries/nomination-sessions.queries';
@@ -19,12 +22,16 @@ export function NominationFileTargetPositionModal(props: {
   open: boolean;
   sessionId: string;
 }) {
+  const { formatMessage } = useIntl();
+  const sidePanel = useSidePanel();
+  const toasts = useToasts();
+
   const [attempt, setAttempt] = useState(0);
   const [files, setFiles] = useState<File[]>([]);
   const [hasFailed, setHasFailed] = useState(false);
 
   const { mutateAsync: addAttachment, isPending: isAddingAttachment } =
-    useAddNominationSessionAttachmentMutation();
+    useAddNominationFileAttachmentsMutation();
   const { mutateAsync: deleteAlert, isPending: isDeletingAlert } = useNominationFilesAlertMutation({
     sessionId: props.sessionId,
   });
@@ -40,7 +47,12 @@ export function NominationFileTargetPositionModal(props: {
     setHasFailed(false);
 
     try {
-      await addAttachment({ files, sessionId: props.sessionId });
+      await addAttachment({
+        files,
+        nominationFileId: props.nominationFile.id,
+        sessionId: props.sessionId,
+        type: 'FICHE_DE_JURIDICTION',
+      });
     } catch {
       setHasFailed(true);
       setFiles([]);
@@ -48,8 +60,22 @@ export function NominationFileTargetPositionModal(props: {
       return;
     }
 
-    await dismissAlert();
-  }, [addAttachment, dismissAlert, files, props.sessionId]);
+    toasts.success({
+      action: {
+        label: formatMessage({ defaultMessage: 'Voir les pièces jointes' }),
+        onClick: () => {
+          sidePanel.open(props.nominationFile.id);
+          revealAttachments(props.nominationFile.id);
+        },
+      },
+      description: formatMessage({
+        defaultMessage: 'À retrouver dans les pièces jointes du magistrat.',
+      }),
+      title: formatMessage({ defaultMessage: 'Fiche de juridiction importée' }),
+    });
+
+    props.onClose();
+  }, [addAttachment, files, formatMessage, props, sidePanel, toasts]);
 
   return (
     <Modal
@@ -79,7 +105,7 @@ export function NominationFileTargetPositionModal(props: {
         />
       </p>
       <p>
-        <FormattedMessage defaultMessage="Une fois importé, le fichier sera disponible dans les pièces jointes de la session." />
+        <FormattedMessage defaultMessage="Une fois importé, le fichier sera disponible dans les pièces jointes du magistrat, accessibles en cliquant sur son nom dans le tableau." />
       </p>
 
       {hasFailed && (
@@ -89,10 +115,7 @@ export function NominationFileTargetPositionModal(props: {
           description={
             <>
               <p>
-                <FormattedMessage
-                  defaultMessage="Il y a eu une erreur pendant le téléchargement {count, plural, one {du fichier} other {des fichiers}}."
-                  values={{ count: files.length }}
-                />
+                <FormattedMessage defaultMessage="Il y a eu une erreur pendant le téléchargement du fichier." />
               </p>
               <p>
                 <FormattedMessage defaultMessage="Merci de réessayer." />
@@ -112,7 +135,6 @@ export function NominationFileTargetPositionModal(props: {
         isPending={isPending}
         key={attempt}
         label={<FormattedMessage defaultMessage="Importer un fichier" />}
-        multiple
         onChange={setFiles}
       />
     </Modal>

--- a/apps/client/src/generated/api/types.ts
+++ b/apps/client/src/generated/api/types.ts
@@ -425,6 +425,7 @@ export type PaginatedNominationFiles = {
             canWrite: boolean;
         } | null;
         hasAttachment: boolean;
+        hasJurisdictionSheet: boolean;
     }>;
     totalCount: number;
     currentPageIndex: number;
@@ -671,6 +672,7 @@ export type DetailedNominationFileDto = {
         canWrite: boolean;
     } | null;
     hasAttachment: boolean;
+    hasJurisdictionSheet: boolean;
 };
 
 export type DetailedNominationSessionDto = {

--- a/apps/client/src/queries/nomination-sessions.queries.ts
+++ b/apps/client/src/queries/nomination-sessions.queries.ts
@@ -369,11 +369,17 @@ export const useAddNominationFileAttachmentsMutation = () => {
         },
       });
     },
-    onSuccess: async (_data, { nominationFileId, sessionId }) => {
+    onSuccess: async (_data, { nominationFileId, sessionId, type }) => {
       queryClient.setQueriesData(
         { queryKey: sessionKeys.listSessionNominationFiles({ sessionId }) },
         mapCachedNominationFiles((item) =>
-          item.id === nominationFileId ? { ...item, hasAttachment: true } : item,
+          item.id === nominationFileId
+            ? {
+                ...item,
+                hasAttachment: true,
+                hasJurisdictionSheet: item.hasJurisdictionSheet || type === 'FICHE_DE_JURIDICTION',
+              }
+            : item,
         ),
       );
       await queryClient.invalidateQueries({
@@ -395,14 +401,28 @@ export const useRemoveNominationFileAttachmentMutation = () => {
       const attachments = queryClient.getQueryData<ListedNominationFileAttachmentDto>(
         sessionKeys.listNominationFileAttachments({ nominationFileId, sessionId }),
       );
-      const hasAttachment = (attachments?.items ?? []).some((item) => item.id !== fileId);
 
-      queryClient.setQueriesData(
-        { queryKey: sessionKeys.listSessionNominationFiles({ sessionId }) },
-        mapCachedNominationFiles((item) =>
-          item.id === nominationFileId ? { ...item, hasAttachment } : item,
-        ),
-      );
+      const remaining = attachments?.items.filter((item) => item.id !== fileId);
+
+      if (remaining) {
+        queryClient.setQueriesData(
+          { queryKey: sessionKeys.listSessionNominationFiles({ sessionId }) },
+          mapCachedNominationFiles((item) =>
+            item.id === nominationFileId
+              ? {
+                  ...item,
+                  hasAttachment: remaining.length > 0,
+                  hasJurisdictionSheet: remaining.some((x) => x.type === 'FICHE_DE_JURIDICTION'),
+                }
+              : item,
+          ),
+        );
+      } else {
+        // nothing tells what is left on that file: let the listing say it
+        await queryClient.invalidateQueries({
+          queryKey: sessionKeys.listSessionNominationFiles({ sessionId }),
+        });
+      }
 
       await queryClient.invalidateQueries({
         queryKey: sessionKeys.listNominationFileAttachments({ nominationFileId, sessionId }),

--- a/apps/client/src/shared/ui/toast/Toast.test.tsx
+++ b/apps/client/src/shared/ui/toast/Toast.test.tsx
@@ -101,7 +101,7 @@ describe('Toast', () => {
     expect(within(notifications()).queryByText('La publication a échoué')).not.toBeInTheDocument();
   });
 
-  it('keeps a toast carrying an action until it is dismissed', () => {
+  it('leaves the longest reading time to a toast carrying an action', () => {
     vi.useFakeTimers();
     const onClick = vi.fn();
     const { trigger, wait } = renderToast('success', {
@@ -110,9 +110,22 @@ describe('Toast', () => {
     });
 
     trigger();
-    wait(60_000);
+    wait(9_000);
 
     fireEvent.click(within(notifications()).getByRole('button', { name: "Voir l'ODJ" }));
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it('dismisses a toast carrying an action once that reading time is over', () => {
+    vi.useFakeTimers();
+    const { trigger, wait } = renderToast('success', {
+      action: { label: "Voir l'ODJ", onClick: vi.fn() },
+      title: '3 propositions ajoutées',
+    });
+
+    trigger();
+    wait(11_000);
+
+    expect(screen.queryByText('3 propositions ajoutées')).not.toBeInTheDocument();
   });
 });

--- a/apps/client/src/shared/ui/toast/useToasts.ts
+++ b/apps/client/src/shared/ui/toast/useToasts.ts
@@ -36,7 +36,7 @@ export function useToasts() {
         manager.add({
           ...optionsOf(notice),
           priority: 'low',
-          timeout: notice.action ? 0 : readingTimeMs(notice),
+          timeout: notice.action ? MAX_TIMEOUT_MS : readingTimeMs(notice),
           type: 'success',
         }),
     }),

--- a/apps/client/src/test-utils/factories/session-nomination-file.factory.ts
+++ b/apps/client/src/test-utils/factories/session-nomination-file.factory.ts
@@ -39,6 +39,7 @@ export function makeSessionNominationFile(overrides: NominationFileOverrides = {
     content: { ...baseContent, ...content },
     expectedReportersCount: null,
     hasAttachment: false,
+    hasJurisdictionSheet: false,
     id: 'nomination-file',
     isArchived: false,
     memo: null,

--- a/apps/client/tests/pages/manage-single-session.page.ts
+++ b/apps/client/tests/pages/manage-single-session.page.ts
@@ -150,7 +150,7 @@ class MagistratSidePanel {
   }
 
   private get attachmentsSection(): Locator {
-    return this.dialog.locator('#magistrat-attachments-section');
+    return this.dialog.locator('[id^="magistrat-attachments-"]');
   }
 
   private get addAttachmentModal(): Locator {


### PR DESCRIPTION
- The imported file is now an attachment of the proposal tagged `Fiche de juridiction`, listed in the magistrat side panel
- A toast confirms the import and offers to open the side panel on that section
- The alert is derived from `hasJurisdictionSheet` (a typed `EXISTS` in the listing query): it goes away when a sheet is attached, it comes back when the sheet is removed
- `alert_hidden` is now only written by "Ignorer cette alerte", which stays final. A data migration resets it on files that already carry a sheet.
